### PR TITLE
Made transpiler for ReviveDeadPlayers to update health values according to Stimpack upgrade

### DIFF
--- a/MoreShipUpgrades/Patches/StartOfRoundPatcher.cs
+++ b/MoreShipUpgrades/Patches/StartOfRoundPatcher.cs
@@ -2,14 +2,12 @@
 using HarmonyLib;
 using MoreShipUpgrades.Managers;
 using MoreShipUpgrades.UpgradeComponents;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using Unity.Netcode;
 using UnityEngine;
-using UnityEngine.EventSystems;
 
 namespace MoreShipUpgrades.Patches
 {

--- a/MoreShipUpgrades/Patches/StartOfRoundPatcher.cs
+++ b/MoreShipUpgrades/Patches/StartOfRoundPatcher.cs
@@ -2,8 +2,14 @@
 using HarmonyLib;
 using MoreShipUpgrades.Managers;
 using MoreShipUpgrades.UpgradeComponents;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
 using Unity.Netcode;
 using UnityEngine;
+using UnityEngine.EventSystems;
 
 namespace MoreShipUpgrades.Patches
 {
@@ -38,11 +44,38 @@ namespace MoreShipUpgrades.Patches
             }
         }
 
-        [HarmonyPostfix]
-        [HarmonyPatch("OpenShipDoors")]
-        private static void UpdatePlayersHealth(StartOfRound __instance)
+        [HarmonyTranspiler]
+        [HarmonyPatch("ReviveDeadPlayers")]
+        public static IEnumerable<CodeInstruction> ReviveDeadPlayers_Transpiler(IEnumerable<CodeInstruction> instructions)
         {
-            playerHealthScript.CheckAdditionalHealth(__instance);
+            var maximumHealthMethod = typeof(playerHealthScript).GetMethod("CheckForAdditionalHealth", BindingFlags.Public | BindingFlags.Static);
+            List<CodeInstruction> codes = instructions.ToList();
+            bool first = false;
+            bool second = false;
+            bool third = false;
+            bool updateHealth = false;
+            for(int i = 0; i < codes.Count; i++)
+            {
+                if (first && second && third && updateHealth) break;
+                if (!updateHealth)
+                {
+                    if (codes[i].opcode == OpCodes.Ldc_I4_S && codes[i].operand.ToString() == "100" &&
+                        codes[i + 1].opcode == OpCodes.Ldc_I4_0 &&
+                        codes[i + 2].opcode == OpCodes.Callvirt && codes[i + 2].operand.ToString() == "Void UpdateHealthUI(Int32, Boolean)")
+                    {
+                        codes[i] = new CodeInstruction(OpCodes.Call, maximumHealthMethod);
+                        updateHealth = true;
+                    }
+                }
+                if (!(codes[i].opcode == OpCodes.Ldc_I4_S && codes[i].operand.ToString() == "100")) continue;
+                if (!(codes[i + 1].opcode == OpCodes.Stfld && codes[i + 1].operand.ToString() == "System.Int32 health")) continue;
+
+                codes[i] = new CodeInstruction(OpCodes.Call, maximumHealthMethod);
+                if (!first) first = true;
+                else if (!second) second = true;
+                else third = true;
+            }
+            return codes.AsEnumerable();
         }
     }
 }


### PR DESCRIPTION
Requested by [this comment](https://github.com/Malcolm-Q/LC-LateGameUpgrades/pull/79#issuecomment-1868562789), instead of updating the health values whenever the ship's doors open upon entering the moon, we just do the same logic in the DamagePlayer transpiler which is we use the value from Stimpack Upgrade instead of vanilla to update the player's health.