### PR TITLE
WhiteSpike/LightningRod

### DIFF
--- a/MoreShipUpgrades/Managers/LGUStore.cs
+++ b/MoreShipUpgrades/Managers/LGUStore.cs
@@ -31,6 +31,7 @@ namespace MoreShipUpgrades.Managers
             {"Back Muscles", SaveInfo => SaveInfo.exoskeleton },
             {"Locksmith", SaveInfo => SaveInfo.lockSmith },
             {"Walkie GPS", SaveInfo => SaveInfo.walkies },
+            {lightningRodScript.UPGRADE_NAME, SaveInfo => SaveInfo.lightningRod },
         };
 
         private static Dictionary<string, Func<SaveInfo, int>> levelConditions = new Dictionary<string, Func<SaveInfo, int>>
@@ -46,7 +47,8 @@ namespace MoreShipUpgrades.Managers
             { "Beekeeper", saveInfo => saveInfo.beeLevel },
             { "Back Muscles", saveInfo => saveInfo.backLevel },
             { "Locksmith", saveInfo => 0 },
-            { "Walkie GPS", saveInfo => 0 }
+            { "Walkie GPS", saveInfo => 0 },
+            { lightningRodScript.UPGRADE_NAME, saveInfo => 0},
         };
 
         private void Start()
@@ -249,6 +251,7 @@ namespace MoreShipUpgrades.Managers
             UpgradeBus.instance.runningShoes = saveInfo.runningShoes;
             UpgradeBus.instance.biggerLungs = saveInfo.biggerLungs;
             UpgradeBus.instance.proteinPowder = saveInfo.proteinPowder;
+            UpgradeBus.instance.lightningRod = saveInfo.lightningRod;
 
             UpgradeBus.instance.beeLevel = saveInfo.beeLevel;
             UpgradeBus.instance.proteinLevel = saveInfo.proteinLevel;
@@ -368,6 +371,7 @@ namespace MoreShipUpgrades.Managers
         public bool biggerLungs = UpgradeBus.instance.biggerLungs;
         public bool lockSmith = UpgradeBus.instance.lockSmith;
         public bool walkies = UpgradeBus.instance.walkies;
+        public bool lightningRod = UpgradeBus.instance.lightningRod;
 
         public int beeLevel = UpgradeBus.instance.beeLevel;
         public int proteinLevel = UpgradeBus.instance.beeLevel;

--- a/MoreShipUpgrades/Managers/UpgradeBus.cs
+++ b/MoreShipUpgrades/Managers/UpgradeBus.cs
@@ -29,6 +29,8 @@ namespace MoreShipUpgrades.Managers
         public bool lockSmith = false;
         public bool biggerLungs = false;
         public bool proteinPowder = false;
+        public bool lightningRod = false;
+        public bool lightningRodActive = false;
 
         public int lungLevel = 0;
         public int proteinLevel = 0;
@@ -40,6 +42,7 @@ namespace MoreShipUpgrades.Managers
         public int legLevel = 0;
         public int nightVisionLevel = 0;
 
+        public float lightningRodProbability = 1f;
         public float flashCooldown = 0f;
         public float alteredWeight = 1f;
 
@@ -112,6 +115,8 @@ namespace MoreShipUpgrades.Managers
             runningShoes = false;
             lockSmith = false;
             biggerLungs = false;
+            lightningRod = false;
+            lightningRodActive = false;
             lungLevel = 0;
             backLevel = 0;
             beeLevel = 0;
@@ -121,6 +126,7 @@ namespace MoreShipUpgrades.Managers
             legLevel = 0;
             nightVisionLevel = 0;
             flashCooldown = 0f;
+            lightningRodProbability = 1f;
             alteredWeight = 1f;
             trapHandler = null;
             flashScript = null;

--- a/MoreShipUpgrades/Misc/PluginConfig.cs
+++ b/MoreShipUpgrades/Misc/PluginConfig.cs
@@ -4,6 +4,7 @@ using System.Drawing;
 using System.Collections.Generic;
 using System;
 using UnityEngine.InputSystem;
+using MoreShipUpgrades.UpgradeComponents;
 
 
 namespace MoreShipUpgrades.Misc
@@ -26,6 +27,7 @@ namespace MoreShipUpgrades.Misc
         public bool STRONG_LEGS_ENABLED { get; set; }
         public bool DISCOMBOBULATOR_ENABLED { get; set; }
         public bool MALWARE_BROADCASTER_ENABLED { get; set; }
