### PR TITLE
Changed PlayerControllerB's pre patches related to Beekeeper to a transpiler in RedLocustBees

### DIFF
--- a/MoreShipUpgrades/Managers/LGUStore.cs
+++ b/MoreShipUpgrades/Managers/LGUStore.cs
@@ -210,25 +210,6 @@ namespace MoreShipUpgrades.Managers
             }
         }
 
-        [ServerRpc(RequireOwnership =false)]
-        public void UpdateBeePercsServerRpc(ulong id, int lvl)
-        {
-            UpdateBeePercsClientRpc(id, lvl);
-        }
-
-        [ClientRpc]
-        private void UpdateBeePercsClientRpc(ulong id, int lvl)
-        {
-            if(UpgradeBus.instance.beePercs.ContainsKey(id))
-            {
-                UpgradeBus.instance.beePercs[id] = lvl;
-            }
-            else
-            {
-                UpgradeBus.instance.beePercs.Add(id, lvl);
-            }
-        }
-
         [ServerRpc(RequireOwnership = false)]
         public void UpdatePlayerNewHealthsServerRpc(ulong id, int health) 
         {

--- a/MoreShipUpgrades/Managers/UpgradeBus.cs
+++ b/MoreShipUpgrades/Managers/UpgradeBus.cs
@@ -87,7 +87,6 @@ namespace MoreShipUpgrades.Managers
             { "NV Headset Batteries", (level, price) => nightVisionScript.GetNightVisionInfo(level, price) },
         };
 
-        public Dictionary<ulong,float> beePercs = new Dictionary<ulong,float>();
         public Dictionary<ulong, int> playerHPs = new Dictionary<ulong, int>();
 
         public Dictionary<string,bool> IndividualUpgrades = new Dictionary<string,bool>();

--- a/MoreShipUpgrades/Patches/PlayerControllerBPatcher.cs
+++ b/MoreShipUpgrades/Patches/PlayerControllerBPatcher.cs
@@ -24,39 +24,6 @@ namespace MoreShipUpgrades.Patches
             if(UpgradeBus.instance.nightVision) { UpgradeBus.instance.UpgradeObjects["NV Headset Batteries"].GetComponent<nightVisionScript>().DisableOnClient(); }
         }
 
-
-        [HarmonyPrefix]
-        [HarmonyPatch("DamagePlayer")]
-        private static void beekeeperReduceDamage(ref int damageNumber, CauseOfDeath causeOfDeath, PlayerControllerB __instance)
-        {
-            if (!UpgradeBus.instance.beePercs.ContainsKey(__instance.playerSteamId) || damageNumber != 10) { return; }
-            damageNumber = Mathf.Clamp((int)(damageNumber * (UpgradeBus.instance.cfg.BEEKEEPER_DAMAGE_MULTIPLIER - (UpgradeBus.instance.beePercs[__instance.playerSteamId] * UpgradeBus.instance.cfg.BEEKEEPER_DAMAGE_MULTIPLIER_INCREMENT))),0,100);
-        }
-
-        [HarmonyPrefix]
-        [HarmonyPatch("DamagePlayerServerRpc")]
-        private static void beekeeperReduceDamageServer(ref int damageNumber, PlayerControllerB __instance)
-        {
-            if (!UpgradeBus.instance.beePercs.ContainsKey(__instance.playerSteamId) || damageNumber != 10) { return; }
-            damageNumber = Mathf.Clamp((int)(damageNumber * (UpgradeBus.instance.cfg.BEEKEEPER_DAMAGE_MULTIPLIER - (UpgradeBus.instance.beePercs[__instance.playerSteamId] * UpgradeBus.instance.cfg.BEEKEEPER_DAMAGE_MULTIPLIER_INCREMENT))), 0, 100);
-        }
-
-        [HarmonyPrefix]
-        [HarmonyPatch("DamagePlayerClientRpc")]
-        private static void beekeeperReduceDamageClient(ref int damageNumber, PlayerControllerB __instance)
-        {
-            if (!UpgradeBus.instance.beePercs.ContainsKey(__instance.playerSteamId) || damageNumber != 10) { return; }
-            damageNumber = Mathf.Clamp((int)(damageNumber * (UpgradeBus.instance.cfg.BEEKEEPER_DAMAGE_MULTIPLIER - (UpgradeBus.instance.beePercs[__instance.playerSteamId] * UpgradeBus.instance.cfg.BEEKEEPER_DAMAGE_MULTIPLIER_INCREMENT))), 0, 100);
-        }
-
-        [HarmonyPrefix]
-        [HarmonyPatch("DamageOnOtherClients")]
-        private static void beekeeperReduceDamageOther(ref int damageNumber, PlayerControllerB __instance)
-        {
-            if (!UpgradeBus.instance.beePercs.ContainsKey(__instance.playerSteamId) || damageNumber != 10) { return; }
-            damageNumber = Mathf.Clamp((int)(damageNumber * (UpgradeBus.instance.cfg.BEEKEEPER_DAMAGE_MULTIPLIER - (UpgradeBus.instance.beePercs[__instance.playerSteamId] * UpgradeBus.instance.cfg.BEEKEEPER_DAMAGE_MULTIPLIER_INCREMENT))), 0, 100);
-        }
-
         [HarmonyPatch("DamagePlayer")]
         [HarmonyTranspiler]
         public static IEnumerable<CodeInstruction> DamagePlayerTranspiler(IEnumerable<CodeInstruction> instructions)

