### PR TITLE
Fixing Medpack & Stimpack

### DIFF
--- a/MoreShipUpgrades/Managers/UpgradeBus.cs
+++ b/MoreShipUpgrades/Managers/UpgradeBus.cs
@@ -90,6 +90,7 @@ namespace MoreShipUpgrades.Managers
         public Dictionary<ulong,float> beePercs = new Dictionary<ulong,float>();
         public Dictionary<ulong,int> forceMults = new Dictionary<ulong,int>();
         public Dictionary<ulong, int> playerHPs = new Dictionary<ulong, int>();
+        public Dictionary<ulong, int> currentPlayerHPs = new Dictionary<ulong, int>();
 
         public Dictionary<string,bool> IndividualUpgrades = new Dictionary<string,bool>();
         public string[] internNames, internInterests;

--- a/MoreShipUpgrades/Patches/PlayerControllerBPatcher.cs
+++ b/MoreShipUpgrades/Patches/PlayerControllerBPatcher.cs
@@ -2,6 +2,7 @@
 using HarmonyLib;
 using MoreShipUpgrades.Managers;
 using MoreShipUpgrades.UpgradeComponents;
+using System.Numerics;
 using UnityEngine;
 
 namespace MoreShipUpgrades.Patches
@@ -28,7 +29,19 @@ namespace MoreShipUpgrades.Patches
             if (!UpgradeBus.instance.beePercs.ContainsKey(__instance.playerSteamId) || damageNumber != 10) { return; }
             damageNumber = Mathf.Clamp((int)(damageNumber * (UpgradeBus.instance.cfg.BEEKEEPER_DAMAGE_MULTIPLIER - (UpgradeBus.instance.beePercs[__instance.playerSteamId] * UpgradeBus.instance.cfg.BEEKEEPER_DAMAGE_MULTIPLIER_INCREMENT))),0,100);
         }
-        
+        [HarmonyPrefix]
+        [HarmonyPatch("DamagePlayer")]
+        private static void StimpackBeforeDamage(ref int damageNumber, PlayerControllerB __instance)
+        {
+            playerHealthScript.BeforeDamagePlayer(ref damageNumber, ref __instance);
+        }
+        [HarmonyPostfix]
+        [HarmonyPatch("DamagePlayer")]
+        private static void StimpackAfterDamage(PlayerControllerB __instance)
+        {
+            playerHealthScript.AfterDamagePlayer(ref __instance);
+        }
+
         [HarmonyPrefix]
         [HarmonyPatch("DamagePlayerServerRpc")]
         private static void beekeeperReduceDamageServer(ref int damageNumber, PlayerControllerB __instance)

--- a/MoreShipUpgrades/UpgradeComponents/MedkitScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/MedkitScript.cs
@@ -52,6 +52,7 @@ namespace MoreShipUpgrades.UpgradeComponents
                     itemUsedUp = true;
                     HUDManager.Instance.DisplayTip("NO MORE USES!", "This medkit doesn't have anymore supplies!", true, false, "LC_Tip1");
                 }
+                if (playerHeldBy.health >= 20) playerHeldBy.MakeCriticallyInjured(false);
             }
         }
     }

--- a/MoreShipUpgrades/UpgradeComponents/defibScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/defibScript.cs
@@ -129,7 +129,7 @@ namespace MoreShipUpgrades.UpgradeComponents
                 player.criticallyInjured = false;
                 player.playerBodyAnimator.SetBool("Limp", false);
                 player.health = health;
-                HUDManager.Instance.UpdateHealthUI(100, false);
+                HUDManager.Instance.UpdateHealthUI(health, false);
                 player.spectatedPlayerScript = null;
                 HUDManager.Instance.audioListenerLowPass.enabled = false;
                 StartOfRound.Instance.SetSpectateCameraToGameOverMode(false, player);

--- a/MoreShipUpgrades/UpgradeComponents/playerHealthScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/playerHealthScript.cs
@@ -1,6 +1,8 @@
 ﻿using GameNetcodeStuff;
 using MoreShipUpgrades.Managers;
 using MoreShipUpgrades.Misc;
+using System;
+using UnityEngine;
 
 namespace MoreShipUpgrades.UpgradeComponents
 {
@@ -87,6 +89,24 @@ namespace MoreShipUpgrades.UpgradeComponents
                 player.health = UpgradeBus.instance.playerHPs[player.playerSteamId];
             if (player.playerSteamId == GameNetworkManager.Instance.localPlayerController.playerSteamId)
                 HUDManager.Instance.UpdateHealthUI(player.health, hurtPlayer: false);
+        }
+
+        internal static void BeforeDamagePlayer(ref int damageNumber, ref PlayerControllerB __instance)
+        {
+            if (!UpgradeBus.instance.playerHPs.ContainsKey(__instance.playerSteamId)) { return; }
+            int newHealth = Mathf.Clamp(__instance.health - damageNumber, 5, UpgradeBus.instance.playerHPs[__instance.playerSteamId]);
+            if (!UpgradeBus.instance.currentPlayerHPs.ContainsKey(__instance.playerSteamId))
+                UpgradeBus.instance.currentPlayerHPs.Add(__instance.playerSteamId, newHealth);
+            else UpgradeBus.instance.currentPlayerHPs[__instance.playerSteamId] = newHealth;
+        }
+
+        internal static void AfterDamagePlayer(ref PlayerControllerB __instance)
+        {
+            if (!UpgradeBus.instance.playerHPs.ContainsKey(__instance.playerSteamId)) { return; }
+            if (__instance.isPlayerDead) { return; }
+
+            __instance.health = UpgradeBus.instance.currentPlayerHPs[__instance.playerSteamId];
+            HUDManager.Instance.UpdateHealthUI(__instance.health);
         }
     }
 }


### PR DESCRIPTION
Fixed medkit not releasing player from Critical Injury state when used and heals pasts the critical threshold.
Added a fix for DamagePlayer resetting any additional health from Stimpack back to 100 due to Mathf.Clamp being restricted between 0 to 100