### PR TITLE
Pager changes and nightvision tiers

### DIFF
--- a/MoreShipUpgrades/Managers/UpgradeBus.cs
+++ b/MoreShipUpgrades/Managers/UpgradeBus.cs
@@ -37,6 +37,7 @@ namespace MoreShipUpgrades.Managers
         public int discoLevel = 0;
         //public int scanLevel = 0; problematic, balance / refactor and then introduce tiered upgrades.
         public int legLevel = 0;
+        public int nightVisionLevel = 0; // Add this property
         public float alteredWeight = 1f;
         public AudioClip flashNoise;
         public trapDestroyerScript trapHandler = null;
@@ -49,7 +50,7 @@ namespace MoreShipUpgrades.Managers
         public List<CustomTerminalNode> terminalNodes = new List<CustomTerminalNode>();
         public List<CustomTerminalNode> terminalNodesOriginal = new List<CustomTerminalNode>();
         public Dictionary<string, GameObject> UpgradeObjects = new Dictionary<string, GameObject>();
-        
+
         void Awake()
         {
             instance = this;
@@ -66,9 +67,9 @@ namespace MoreShipUpgrades.Managers
                 if (!terminalNode.Unlocked) { modStoreInterface.displayText += $"\n{terminalNode.Name} // {terminalNode.Price}  "; }
                 else if (terminalNode.MaxUpgrade == 0) { modStoreInterface.displayText += $"\n{terminalNode.Name} // UNLOCKED  "; }
                 else if (terminalNode.MaxUpgrade > terminalNode.CurrentUpgrade) { modStoreInterface.displayText += $"\n{terminalNode.Name} // {terminalNode.Price} // LVL {terminalNode.CurrentUpgrade + 1}"; }
-                else { modStoreInterface.displayText += $"\n{terminalNode.Name} // MAX LVL";  }
+                else { modStoreInterface.displayText += $"\n{terminalNode.Name} // MAX LVL"; }
             }
-            if(modStoreInterface.displayText == "")
+            if (modStoreInterface.displayText == "")
             {
                 modStoreInterface.displayText = "No upgrades available";
             }
@@ -98,6 +99,7 @@ namespace MoreShipUpgrades.Managers
             lightLevel = 0;
             discoLevel = 0;
             legLevel = 0;
+            nightVisionLevel = 0; // Add this line
             alteredWeight = 1f;
             trapHandler = null;
             flashScript = null;
@@ -106,9 +108,9 @@ namespace MoreShipUpgrades.Managers
 
             try { LGUStore.instance.DeleteUpgradesServerRpc(); }
             catch (Exception ex)
-            { 
+            {
                 BaseUpgrade[] upgradeObjects = GameObject.FindObjectsOfType<BaseUpgrade>();
-                foreach(BaseUpgrade upgrade in upgradeObjects)
+                foreach (BaseUpgrade upgrade in upgradeObjects)
                 {
                     Destroy(upgrade.gameObject);
                 }

--- a/MoreShipUpgrades/Misc/PluginConfig.cs
+++ b/MoreShipUpgrades/Misc/PluginConfig.cs
@@ -77,8 +77,11 @@ namespace MoreShipUpgrades.Misc
         public int PAGER_PRICE { get; set; }
         public int LOCKSMITH_PRICE { get; set; }
         public bool PAGER_ENABLED { get; set; }
+        public float PAGER_COOLDOWN_DURATION { get; set; }
         public bool LOCKSMITH_ENABLED { get; set; }
         public string TOGGLE_NIGHT_VISION_KEY { get; set; }
+        public float NIGHT_VIS_DRAIN_DECREASE_PERCENT { get; set; }
+        public float NIGHT_VIS_REGEN_INCREASE_PERCENT { get; set; }
 
         public PluginConfig(ConfigFile cfg)
         {
@@ -144,6 +147,8 @@ namespace MoreShipUpgrades.Misc
             NIGHT_VIS_STARTUP = ConfigEntry("Night Vision", "Night Vision StartUp Cost", 0.1f, "The percent battery drained when turned on (0.1 = 10%).");
             NIGHT_VIS_EXHAUST = ConfigEntry("Night Vision", "Night Vision Exhaustion", 2f, "How many seconds night vision stays fully depleted.");
             TOGGLE_NIGHT_VISION_KEY = ConfigEntry("Night Vision", "Toggle Night Vision Key", "LeftAlt", "Key to toggle Night Vision, you can use any key on your system such as LeftAlt, LeftShift, or any letter which exists.");
+            NIGHT_VIS_DRAIN_DECREASE_PERCENT = ConfigEntry("Night Vision", "Percentage decrease for night vis battery drain", 10f, "Percentage decrease applied to drain speed on each upgrade.");
+            NIGHT_VIS_REGEN_INCREASE_PERCENT = ConfigEntry("Night Vision", "Percentage increase for night vis battery regen", 20f, "Percentage increase applied to regen speed on each upgrade.");
 
             DISCOMBOBULATOR_ENABLED = ConfigEntry("Discombobulator", "Enable Discombobulator Upgrade", true, "Stun enemies around the ship.");
             DISCOMBOBULATOR_PRICE = ConfigEntry("Discombobulator", "Price of Discombobulator Upgrade", 550, "");
@@ -166,6 +171,7 @@ namespace MoreShipUpgrades.Misc
 
             PAGER_ENABLED = ConfigEntry("Pager", "Enable pager upgrade", true, "Type `page <message>` to send a message to all clients chat.");
             PAGER_PRICE = ConfigEntry("Pager", "Pager Price", 490, "Default price of pager upgrade.");
+            PAGER_COOLDOWN_DURATION = ConfigEntry("Pager", "Pager Cooldown Duration", 30f, "Total cooldown time for the pager in seconds.");
 
             LOCKSMITH_ENABLED = ConfigEntry("Locksmith", "Enable Locksmith upgrade", true, "Allows you to pick locked doors by completing a minigame.");
             LOCKSMITH_PRICE = ConfigEntry("Locksmith", "Locksmith Price", 740, "Default price of Locksmith upgrade.");

--- a/MoreShipUpgrades/Plugin.cs
+++ b/MoreShipUpgrades/Plugin.cs
@@ -191,7 +191,7 @@ namespace MoreShipUpgrades
             LethalLib.Modules.NetworkPrefabs.RegisterNetworkPrefab(nightVision);
             if(cfg.NIGHT_VISION_ENABLED) 
             { 
-                CustomTerminalNode node = new CustomTerminalNode("Night Vision", cfg.NIGHT_VISION_PRICE, $"Allows you to see in the dark. Press Left-Alt to turn on.  \nDrain speed is {cfg.NIGHT_VIS_DRAIN_SPEED}  \nRegen speed is {cfg.NIGHT_VIS_REGEN_SPEED}", nightVision);
+                CustomTerminalNode node = new CustomTerminalNode("Night Vision", cfg.NIGHT_VISION_PRICE, $"Allows you to see in the dark. Press Left-Alt to turn on.  \nDrain speed is {cfg.NIGHT_VIS_DRAIN_SPEED}  \nRegen speed is {cfg.NIGHT_VIS_REGEN_SPEED}", nightVision, 3);
                 UpgradeBus.instance.terminalNodes.Add(node);
             }
 


### PR DESCRIPTION
pager can only be used once per 30 seconds (configurable, meant to not negate walkies) as well as added night vision tiers. each tier increases the regen speed by 20%, and decreases the drain speed by 10% (both percentages configurable)

let me know if we should just make the pager work in tiers for a lower cooldown as well, im not fully sure what the right balance should be for it since we have such short messages from the pager as a possibility 