--- a/MoreShipUpgrades/Patches/RedLocustBeesPatch.cs
+++ b/MoreShipUpgrades/Patches/RedLocustBeesPatch.cs
@@ -1,0 +1,46 @@
+﻿using HarmonyLib;
+using MoreShipUpgrades.UpgradeComponents;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Text;
+
+namespace MoreShipUpgrades.Patches
+{
+    [HarmonyPatch(typeof(RedLocustBees))]
+    internal class RedLocustBeesPatch
+    {
+        [HarmonyTranspiler]
+        [HarmonyPatch("OnCollideWithPlayer")]
+        public static IEnumerable<CodeInstruction> OnCollideWithPlayer_Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            MethodInfo beeReduceDamage = typeof(beekeeperScript).GetMethod("CalculateBeeDamage", BindingFlags.Public | BindingFlags.Static);
+            List<CodeInstruction> codes = instructions.ToList();
+            bool found = false;
+            for(int i = 0; i < codes.Count; i++)
+            {
+                if (found) break;
+                if (!(codes[i].opcode == OpCodes.Callvirt && codes[i].operand.ToString() == "Void DamagePlayer(Int32, Boolean, Boolean, CauseOfDeath, Int32, Boolean, UnityEngine.Vector3)")) continue;
+
+                /* 
+                * ldc.i4.s  10  -> damageNumber
+                * ldc.i4.1      -> damageSFX
+                * ldc.i4.1      -> callRPC
+                * ldc.i4.s  11  -> CauseDeath
+                * ldc.i4.3      -> DeathAnimationTime
+                * ldc.i4.0      -> fallDamage
+                * ldloca.s V_1  
+                * initobj[UnityEngine.CoreModule]UnityEngine.Vector3
+                * ldloc.1       -> force
+                * callvirt instance void GameNetcodeStuff.PlayerControllerB::DamagePlayer(int32, bool, bool, valuetype CauseOfDeath, int32, bool, valuetype[UnityEngine.CoreModule]UnityEngine.Vector3)
+                */
+                codes.Insert(i - 8, new CodeInstruction(OpCodes.Call, beeReduceDamage));
+                found = true;
+            }
+            if (!found) { Plugin.mls.LogInfo("Did not find DamagePlayer function"); }
+            return codes.AsEnumerable();
+        }
+    }
+}

--- a/MoreShipUpgrades/UpgradeComponents/beekeeperScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/beekeeperScript.cs
@@ -1,5 +1,6 @@
 ﻿using MoreShipUpgrades.Managers;
 using MoreShipUpgrades.Misc;
+using UnityEngine;
 
 namespace MoreShipUpgrades.UpgradeComponents
 {
@@ -14,14 +15,12 @@ namespace MoreShipUpgrades.UpgradeComponents
         public override void Increment()
         {
             UpgradeBus.instance.beeLevel++;
-            LGUStore.instance.UpdateBeePercsServerRpc(GameNetworkManager.Instance.localPlayerController.playerSteamId, UpgradeBus.instance.beeLevel);
         }
 
         public override void load()
         {
             UpgradeBus.instance.beekeeper = true;
             HUDManager.Instance.chatText.text += "\n<color=#FF0000>Beekeeper is active!</color>";
-            LGUStore.instance.UpdateBeePercsServerRpc(GameNetworkManager.Instance.localPlayerController.playerSteamId, UpgradeBus.instance.beeLevel);
         }
 
         public override void Register()
@@ -34,7 +33,12 @@ namespace MoreShipUpgrades.UpgradeComponents
             UpgradeBus.instance.beeLevel = 0;
             UpgradeBus.instance.beekeeper = false;
             HUDManager.Instance.chatText.text += "\n<color=#FF0000>Beekeeper has been disabled</color>";
-            LGUStore.instance.UpdateBeePercsServerRpc(GameNetworkManager.Instance.localPlayerController.playerSteamId, 0);
+        }
+
+        public static int CalculateBeeDamage(int damageNumber)
+        {
+            if (!UpgradeBus.instance.beekeeper) return damageNumber;
+            return Mathf.Clamp((int)(damageNumber * (UpgradeBus.instance.cfg.BEEKEEPER_DAMAGE_MULTIPLIER - (UpgradeBus.instance.beeLevel * UpgradeBus.instance.cfg.BEEKEEPER_DAMAGE_MULTIPLIER_INCREMENT))), 0, damageNumber);
         }
     }
 }


### PR DESCRIPTION
The transpiler now changes the damageNumber according to the state of beekeeper level and unlock before it's received by DamagePlayer in RedLocustBee.

With this, we do not need the RPCs related to storing the beekeeper level of each player