### PR TITLE
Implementation of Player Health Upgrade (Stimpack)

### DIFF
--- a/MoreShipUpgrades/Managers/LGUStore.cs
+++ b/MoreShipUpgrades/Managers/LGUStore.cs
@@ -36,6 +36,7 @@ namespace MoreShipUpgrades.Managers
             {"Fast Encryption", SaveInfo => SaveInfo.pager },
             {"Hunter", SaveInfo => SaveInfo.hunter },
             {lightningRodScript.UPGRADE_NAME, SaveInfo => SaveInfo.lightningRod },
+            {playerHealthScript.UPGRADE_NAME, SaveInfo => SaveInfo.playerHealth },
         };
 
         private static Dictionary<string, Func<SaveInfo, int>> levelConditions = new Dictionary<string, Func<SaveInfo, int>>
@@ -56,6 +57,7 @@ namespace MoreShipUpgrades.Managers
             {"Fast Encryption", SaveInfo => 0 },
             {"Hunter", SaveInfo => SaveInfo.huntLevel },
             { lightningRodScript.UPGRADE_NAME, saveInfo => 0},
+            { playerHealthScript.UPGRADE_NAME, saveInfo => saveInfo.playerHealthLevel },
         };
         private bool retrievedCfg;
         private bool receivedSave;
@@ -226,6 +228,21 @@ namespace MoreShipUpgrades.Managers
             }
         }
 
+        [ServerRpc(RequireOwnership = false)]
+        public void UpdatePlayerNewHealthsServerRpc(ulong id, int health) 
+        {
+            UpdatePlayerNewHealthsClientRpc(id, health);
+        }
+
+        [ClientRpc]
+        private void UpdatePlayerNewHealthsClientRpc(ulong id, int health)
+        {
+            if (UpgradeBus.instance.playerHPs.ContainsKey(id))
+                UpgradeBus.instance.playerHPs[id] = health;
+            else UpgradeBus.instance.playerHPs.Add(id, health);
+            playerHealthScript.CheckForAdditionalHealth(GameNetworkManager.Instance.localPlayerController);
+        }
+
         [ServerRpc(RequireOwnership =false)]
         public void UpdateForceMultsServerRpc(ulong id, int lvl)
         {
@@ -307,6 +324,7 @@ namespace MoreShipUpgrades.Managers
             UpgradeBus.instance.lightningRod = saveInfo.lightningRod;
             UpgradeBus.instance.pager = saveInfo.pager;
             UpgradeBus.instance.hunter = saveInfo.hunter;
+            UpgradeBus.instance.playerHealth = saveInfo.playerHealth;
 
             UpgradeBus.instance.beeLevel = saveInfo.beeLevel;
             UpgradeBus.instance.huntLevel = saveInfo.huntLevel;
@@ -320,6 +338,7 @@ namespace MoreShipUpgrades.Managers
             UpgradeBus.instance.legLevel = saveInfo.legLevel;
             UpgradeBus.instance.scanLevel = saveInfo.scanLevel;
             UpgradeBus.instance.nightVisionLevel = saveInfo.nightVisionLevel;
+            UpgradeBus.instance.playerHealthLevel = saveInfo.playerHealthLevel;
 
             StartCoroutine(WaitForUpgradeObject());
         }
@@ -443,6 +462,7 @@ namespace MoreShipUpgrades.Managers
         public bool lightningRod = UpgradeBus.instance.lightningRod;
         public bool pager = UpgradeBus.instance.pager;
         public bool hunter = UpgradeBus.instance.hunter;
+        public bool playerHealth = UpgradeBus.instance.playerHealth;
 
         public int beeLevel = UpgradeBus.instance.beeLevel;
         public int huntLevel = UpgradeBus.instance.huntLevel;
@@ -455,6 +475,7 @@ namespace MoreShipUpgrades.Managers
         public int discoLevel = UpgradeBus.instance.discoLevel;
         public int legLevel = UpgradeBus.instance.legLevel;
         public int nightVisionLevel = UpgradeBus.instance.nightVisionLevel;
+        public int playerHealthLevel = UpgradeBus.instance.playerHealthLevel;
     }
 
     [Serializable]