+        public bool LIGHTNING_ROD_ENABLED { get; set; }
 
         // individual or shared
         public bool ADVANCED_TELE_INDIVIDUAL { get; set; }
@@ -62,6 +64,7 @@ namespace MoreShipUpgrades.Misc
         public int DISCOMBOBULATOR_PRICE { get; set; }
         public int MALWARE_BROADCASTER_PRICE { get; set; }
         public int WALKIE_PRICE { get; set; }
+        public int LIGHTNING_ROD_PRICE { get; set; }
 
         // attributes
         public int PROTEIN_INCREMENT { get; set; }
@@ -120,6 +123,9 @@ namespace MoreShipUpgrades.Misc
         public bool WALKIE_ENABLED { get; set; }
         public bool WALKIE_INDIVIDUAL { get; set; }
         public int PROTEIN_UNLOCK_FORCE {  get; set; }
+        public float LIGHTNING_ROD_PROBABILITY { get; set; }
+        public bool LIGHTNING_ROD_ACTIVE { get; set; }
+
 
         public PluginConfig(ConfigFile cfg)
         {
@@ -248,6 +254,11 @@ namespace MoreShipUpgrades.Misc
 
             PEEPER_ENABLED = ConfigEntry("Peeper", "Enable Peeper item", true, "An item that will stare at coilheads for you.");
             PEEPER_PRICE = ConfigEntry("Peeper", "Peeper Price", 500, "Default price to purchase a Peeper.");
+
+            LIGHTNING_ROD_ENABLED = ConfigEntry(lightningRodScript.UPGRADE_NAME, lightningRodScript.ENABLED_SECTION, lightningRodScript.ENABLED_DEFAULT, lightningRodScript.ENABLED_DESCRIPTION);
+            LIGHTNING_ROD_PRICE = ConfigEntry(lightningRodScript.UPGRADE_NAME, lightningRodScript.PRICE_SECTION, lightningRodScript.PRICE_DEFAULT, "");
+            LIGHTNING_ROD_PROBABILITY = ConfigEntry(lightningRodScript.UPGRADE_NAME, lightningRodScript.PROBABILITY_SECTION, lightningRodScript.PROBABILITY_DEFAULT, lightningRodScript.PROBABILITY_DESCRIPTION);
+            LIGHTNING_ROD_ACTIVE = ConfigEntry(lightningRodScript.UPGRADE_NAME, lightningRodScript.ACTIVE_SECTION, lightningRodScript.ACTIVE_DEFAULT, lightningRodScript.ACTIVE_DESCRIPTION);
 
             WALKIE_ENABLED = ConfigEntry("Walkie", "Enable the walkie talkie gps upgrade", true, "Holding a walkie talkie displays location.");
             WALKIE_PRICE = ConfigEntry("Walkie", "Walkie GPS Price", 450, "Default price for upgrade.");

--- a/MoreShipUpgrades/Patches/StormyWeatherPatcher.cs
+++ b/MoreShipUpgrades/Patches/StormyWeatherPatcher.cs
@@ -1,0 +1,22 @@
+﻿using HarmonyLib;
+using MoreShipUpgrades.Managers;
+using MoreShipUpgrades.UpgradeComponents;
+using UnityEngine;
+
+
+namespace MoreShipUpgrades.Patches
+{
+    [HarmonyPatch(typeof(StormyWeather))]
+    internal class StormyWeatherPatcher
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch("LightningStrike")]
+        public static void CheckIfLightningRodPresent(ref Vector3 strikePosition)
+        {
+            if (UpgradeBus.instance.lightningRod)
+            {
+                lightningRodScript.TryCatchLightningBolt(ref strikePosition);
+            }
+        }
+    }
+}

--- a/MoreShipUpgrades/Patches/TerminalPatcher.cs
+++ b/MoreShipUpgrades/Patches/TerminalPatcher.cs
@@ -2,6 +2,7 @@
 using HarmonyLib;
 using MoreShipUpgrades.Managers;
 using MoreShipUpgrades.Misc;
+using MoreShipUpgrades.UpgradeComponents;
 using Newtonsoft.Json;
 using System.Collections;
 using System.Collections.Generic;
