### PR TITLE
Project Setup Script

### DIFF
--- a/MoreShipUpgrades/MoreShipUpgrades.csproj
+++ b/MoreShipUpgrades/MoreShipUpgrades.csproj
@@ -1,85 +1,86 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
-    <OutputType>Library</OutputType>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <AssemblyTitle>MoreShipUpgrades</AssemblyTitle>
-    <Product>MoreShipUpgrades</Product>
-    <Copyright>Copyright ©  2023</Copyright>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>1.0.0.0</FileVersion>
-	<LangVersion>9.0</LangVersion>
-  </PropertyGroup>
-  <ItemGroup>
-    <None Remove="Managers\InfoStrings.json" />
-    <None Remove="Misc\InfoStrings.json" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="0Harmony">
-      <HintPath>D:\SteamLibrary\steamapps\common\Lethal Company\BepInEx\core\0Harmony.dll</HintPath>
-    </Reference>
-    <Reference Include="Assembly-CSharp">
-      <HintPath>D:\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Assembly-CSharp.dll</HintPath>
-    </Reference>
-    <Reference Include="BepInEx">
-      <HintPath>D:\SteamLibrary\steamapps\common\Lethal Company\BepInEx\core\BepInEx.dll</HintPath>
-    </Reference>
-    <Reference Include="LethalLib">
-      <HintPath>D:\SteamLibrary\steamapps\common\Lethal Company\BepInEx\plugins\LethalLib\LethalLib.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>D:\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.InputSystem">
-      <HintPath>D:\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Unity.InputSystem.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.InputSystem.ForUI">
-      <HintPath>D:\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Unity.InputSystem.ForUI.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.Netcode.Runtime">
-      <HintPath>D:\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Unity.Netcode.Runtime.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.TextMeshPro">
-      <HintPath>D:\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Unity.TextMeshPro.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine">
-      <HintPath>D:\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\UnityEngine.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.AIModule">
-      <HintPath>D:\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\UnityEngine.AIModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.AnimationModule">
-      <HintPath>D:\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\UnityEngine.AnimationModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.AssetBundleModule">
-      <HintPath>D:\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.AudioModule">
-      <HintPath>D:\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\UnityEngine.AudioModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.CoreModule">
-      <HintPath>D:\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.InputModule">
-      <HintPath>D:\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\UnityEngine.InputModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.PhysicsModule">
-      <HintPath>D:\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.UI">
-      <HintPath>D:\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\UnityEngine.UI.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="Misc\InfoStrings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </EmbeddedResource>
-  </ItemGroup>
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="cd C:\Users\malco\Downloads\NetcodePatcher-2.0.0&#xD;&#xA;NetcodePatcher.dll $(TargetDir) deps/" />
-  </Target>
+	<PropertyGroup>
+		<TargetFramework>netstandard2.1</TargetFramework>
+		<OutputType>Library</OutputType>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+		<AssemblyTitle>MoreShipUpgrades</AssemblyTitle>
+		<Product>MoreShipUpgrades</Product>
+		<Copyright>Copyright ©  2023</Copyright>
+		<AssemblyVersion>1.0.0.0</AssemblyVersion>
+		<FileVersion>1.0.0.0</FileVersion>
+		<LangVersion>9.0</LangVersion>
+	</PropertyGroup>
+	<ItemGroup>
+		<Reference Include="0Harmony">
+			<HintPath>{{LC_PATH}}\0Harmony.dll</HintPath>
+			<Private>false</Private>
+		</Reference>
+		<Reference Include="Assembly-CSharp">
+			<HintPath>{{LC_PATH}}\Assembly-CSharp.dll</HintPath>
+			<Private>false</Private>
+		</Reference>
+		<Reference Include="BepInEx">
+			<HintPath>{{BEPINEX_ASSEMBLY_PATH}}\BepInEx.dll</HintPath>
+			<Private>false</Private>
+		</Reference>
+		<Reference Include="LethalLib">
+			<HintPath>{{BEPINEX_PLUGIN_PATH}}\LethalLib.dll</HintPath>
+			<Private>false</Private>
+		</Reference>
+		<Reference Include="Newtonsoft.Json">
+			<HintPath>{{LC_PATH}}\Newtonsoft.Json.dll</HintPath>
+			<Private>false</Private>
+		</Reference>
+		<Reference Include="Unity.InputSystem">
+			<HintPath>{{LC_PATH}}\Unity.InputSystem.dll</HintPath>
+			<Private>false</Private>
+		</Reference>
+		<Reference Include="Unity.InputSystem.ForUI">
+			<HintPath>{{LC_PATH}}\Unity.InputSystem.ForUI.dll</HintPath>
+			<Private>false</Private>
+		</Reference>
+		<Reference Include="Unity.Netcode.Runtime">
+			<HintPath>{{LC_PATH}}\Unity.Netcode.Runtime.dll</HintPath>
+			<Private>false</Private>
+		</Reference>
+		<Reference Include="Unity.TextMeshPro">
+			<HintPath>{{LC_PATH}}\Unity.TextMeshPro.dll</HintPath>
+			<Private>false</Private>
+		</Reference>
+		<Reference Include="UnityEngine">
+			<HintPath>{{LC_PATH}}\UnityEngine.dll</HintPath>
+			<Private>false</Private>
+		</Reference>
+		<Reference Include="UnityEngine.AssetBundleModule">
+			<HintPath>{{LC_PATH}}\UnityEngine.AssetBundleModule.dll</HintPath>
+			<Private>false</Private>
+		</Reference>
+		<Reference Include="UnityEngine.AudioModule">
+			<HintPath>{{LC_PATH}}\UnityEngine.AudioModule.dll</HintPath>
+			<Private>false</Private>
+		</Reference>
+		<Reference Include="UnityEngine.CoreModule">
+			<HintPath>{{LC_PATH}}\UnityEngine.CoreModule.dll</HintPath>
+			<Private>false</Private>
+		</Reference>
+		<Reference Include="UnityEngine.InputModule">
+			<HintPath>{{LC_PATH}}\UnityEngine.InputModule.dll</HintPath>
+			<Private>false</Private>
+		</Reference>
+		<Reference Include="UnityEngine.PhysicsModule">
+			<HintPath>{{LC_PATH}}\UnityEngine.PhysicsModule.dll</HintPath>
+			<Private>false</Private>
+		</Reference>
+		<Reference Include="UnityEngine.UI">
+			<HintPath>{{LC_PATH}}\UnityEngine.UI.dll</HintPath>
+			<Private>false</Private>
+		</Reference>
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+		<PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
+	</ItemGroup>
+	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
+		<Exec Command="cd ..\NetcodePatcher-2.4.0&#xD;&#xA;NetcodePatcher.dll $(TargetDir) deps/" />
+	</Target>
 </Project>