--- a/MoreShipUpgrades/Misc/PluginConfig.cs
+++ b/MoreShipUpgrades/Misc/PluginConfig.cs
@@ -27,6 +27,7 @@ namespace MoreShipUpgrades.Misc
         public bool MALWARE_BROADCASTER_ENABLED { get; set; }
         public bool LIGHTNING_ROD_ENABLED { get; set; }
         public bool HUNTER_ENABLED { get; set; }
+        public bool PLAYER_HEALTH_ENABLED { get; set; }
 
         // individual or shared
         public bool ADVANCED_TELE_INDIVIDUAL { get; set; }
@@ -38,6 +39,7 @@ namespace MoreShipUpgrades.Misc
         public bool LIGHT_FOOTED_INDIVIDUAL { get; set; }
         public bool NIGHT_VISION_INDIVIDUAL { get; set; }
         public bool HUNTER_INDIVIDUAL { get; set; }
+        public bool PLAYER_HEALTH_INDIVIDUAL { get; set; }
 
         public bool RUNNING_SHOES_INDIVIDUAL { get; set; }
         public bool BETTER_SCANNER_INDIVIDUAL { get; set; }
@@ -66,6 +68,7 @@ namespace MoreShipUpgrades.Misc
         public int MALWARE_BROADCASTER_PRICE { get; set; }
         public int WALKIE_PRICE { get; set; }
         public int LIGHTNING_ROD_PRICE { get; set; }
+        public int PLAYER_HEALTH_PRICE { get; set; }
 
         // attributes
         public int PROTEIN_INCREMENT { get; set; }
@@ -127,6 +130,7 @@ namespace MoreShipUpgrades.Misc
         public string STRONG_LEGS_UPGRADE_PRICES { get; set; }
         public string DISCO_UPGRADE_PRICES { get; set; }
         public string PROTEIN_UPGRADE_PRICES { get; set; }
+        public string PLAYER_HEALTH_UPGRADE_PRICES { get; set; }
         public bool SHARED_UPGRADES { get; set; }
         public bool WALKIE_ENABLED { get; set; }
         public bool WALKIE_INDIVIDUAL { get; set; }
@@ -140,6 +144,8 @@ namespace MoreShipUpgrades.Misc
         public bool PAGER_ENABLED {  get; set; }
         public int PAGER_PRICE {  get; set; }
         public bool VERBOSE_ENEMIES {  get; set; }
+        public int PLAYER_HEALTH_ADDITIONAL_HEALTH_UNLOCK { get; set; }
+        public int PLAYER_HEALTH_ADDITIONAL_HEALTH_INCREMENT { get; set; }
 
 
         public PluginConfig(ConfigFile cfg)
@@ -290,7 +296,13 @@ namespace MoreShipUpgrades.Misc
 
             HUNTER_ENABLED = ConfigEntry("Hunter", "Enable the Hunter upgrade", true, "Collect and sell samples from dead enemies");
             HUNTER_PRICE = ConfigEntry("Hunter", "Hunter price", 700, "Default price for upgrade.");
-        }
 
+            PLAYER_HEALTH_ENABLED = ConfigEntry(playerHealthScript.UPGRADE_NAME, playerHealthScript.ENABLED_SECTION, playerHealthScript.ENABLED_DEFAULT, playerHealthScript.ENABLED_DESCRIPTION);
+            PLAYER_HEALTH_PRICE = ConfigEntry(playerHealthScript.UPGRADE_NAME, playerHealthScript.PRICE_SECTION, playerHealthScript.PRICE_DEFAULT, "");
+            PLAYER_HEALTH_INDIVIDUAL = ConfigEntry(playerHealthScript.UPGRADE_NAME, playerHealthScript.INDIVIDUAL_SECTION, playerHealthScript.INDIVIDUAL_DEFAULT, playerHealthScript.INDIVIDUAL_DESCRIPTION);
+            PLAYER_HEALTH_UPGRADE_PRICES = ConfigEntry(playerHealthScript.UPGRADE_NAME, playerHealthScript.UPGRADE_PRICES_SECTION, playerHealthScript.UPGRADE_PRICES_DEFAULT, "");
+            PLAYER_HEALTH_ADDITIONAL_HEALTH_UNLOCK = ConfigEntry(playerHealthScript.UPGRADE_NAME, playerHealthScript.ADDITIONAL_HEALTH_UNLOCK_SECTION, playerHealthScript.ADDITIONAL_HEALTH_UNLOCK_DEFAULT, playerHealthScript.ADDITIONAL_HEALTH_UNLOCK_DESCRIPTION);
+            PLAYER_HEALTH_ADDITIONAL_HEALTH_INCREMENT = ConfigEntry(playerHealthScript.UPGRADE_NAME, playerHealthScript.ADDITIONAL_HEALTH_INCREMENT_SECTION, playerHealthScript.ADDITIONAL_HEALTH_INCREMENT_DEFAULT, playerHealthScript.ADDITIONAL_HEALTH_INCREMENT_DESCRIPTION);
+        }
     }
 }