@@ -28,6 +29,15 @@ namespace MoreShipUpgrades.Patches
         private static void CustomParser(ref Terminal __instance, ref TerminalNode __result)
         {
             string text = __instance.screenText.text.Substring(__instance.screenText.text.Length - __instance.textAdded);
+            if (text.Split()[0].ToLower() == "toggle" && text.Split()[1].ToLower() == "lightning")
+            {
+                if (!UpgradeBus.instance.lightningRod)
+                {
+                    lightningRodScript.AccessDeniedMessage(ref __result);
+                    return;
+                }
+                lightningRodScript.ToggleLightningRod(ref __result);
+            }
             if (text.ToLower() == "initattack" || text.ToLower() == "atk")
             {
                 if (!UpgradeBus.instance.terminalFlash)

--- a/MoreShipUpgrades/Plugin.cs
+++ b/MoreShipUpgrades/Plugin.cs
@@ -538,6 +538,10 @@ namespace MoreShipUpgrades
                 UpgradeBus.instance.terminalNodes.Add(node);
             }
 
+            // Lightning Rod
+            SetupLightningRod(ref UpgradeAssets, ref infoJson);
+
+
             //lockSmith
             GameObject lockSmith = UpgradeAssets.LoadAsset<GameObject>("Assets/ShipUpgrades/LockSmith.prefab");
             lockSmith.AddComponent<lockSmithScript>();
@@ -581,6 +585,20 @@ namespace MoreShipUpgrades
                     break;
                 }
 
+            }
+        }
+
+        private void SetupLightningRod(ref AssetBundle UpgradeAssets, ref Dictionary<string, string> infoJson)
+        {
+            GameObject lightningRod = UpgradeAssets.LoadAsset<GameObject>("Assets/ShipUpgrades/LightningRod.prefab");
+            lightningRod.AddComponent<lightningRodScript>();
+            LethalLib.Modules.NetworkPrefabs.RegisterNetworkPrefab(lightningRod);
+            bool shareStatus = true; // It doesn't really make sense making this individual
+            UpgradeBus.instance.IndividualUpgrades.Add(lightningRodScript.UPGRADE_NAME, shareStatus);
+            if (cfg.LIGHTNING_ROD_ENABLED)
+            {
+                CustomTerminalNode node = new CustomTerminalNode(lightningRodScript.UPGRADE_NAME, cfg.LIGHTNING_ROD_PRICE, string.Format(infoJson[lightningRodScript.UPGRADE_NAME], cfg.LIGHTNING_ROD_PRICE), lightningRod);
+                UpgradeBus.instance.terminalNodes.Add(node);
             }
         }
     }