--- a/MoreShipUpgrades/MoreShipUpgrades.csproj
+++ b/MoreShipUpgrades/MoreShipUpgrades.csproj
@@ -12,7 +12,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<Reference Include="0Harmony">
-			<HintPath>{{LC_PATH}}\0Harmony.dll</HintPath>
+			<HintPath>{{BEPINEX_ASSEMBLY_PATH}}\0Harmony.dll</HintPath>
 			<Private>false</Private>
 		</Reference>
 		<Reference Include="Assembly-CSharp">

--- a/SetupProject.py
+++ b/SetupProject.py
@@ -1,0 +1,57 @@
+import os
+import sys
+
+# Reads the steam library VDF file to find where Lethal Company is installed
+libraryFolderDb = "C:\\Program Files (x86)\\Steam\\steamapps\\libraryfolders.vdf"
+
+vs_project_file = ".\\LateGameUpgrades\\LateGameUpgrades.csproj"
+
+lc_path = ""
+
+# Parsing through steam library vdf
+with open(libraryFolderDb, "r") as file:
+    steamAppDirectory = ""
+
+    for line in file:
+        line = line.strip()
+        if (line.startswith('"path"')): # Parsing (messily) through the steam library folders vdf
+            steamAppDirectory = line.split('"path"')[1].strip().replace("\\\\", "\\")[1:-1] # Steam data directory
+            #print(steamAppDirectory)
+
+        elif (line.startswith('"1966720"')): # Checks for Lethal Company app id
+            lc_path = os.path.join(steamAppDirectory, "steamapps\\common\\Lethal Company") # Lethal Company Path
+
+# Ensures path exists before modifying project file
+if (lc_path == ""):
+    print("Unable to find Lethal Company path.")
+    sys.exit(1)
+
+# Replaces referenced assembly paths in the project file to match computer configuration
+replace_paths = {}
+
+# Lethal Company Managed Assembly Path
+replace_paths["{{LC_PATH}}"] = os.path.join(lc_path, "Lethal Company_Data\\Managed")
+
+# BepInEx Assembly Path
+replace_paths["{{BEPINEX_ASSEMBLY_PATH}}"] = os.path.join(lc_path, "BepInEx\\core")
+
+# BepInEx Plugin Path
+replace_paths["{{BEPINEX_PLUGIN_PATH}}"] = os.path.join(lc_path, "BepInEx\\plugins")
+
+# Replace reference string with corrected paths
+lines = []
+with open(vs_project_file, "r") as file:
+    lines = file.readlines()
+
+# Does the replacement
+for i in range(len(lines)):
+    for rep in replace_paths.keys():
+        lines[i] = lines[i].replace(rep, replace_paths[rep])
+
+# Writes changes
+with open(vs_project_file, "w") as file:
+    file.writelines(lines)
+
+# Finalize Output
+for key in replace_paths.keys():
+    print(key + " -> " + replace_paths[key])

--- a/SetupProject.py
+++ b/SetupProject.py
@@ -4,7 +4,7 @@ import sys
 # Reads the steam library VDF file to find where Lethal Company is installed
 libraryFolderDb = "C:\\Program Files (x86)\\Steam\\steamapps\\libraryfolders.vdf"
 
-vs_project_file = ".\\LateGameUpgrades\\LateGameUpgrades.csproj"
+vs_project_file = ".\\MoreShipUpgrades\\MoreShipUpgrades.csproj"
 
 lc_path = ""
 


### PR DESCRIPTION
I created a python script that automatically grabs the game path and allows for the assemblies to be correctly referenced at their actual locations once the script is run. This allows for the project to be more easily compiled but by developers.

I parse through the steam library vdf file (C:\Program Files (x86)\Steam\steamapps\libraryfolders.vdf) to grab the Lethal Company directory and replace assembly references in the visual studio project file with updated references. This may seem like too much work or not worth it but I got annoyed ¯\_(ツ)_/¯. Do with this what you will.

If there's anything that needs to be changed or something I missed completely, let me know!