--- a/MoreShipUpgrades/Patches/StartOfRoundPatcher.cs
+++ b/MoreShipUpgrades/Patches/StartOfRoundPatcher.cs
@@ -1,6 +1,7 @@
 ﻿using GameNetcodeStuff;
 using HarmonyLib;
 using MoreShipUpgrades.Managers;
+using MoreShipUpgrades.UpgradeComponents;
 using Unity.Netcode;
 using UnityEngine;
 
@@ -35,6 +36,13 @@ namespace MoreShipUpgrades.Patches
             {
                 LGUStore.instance.PlayersFiredServerRpc();
             }
+        }
+
+        [HarmonyPostfix]
+        [HarmonyPatch("OpenShipDoors")]
+        private static void UpdatePlayersHealth(StartOfRound __instance)
+        {
+            playerHealthScript.CheckAdditionalHealth(__instance);
         }
     }
 }

--- a/MoreShipUpgrades/Plugin.cs
+++ b/MoreShipUpgrades/Plugin.cs
@@ -259,6 +259,10 @@ namespace MoreShipUpgrades
             lockSmith.AddComponent<lockSmithScript>();
             LethalLib.Modules.NetworkPrefabs.RegisterNetworkPrefab(lockSmith);
 
+            GameObject playerHealth = AssetBundleHandler.TryLoadGameObjectAsset(ref UpgradeAssets, "Assets/ShipUpgrades/PlayerHealth.prefab");
+            playerHealth.AddComponent<playerHealthScript>();
+            LethalLib.Modules.NetworkPrefabs.RegisterNetworkPrefab(playerHealth);
+
             harmony.PatchAll();
 
             mls.LogInfo("LGU has been patched");