--- a/MoreShipUpgrades/UpgradeComponents/lightningRodScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/lightningRodScript.cs
@@ -1,0 +1,97 @@
+﻿using MoreShipUpgrades.Managers;
+using MoreShipUpgrades.Misc;
+using UnityEngine;
+
+namespace MoreShipUpgrades.UpgradeComponents
+{
+    internal class lightningRodScript : BaseUpgrade
+    {
+        public static string UPGRADE_NAME = "Lightning Rod";
+
+        // Configuration
+        public static string ENABLED_SECTION = string.Format("Enable {0} Upgrade", UPGRADE_NAME);
+        public static bool ENABLED_DEFAULT = true;
+        public static string ENABLED_DESCRIPTION = "A device which redirects lightning bolts to the ship.";
+
+        public static string PRICE_SECTION = string.Format("{0} Price", UPGRADE_NAME);
+        public static int PRICE_DEFAULT = 1000;
+
+        public static string PROBABILITY_SECTION = string.Format("Probability that {0} will redirect a lightning bolt to the ship.", UPGRADE_NAME);
+        public static float PROBABILITY_DEFAULT = 1.0f;
+        public static string PROBABILITY_DESCRIPTION = "Values from [0,1], being 0 equivalent to zero chance and 1 being guaranteed to redirect.";
+
+        public static string ACTIVE_SECTION = "Active on Purchase";
+        public static bool ACTIVE_DEFAULT = true;
+        public static string ACTIVE_DESCRIPTION = string.Format("If true: {0} will be active on purchase.", UPGRADE_NAME);
+
+        // Chat Messages
+        private static string LOAD_COLOUR = "#FF0000";
+        private static string LOAD_MESSAGE = string.Format("\n<color={0}>{1} is active!</color>", LOAD_COLOUR, UPGRADE_NAME);
+
+        private static string UNLOAD_COLOUR = LOAD_COLOUR;
+        private static string UNLOAD_MESSAGE = string.Format("\n<color={0}>{1} has been disabled</color>", UNLOAD_COLOUR, UPGRADE_NAME);
+
+        // Toggle
+        private static string ACCESS_DENIED_MESSAGE = string.Format("You don't have access to this command yet. Purchase the '{0}'.\n", lightningRodScript.UPGRADE_NAME);
+        private static string TOGGLE_ON_MESSAGE = string.Format("{0} has been enabled. Lightning bolts will now be redirected to the ship.\n", UPGRADE_NAME);
+        private static string TOGGLE_OFF_MESSAGE = string.Format("{0} has been disabled. Lightning bolts will no longer be redirected to the ship.\n", UPGRADE_NAME);
+
+        void Start()
+        {
+            DontDestroyOnLoad(gameObject);
+            UpgradeBus.instance.UpgradeObjects.Add(UPGRADE_NAME, gameObject);
+        }
+
+        public override void Increment()
+        {
+
+        }
+
+        public override void load()
+        {
+            UpgradeBus.instance.lightningRod = true;
+            UpgradeBus.instance.lightningRodProbability = UpgradeBus.instance.cfg.LIGHTNING_ROD_PROBABILITY;
+            UpgradeBus.instance.lightningRodActive = UpgradeBus.instance.cfg.LIGHTNING_ROD_ACTIVE;
+            HUDManager.Instance.chatText.text += LOAD_MESSAGE;
+        }
+
+        public override void Register()
+        {
+            if (!UpgradeBus.instance.UpgradeObjects.ContainsKey(UPGRADE_NAME)) { UpgradeBus.instance.UpgradeObjects.Add(UPGRADE_NAME, gameObject); }
+        }
+
+        public override void Unwind()
+        {
+            UpgradeBus.instance.lightningRod = false;
+            UpgradeBus.instance.lightningRodProbability = 0f;
+            UpgradeBus.instance.lightningRodActive = false;
+            HUDManager.Instance.chatText.text += UNLOAD_MESSAGE;
+        }
+
+        public static void TryCatchLightningBolt(ref Vector3 explosionPosition)
+        {
+            if (UpgradeBus.instance.lightningRodActive && Random.Range(0, 1) <= UpgradeBus.instance.lightningRodProbability)
+            {
+                Terminal terminal = GameObject.Find("TerminalScript").GetComponent<Terminal>();
+                explosionPosition = terminal.transform.position;
+            }
+        }
+
+        public static void ToggleLightningRod(ref TerminalNode __result)
+        {
+            UpgradeBus.instance.lightningRodActive = !UpgradeBus.instance.lightningRodActive;
+            TerminalNode infoNode = new TerminalNode();
+            infoNode.displayText = UpgradeBus.instance.lightningRodActive ? TOGGLE_ON_MESSAGE: TOGGLE_OFF_MESSAGE;
+            infoNode.clearPreviousText = true;
+            __result = infoNode;
+        }
+
+        public static void AccessDeniedMessage(ref TerminalNode __result)
+        {
+            TerminalNode failNode = new TerminalNode();
+            failNode.displayText = ACCESS_DENIED_MESSAGE;
+            failNode.clearPreviousText = true;
+            __result = failNode;
+        }
+    }
+}


### PR DESCRIPTION
*inhales*
LGUStore.cs
- Added attributes related to Lightning Rod

UpgradeBus.cs
- Added attributes related to Lightning Rod

PluginConfig.cs
- Added parameters that can alter the attributes of Lightning Rod: -- Enable the Lightning Rod perk (default = true)
-- The price of the Lightning Rod perk (default = 1000) -- The probability the Lightning rod redirecting the lightning bolts to the ship. (default = 1f) -- The default state when purchasing the perk from the store (default = true)

StormyWeatherPatcher.cs
- Added a patch for "StormyWeather" class so that, when a lightning strike spawns, check if the lightning rod has been bought and if so, tries to catch the lightning bolt and point it to the ship.

TerminalPatcher.cs
- Added a command "toggle lightning" which toggles the active state of the lightning rod. If the player did not buy the perk and try executing this command, they will prompted to not having access to the command and suggest buying the perk.

Plugin.cs
- Added a function which setups the Lightning Rod perk for purchase in the late game store.

lightningRodScript.cs
- Added the associated attributes, strings and default values for easier refactoring when necessary.
- TryCatchLightningBolt checks if the perk is active and does a Random to see if it's lower than the configured probability. If true, redirects the strike position of the lightning bolt to the terminal (not exactly on the terminal but rather on the roof of the ship where the terminal is located)
- ToggleLightningRod toggles the perk on or off depending on the current state and outputs to the terminal the result of the operation.
- AccessDeniedMessage which is triggered when an user tries to use "toggle lightning" without buying the perk first.
*exhales*

The asset used is in the zip. I didn't touch the binaries on this one.