--- a/MoreShipUpgrades/UpgradeComponents/playerHealthScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/playerHealthScript.cs
@@ -1,0 +1,95 @@
+﻿using GameNetcodeStuff;
+using MoreShipUpgrades.Managers;
+using MoreShipUpgrades.Misc;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MoreShipUpgrades.UpgradeComponents
+{
+    internal class playerHealthScript : BaseUpgrade
+    {
+        public static string UPGRADE_NAME = "Stimpack";
+
+        private static int DEFAULT_HEALTH = 100;
+
+        // Configuration
+        public static string ENABLED_SECTION = string.Format("Enable {0} Upgrade", UPGRADE_NAME);
+        public static bool ENABLED_DEFAULT = true;
+        public static string ENABLED_DESCRIPTION = "Increases player's health.";
+
+        public static string PRICE_SECTION = string.Format("{0} Price", UPGRADE_NAME);
+        public static int PRICE_DEFAULT = 600;
+
+        public static string INDIVIDUAL_SECTION = "Individual Purchase";
+        public static bool INDIVIDUAL_DEFAULT = false;
+        public static string INDIVIDUAL_DESCRIPTION = "If true: upgrade will apply only to the client that purchased it.";
+
+        // Chat Messages
+        private static string LOAD_COLOUR = "#FF0000";
+        private static string LOAD_MESSAGE = string.Format("\n<color={0}>{1} is active!</color>", LOAD_COLOUR, UPGRADE_NAME);
+
+        private static string UNLOAD_COLOUR = LOAD_COLOUR;
+        private static string UNLOAD_MESSAGE = string.Format("\n<color={0}>{1} has been disabled</color>", UNLOAD_COLOUR, UPGRADE_NAME);
+
+        public static string UPGRADE_PRICES_SECTION = "Price of each additional upgrade";
+        public static string UPGRADE_PRICES_DEFAULT = "300, 450, 600";
+
+        public static string ADDITIONAL_HEALTH_UNLOCK_SECTION = "Initial health boost";
+        public static int ADDITIONAL_HEALTH_UNLOCK_DEFAULT = 20;
+        public static string ADDITIONAL_HEALTH_UNLOCK_DESCRIPTION = "Amount of health gained when unlocking the upgrade";
+
+        public static string ADDITIONAL_HEALTH_INCREMENT_SECTION = "Additional health boost";
+        public static int ADDITIONAL_HEALTH_INCREMENT_DEFAULT = 20;
+        public static string ADDITIONAL_HEALTH_INCREMENT_DESCRIPTION = string.Format("Every time {0} is upgraded this value will be added to the value above.", UPGRADE_NAME);
+
+        void Start()
+        {
+            DontDestroyOnLoad(gameObject);
+            UpgradeBus.instance.UpgradeObjects.Add(UPGRADE_NAME, gameObject);
+        }
+
+        public override void Increment()
+        {
+            UpgradeBus.instance.playerHealthLevel++;
+            LGUStore.instance.UpdatePlayerNewHealthsServerRpc(GameNetworkManager.Instance.localPlayerController.playerSteamId, DEFAULT_HEALTH + UpgradeBus.instance.cfg.PLAYER_HEALTH_ADDITIONAL_HEALTH_UNLOCK + (UpgradeBus.instance.playerHealthLevel * UpgradeBus.instance.cfg.PLAYER_HEALTH_ADDITIONAL_HEALTH_INCREMENT));
+        }
+
+        public override void load()
+        {
+            UpgradeBus.instance.playerHealth = true;
+            HUDManager.Instance.chatText.text += LOAD_MESSAGE;
+            LGUStore.instance.UpdatePlayerNewHealthsServerRpc(GameNetworkManager.Instance.localPlayerController.playerSteamId, DEFAULT_HEALTH + UpgradeBus.instance.cfg.PLAYER_HEALTH_ADDITIONAL_HEALTH_UNLOCK + (UpgradeBus.instance.playerHealthLevel * UpgradeBus.instance.cfg.PLAYER_HEALTH_ADDITIONAL_HEALTH_INCREMENT));
+        }
+
+        public override void Register()
+        {
+            if (!UpgradeBus.instance.UpgradeObjects.ContainsKey(UPGRADE_NAME)) { UpgradeBus.instance.UpgradeObjects.Add(UPGRADE_NAME, gameObject); }
+        }
+
+        public override void Unwind()
+        {
+            UpgradeBus.instance.playerHealthLevel = 0;
+            UpgradeBus.instance.playerHealth = false;
+            HUDManager.Instance.chatText.text += UNLOAD_MESSAGE;
+            LGUStore.instance.UpdatePlayerNewHealthsServerRpc(GameNetworkManager.Instance.localPlayerController.playerSteamId, 0);
+        }
+
+        public static void CheckAdditionalHealth(StartOfRound __instance)
+        {
+            PlayerControllerB[] players = __instance.allPlayerScripts;
+            foreach (PlayerControllerB player in players)
+            {
+                CheckForAdditionalHealth(player);
+            }
+        }
+
+        public static void CheckForAdditionalHealth(PlayerControllerB player)
+        {
+            if (UpgradeBus.instance.playerHPs.ContainsKey(player.playerSteamId))
+                player.health = UpgradeBus.instance.playerHPs[player.playerSteamId];
+            if (player.playerSteamId == GameNetworkManager.Instance.localPlayerController.playerSteamId)
+                HUDManager.Instance.UpdateHealthUI(player.health, hurtPlayer: false);
+        }
+    }
+}


### PR DESCRIPTION
Made a new upgrade called "Stimpack" which basically increases the player's health.
Sounds easy enough right? Just increase the max health of the player and be going with it.
WELL, apparently it's just one variable for health and it's the current one so I had to be creative.

Whenever the player buys the upgrade or increments the level, check if it's the local player that bought it to update the health.
Whenever a new round starts, each player's health gets updated if they have any entries in the dictionary associated to this upgrade (which stores the amount of health they will have). If so, put the respective value into their health and update the HUD.

This obviously won't work if any other mods that regen health as they all, and rightfully so, set the health value to the default which is 100. For mods that use DamagePlayer with negative value, we could use a patcher where it checks it's negative and if it's a full vanilla heal. If so, set it the player's additional health value from the dictionary. This is if we really want the health boost to be still applying after a heal (that isn't ours since we're adding the medkit)