### PR TITLE
Refactoring of BaseUpgrade and derived classes

### DIFF
--- a/MoreShipUpgrades/Managers/UpgradeBus.cs
+++ b/MoreShipUpgrades/Managers/UpgradeBus.cs
@@ -13,6 +13,7 @@ namespace MoreShipUpgrades.Managers
         public static UpgradeBus instance;
         public PluginConfig cfg;
         public GameObject introScreen;
+        private static LGULogger logger;
 
         public bool DestroyTraps = false;
         public bool softSteps = false;
@@ -108,6 +109,7 @@ namespace MoreShipUpgrades.Managers
             instance = this;
             DontDestroyOnLoad(gameObject);
             cfg = Plugin.cfg;
+            logger = new LGULogger(typeof(UpgradeBus).Name);
         }
 
         public Terminal GetTerminal()
@@ -564,7 +566,7 @@ namespace MoreShipUpgrades.Managers
                 }
                 else
                 {
-                    Debug.LogWarning($"[LGU] Invalid upgrade price submitted: {prices[i]}");
+                    logger.LogWarning($"Invalid upgrade price submitted: {prices[i]}");
                     prices[i] = -1;
 
                 }

--- a/MoreShipUpgrades/Misc/AssetBundleHandler.cs
+++ b/MoreShipUpgrades/Misc/AssetBundleHandler.cs
@@ -69,9 +69,9 @@ namespace MoreShipUpgrades.Misc
             GameObject result = bundle.LoadAsset<GameObject>(path);
             if (result == null)
             {
-                logger.LogError(string.Format("An error has occurred trying to load asset from {0}", path));
+                logger.LogError($"An error has occurred trying to load asset from {path}");
             }
-            logger.LogInfo(string.Format("Loaded asset located in {0}", path));
+            logger.LogDebug($"Loaded asset located in {path}");
             return result;
         }
         /// <summary>
@@ -88,9 +88,9 @@ namespace MoreShipUpgrades.Misc
             AudioClip result = bundle.LoadAsset<AudioClip>(path);
             if (result == null)
             {
-                logger.LogError(string.Format("An error has occurred trying to load asset from {0}", path));
+                logger.LogError($"An error has occurred trying to load asset from {path}");
             }
-            logger.LogInfo(string.Format("Loaded asset located in {0}", path));
+            logger.LogDebug($"Loaded asset located in {path}");
             return result;
         }
 
@@ -108,9 +108,9 @@ namespace MoreShipUpgrades.Misc
             Item result = bundle.LoadAsset<Item>(path);
             if (result == null)
             {
-                logger.LogError(string.Format("An error has occurred trying to load asset from {0}", path));
+                logger.LogError($"An error has occurred trying to load asset from {path}");
             }
-            logger.LogInfo(string.Format("Loaded asset located in {0}", path));
+            logger.LogDebug($"Loaded asset located in {path}");
             return result;
         }
 
@@ -151,7 +151,7 @@ namespace MoreShipUpgrades.Misc
         {
             if (!assetPaths.ContainsKey(upgradeName))
             {
-                logger.LogError(string.Format("{0} was not present in the asset dictionary!", upgradeName));
+                logger.LogError($"{upgradeName} was not present in the asset dictionary!");
                 return null;
             }
             return TryLoadGameObjectAsset(ref UpgradeBus.instance.UpgradeAssets, assetPaths[upgradeName]);
@@ -162,7 +162,7 @@ namespace MoreShipUpgrades.Misc
             if (assetPaths.ContainsKey(itemName)) return TryLoadItemAsset(ref UpgradeBus.instance.UpgradeAssets, assetPaths[itemName]);
             if (samplePaths.ContainsKey(itemName)) return TryLoadItemAsset(ref UpgradeBus.instance.UpgradeAssets, samplePaths[itemName]);
 
-            logger.LogError(string.Format("{0} was not present in the asset or sample dictionary!", itemName));
+            logger.LogError($"{itemName} was not present in the asset or sample dictionary!");
             return null;
         }
 
@@ -170,7 +170,7 @@ namespace MoreShipUpgrades.Misc
         {
             if (!assetPaths.ContainsKey(audioName))
             {
-                logger.LogError(string.Format("{0} was not present in the asset dictionary!", audioName));
+                logger.LogError($"{audioName} was not present in the asset dictionary!");
                 return null;
             }
             return TryLoadAudioClipAsset(ref UpgradeBus.instance.UpgradeAssets, assetPaths[audioName]);

--- a/MoreShipUpgrades/Misc/BaseUpgrade.cs
+++ b/MoreShipUpgrades/Misc/BaseUpgrade.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using MoreShipUpgrades.Managers;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Unity.Netcode;
@@ -7,6 +8,15 @@ namespace MoreShipUpgrades.Misc
 {
     public class BaseUpgrade : NetworkBehaviour
     {
+        protected string upgradeName = "Base Upgrade";
+
+        public static string INDIVIDUAL_SECTION = "Individual Purchase";
+        public static bool INDIVIDUAL_DEFAULT = true;
+        public static string INDIVIDUAL_DESCRIPTION = "If true: upgrade will apply only to the client that purchased it.";
+
+        public static string PRICES_SECTION = "Price of each additional upgrade";
+        public static string PRICES_DESCRIPTION = "Value must be seperated by commas EX: '123,321,222'";
+
         public virtual void Increment()
         {
 
@@ -14,17 +24,21 @@ namespace MoreShipUpgrades.Misc
 
         public virtual void load()
         {
-
+            string loadColour = "#FF0000";
+            string loadMessage = $"\n<color={loadColour}>{upgradeName} is active!</color>";
+            HUDManager.Instance.chatText.text += loadMessage;
         }
 
         public virtual void Register()
         {
-
+            if (!UpgradeBus.instance.UpgradeObjects.ContainsKey(upgradeName)) { UpgradeBus.instance.UpgradeObjects.Add(upgradeName, gameObject); }
         }
 
         public virtual void Unwind()
         {
-
+            string unloadColour = "#FF0000";
+            string unloadMessage = $"\n<color={unloadColour}>{upgradeName} has been disabled!</color>";
+            HUDManager.Instance.chatText.text += unloadMessage;
         }
     }
 }

--- a/MoreShipUpgrades/Misc/LGULogger.cs
+++ b/MoreShipUpgrades/Misc/LGULogger.cs
@@ -14,21 +14,25 @@ namespace MoreShipUpgrades.Misc
             this.moduleName = moduleName;
             logSource = Plugin.mls;
         }
+        public void LogDebug(string message)
+        {
+            logSource.LogDebug($"[{moduleName}] {message}");
+        }
         public void LogMessage(string message)
         {
-            logSource.LogMessage(string.Format("[{0}] " + message, moduleName));
+            logSource.LogMessage($"[{moduleName}] {message}");
         }
         public void LogInfo(string message)
         {
-            logSource.LogInfo(string.Format("[{0}] " + message, moduleName));
+            logSource.LogInfo($"[{moduleName}]  {message}");
         }
         public void LogWarning(string message) 
         { 
-            logSource.LogWarning(string.Format("[{0}] " + message, moduleName));
+            logSource.LogWarning($"[{moduleName}]  {message}");
         }
         public void LogError(string message)
         {
-            logSource.LogError(string.Format("[{0}] " + message, moduleName));
+            logSource.LogError($"[{moduleName}]  {message}");
         }
     }
 }

--- a/MoreShipUpgrades/Misc/PluginConfig.cs
+++ b/MoreShipUpgrades/Misc/PluginConfig.cs
@@ -185,12 +185,12 @@ namespace MoreShipUpgrades.Misc
 
             KEEP_ITEMS_ON_TELE = ConfigEntry(topSection,"Keep Items When Using Portable Teleporters", true, "If set to false you will drop your items like when using the vanilla TP.");
 
-            topSection = "Beekeeper";
+            topSection = beekeeperScript.UPGRADE_NAME;
             BEEKEEPER_ENABLED = ConfigEntry(topSection, "Enable Beekeeper Upgrade", true, "Take less damage from bees");
             BEEKEEPER_PRICE = ConfigEntry(topSection, "Price of Beekeeper Upgrade", 450, "");
             BEEKEEPER_DAMAGE_MULTIPLIER = ConfigEntry(topSection, "Multiplied to incoming damage (rounded to int)", 0.64f, "Incoming damage from bees is 10.");
-            BEEKEEPER_UPGRADE_PRICES = ConfigEntry(topSection, "Price of each additional upgrade", "225,280,340", "");
-            BEEKEEPER_INDIVIDUAL = ConfigEntry(topSection, "Individual Purchase", true, "If true: upgrade will apply only to the client that purchased it.");
+            BEEKEEPER_UPGRADE_PRICES = ConfigEntry(topSection, BaseUpgrade.PRICES_SECTION, beekeeperScript.PRICES_DEFAULT, BaseUpgrade.PRICES_DESCRIPTION);
+            BEEKEEPER_INDIVIDUAL = ConfigEntry(topSection, BaseUpgrade.INDIVIDUAL_SECTION, BaseUpgrade.INDIVIDUAL_DEFAULT, BaseUpgrade.INDIVIDUAL_DESCRIPTION);
 
             BEEKEEPER_DAMAGE_MULTIPLIER_INCREMENT = ConfigEntry(topSection, "Additional % Reduced per level", 0.15f, "Every time beekeeper is upgraded this value will be subtracted to the base multiplier above.");
 
@@ -199,49 +199,49 @@ namespace MoreShipUpgrades.Misc
             PROTEIN_PRICE = ConfigEntry(topSection, proteinPowderScript.PRICE_SECTION, proteinPowderScript.PRICE_DEFAULT, "");
             PROTEIN_UNLOCK_FORCE = ConfigEntry(topSection, proteinPowderScript.UNLOCK_FORCE_SECTION, proteinPowderScript.UNLOCK_FORCE_DEFAULT, proteinPowderScript.UNLOCK_FORCE_DESCRIPTION);
             PROTEIN_INCREMENT = ConfigEntry(topSection, proteinPowderScript.INCREMENT_FORCE_SECTION, proteinPowderScript.INCREMENT_FORCE_DEFAULT, proteinPowderScript.INCREMENT_FORCE_DESCRIPTION);
-            PROTEIN_INDIVIDUAL = ConfigEntry(topSection, proteinPowderScript.INDIVIDUAL_SECTION, proteinPowderScript.INDIVIDUAL_DEFAULT, proteinPowderScript.INDIVIDUAL_DESCRIPTION);
-            PROTEIN_UPGRADE_PRICES = ConfigEntry(topSection, proteinPowderScript.PRICES_SECTION, proteinPowderScript.PRICES_DEFAULT, proteinPowderScript.PRICES_DESCRIPTION);
+            PROTEIN_INDIVIDUAL = ConfigEntry(topSection, BaseUpgrade.INDIVIDUAL_SECTION, BaseUpgrade.INDIVIDUAL_DEFAULT, BaseUpgrade.INDIVIDUAL_DESCRIPTION);
+            PROTEIN_UPGRADE_PRICES = ConfigEntry(topSection, BaseUpgrade.PRICES_SECTION, proteinPowderScript.PRICES_DEFAULT, BaseUpgrade.PRICES_DESCRIPTION);
             PROTEIN_CRIT_CHANCE = ConfigEntry(topSection, proteinPowderScript.CRIT_CHANCE_SECTION, proteinPowderScript.CRIT_CHANCE_DEFAULT, proteinPowderScript.CRIT_CHANCE_DESCRIPTION);
 
-            topSection = "Bigger Lungs";
+            topSection = biggerLungScript.UPGRADE_NAME;
             BIGGER_LUNGS_ENABLED = ConfigEntry(topSection, "Enable Bigger Lungs Upgrade", true, "More Stamina");
             BIGGER_LUNGS_PRICE = ConfigEntry(topSection, "Price of Bigger Lungs Upgrade", 600, "");
             SPRINT_TIME_INCREASE = ConfigEntry(topSection, "SprintTime value", 17f, "Vanilla value is 11");
             SPRINT_TIME_INCREMENT = ConfigEntry(topSection, "SprintTime Increment", 1.25f,"How much the above value is increased on upgrade.");
-            BIGGER_LUNGS_UPGRADE_PRICES = ConfigEntry(topSection, "Price of each additional upgrade", "350,450,550", "");
-            BIGGER_LUNGS_INDIVIDUAL = ConfigEntry(topSection, "Individual Purchase", true, "If true: upgrade will apply only to the client that purchased it.");
+            BIGGER_LUNGS_UPGRADE_PRICES = ConfigEntry(topSection, BaseUpgrade.PRICES_SECTION, biggerLungScript.PRICES_DEFAULT, BaseUpgrade.PRICES_DESCRIPTION);
+            BIGGER_LUNGS_INDIVIDUAL = ConfigEntry(topSection, BaseUpgrade.INDIVIDUAL_SECTION, BaseUpgrade.INDIVIDUAL_DEFAULT, BaseUpgrade.INDIVIDUAL_DESCRIPTION);
 
-            topSection = "Running Shoes";
+            topSection = runningShoeScript.UPGRADE_NAME;
             RUNNING_SHOES_ENABLED = ConfigEntry(topSection, "Enable Running Shoes Upgrade", true, "Run Faster");
             RUNNING_SHOES_PRICE = ConfigEntry(topSection, "Price of Running Shoes Upgrade", 650, "");
             MOVEMENT_SPEED = ConfigEntry(topSection, "Movement Speed Value", 6f, "Vanilla value is 4.6");
             MOVEMENT_INCREMENT = ConfigEntry(topSection, "Movement Speed Increment", 0.5f, "How much the above value is increased on upgrade.");
-            RUNNING_SHOES_UPGRADE_PRICES = ConfigEntry(topSection, "Price of each additional upgrade", "500,750,1000", "");
-            RUNNING_SHOES_INDIVIDUAL = ConfigEntry(topSection, "Individual Purchase", true, "If true: upgrade will apply only to the client that purchased it.");
+            RUNNING_SHOES_UPGRADE_PRICES = ConfigEntry(topSection, BaseUpgrade.PRICES_SECTION, biggerLungScript.PRICES_DEFAULT, BaseUpgrade.PRICES_DESCRIPTION);
+            RUNNING_SHOES_INDIVIDUAL = ConfigEntry(topSection, BaseUpgrade.INDIVIDUAL_SECTION, BaseUpgrade.INDIVIDUAL_DEFAULT, BaseUpgrade.INDIVIDUAL_DESCRIPTION);
 
-            topSection = "Strong Legs";
+            topSection = strongLegsScript.UPGRADE_NAME;
             STRONG_LEGS_ENABLED = ConfigEntry(topSection, "Enable Strong Legs Upgrade", true, "Jump Higher");
             STRONG_LEGS_PRICE = ConfigEntry(topSection, "Price of Strong Legs Upgrade", 300, "");
             JUMP_FORCE = ConfigEntry(topSection, "Jump Force", 16f, "Vanilla value is 13");
             JUMP_FORCE_INCREMENT = ConfigEntry(topSection, "Jump Force Increment", 0.75f, "How much the above value is increased on upgrade.");
-            STRONG_LEGS_UPGRADE_PRICES = ConfigEntry(topSection, "Price of each additional upgrade", "150,190,250", "");
-            STRONG_LEGS_INDIVIDUAL = ConfigEntry(topSection, "Individual Purchase", true, "If true: upgrade will apply only to the client that purchased it.");
+            STRONG_LEGS_UPGRADE_PRICES = ConfigEntry(topSection, BaseUpgrade.PRICES_SECTION, strongLegsScript.PRICES_DEFAULT, BaseUpgrade.PRICES_DESCRIPTION);
+            STRONG_LEGS_INDIVIDUAL = ConfigEntry(topSection, BaseUpgrade.INDIVIDUAL_SECTION, BaseUpgrade.INDIVIDUAL_DEFAULT, BaseUpgrade.INDIVIDUAL_DESCRIPTION);
 
-            topSection = "Malware Broadcaster";
+            topSection = trapDestroyerScript.UPGRADE_NAME;
             MALWARE_BROADCASTER_ENABLED = ConfigEntry(topSection, "Enable Malware Broadcaster Upgrade", true, "Explode Map Hazards");
             MALWARE_BROADCASTER_PRICE = ConfigEntry(topSection, "Price of Malware Broadcaster Upgrade", 550, "");
             DESTROY_TRAP = ConfigEntry(topSection, "Destroy Trap", true, "If false Malware Broadcaster will disable the trap for a long time instead of destroying.");
             DISARM_TIME = ConfigEntry(topSection, "Disarm Time", 7f, "If `Destroy Trap` is false this is the duration traps will be disabled.");
             EXPLODE_TRAP = ConfigEntry(topSection, "Explode Trap", true, "Destroy Trap must be true! If this is true when destroying a trap it will also explode.");
-            MALWARE_BROADCASTER_INDIVIDUAL = ConfigEntry(topSection, "Individual Purchase", true, "If true: upgrade will apply only to the client that purchased it.");
+            MALWARE_BROADCASTER_INDIVIDUAL = ConfigEntry(topSection, BaseUpgrade.INDIVIDUAL_SECTION, BaseUpgrade.INDIVIDUAL_DEFAULT, BaseUpgrade.INDIVIDUAL_DESCRIPTION);
 
-            topSection = "Light Footed";
+            topSection = lightFootedScript.UPGRADE_NAME;
             LIGHT_FOOTED_ENABLED = ConfigEntry(topSection, "Enable Light Footed Upgrade", true, "Make less noise moving.");
             LIGHT_FOOTED_PRICE = ConfigEntry(topSection, "Price of Light Footed Upgrade", 350, "");
             NOISE_REDUCTION = ConfigEntry(topSection, "Noise Reduction", 7f, "Distance units to subtract from footstep noise.");
             NOISE_REDUCTION_INCREMENT = ConfigEntry(topSection, "Noise Reduction Increment", 1f, "The amount added to above value on upgrade.");
-            LIGHT_FOOTED_UPGRADE_PRICES = ConfigEntry(topSection,"Price of each additional upgrade", "175,235,290", "");
-            LIGHT_FOOTED_INDIVIDUAL = ConfigEntry(topSection, "Individual Purchase", true, "If true: upgrade will apply only to the client that purchased it.");
+            LIGHT_FOOTED_UPGRADE_PRICES = ConfigEntry(topSection,BaseUpgrade.PRICES_SECTION, lightFootedScript.PRICES_DEFAULT, BaseUpgrade.PRICES_DESCRIPTION);
+            LIGHT_FOOTED_INDIVIDUAL = ConfigEntry(topSection, BaseUpgrade.INDIVIDUAL_SECTION, BaseUpgrade.INDIVIDUAL_DEFAULT, BaseUpgrade.INDIVIDUAL_DESCRIPTION);
 
             topSection = "Night Vision";
             NIGHT_VISION_ENABLED = ConfigEntry(topSection, "Enable Night Vision Upgrade", true, "Toggleable night vision.");
@@ -261,10 +261,10 @@ namespace MoreShipUpgrades.Misc
             NIGHT_VIS_REGEN_INCREMENT = ConfigEntry(topSection, "Increase for night vis battery regen", 0.40f, "Applied to regen speed on each upgrade.");
             NIGHT_VIS_BATTERY_INCREMENT = ConfigEntry(topSection, "Increase for night vis battery life", 2f, "Applied to the max charge for night vis battery on each upgrade.");
             LOSE_NIGHT_VIS_ON_DEATH = ConfigEntry(topSection, "Lose Night Vision On Death", true, "If true when you die you will have to re purchase and equip night vision goggles.");
-            NIGHT_VISION_UPGRADE_PRICES = ConfigEntry(topSection,"Price of each additional upgrade", "300,400,500", "");
-            NIGHT_VISION_INDIVIDUAL = ConfigEntry(topSection,"Individual Purchase", true, "If true: upgrade will apply only to the client that purchased it.");
+            NIGHT_VISION_UPGRADE_PRICES = ConfigEntry(topSection,BaseUpgrade.PRICES_SECTION, nightVisionScript.PRICES_DEFAULT, BaseUpgrade.PRICES_DESCRIPTION);
+            NIGHT_VISION_INDIVIDUAL = ConfigEntry(topSection,BaseUpgrade.INDIVIDUAL_SECTION, BaseUpgrade.INDIVIDUAL_DEFAULT, BaseUpgrade.INDIVIDUAL_DESCRIPTION);
 
-            topSection = "Discombobulator";
+            topSection = terminalFlashScript.UPGRADE_NAME;
             DISCOMBOBULATOR_ENABLED = ConfigEntry(topSection, "Enable Discombobulator Upgrade", true, "Stun enemies around the ship.");
             DISCOMBOBULATOR_PRICE = ConfigEntry(topSection, "Price of Discombobulator Upgrade", 450, "");
             DISCOMBOBULATOR_COOLDOWN = ConfigEntry(topSection, "Discombobulator Cooldown", 120f, "");
@@ -272,41 +272,41 @@ namespace MoreShipUpgrades.Misc
             DISCOMBOBULATOR_STUN_DURATION  = ConfigEntry(topSection, "Discombobulator Stun Duration", 7.5f, "");
             DISCOMBOBULATOR_NOTIFY_CHAT = ConfigEntry(topSection, "Notify Local Chat of Enemy Stun Duration", true, "");
             DISCOMBOBULATOR_INCREMENT  = ConfigEntry(topSection, "Discombobulator Increment", 1f, "The amount added to stun duration on upgrade.");
-            DISCO_UPGRADE_PRICES = ConfigEntry(topSection, "Price of each additional upgrade", "330,460,620", "");
-            DISCOMBOBULATOR_INDIVIDUAL = ConfigEntry(topSection, "Individual Purchase", true, "If true: upgrade will apply only to the client that purchased it.");
+            DISCO_UPGRADE_PRICES = ConfigEntry(topSection, BaseUpgrade.PRICES_SECTION, terminalFlashScript.PRICES_DEFAULT, BaseUpgrade.PRICES_DESCRIPTION);
+            DISCOMBOBULATOR_INDIVIDUAL = ConfigEntry(topSection, BaseUpgrade.INDIVIDUAL_SECTION, BaseUpgrade.INDIVIDUAL_DEFAULT, BaseUpgrade.INDIVIDUAL_DESCRIPTION);
 
-            topSection = "Better Scanner";
+            topSection = strongerScannerScript.UPGRADE_NAME;
             BETTER_SCANNER_ENABLED = ConfigEntry(topSection, "Enable Better Scanner Upgrade", true, "Further scan distance, no LOS needed.");
             BETTER_SCANNER_PRICE = ConfigEntry(topSection, "Price of Better Scanner Upgrade", 650, "");
             SHIP_AND_ENTRANCE_DISTANCE_INCREASE = ConfigEntry(topSection, "Ship and Entrance node distance boost", 150f, "How much further away you can scan the ship and entrance.");
             NODE_DISTANCE_INCREASE = ConfigEntry(topSection, "Node distance boost", 20f, "How much further away you can scan other nodes.");
-            BETTER_SCANNER_INDIVIDUAL = ConfigEntry(topSection, "Individual Purchase", true, "If true: upgrade will apply only to the client that purchased it.");
+            BETTER_SCANNER_INDIVIDUAL = ConfigEntry(topSection, BaseUpgrade.INDIVIDUAL_SECTION, BaseUpgrade.INDIVIDUAL_DEFAULT, BaseUpgrade.INDIVIDUAL_DESCRIPTION);
             BETTER_SCANNER_PRICE2 = ConfigEntry(topSection, "Price of first Better Scanner tier", 500, "This tier unlocks ship scan commands.");
             BETTER_SCANNER_PRICE3 = ConfigEntry(topSection, "Price of second Better Scanner tier", 800, "This tier unlocks scanning through walls.");
             BETTER_SCANNER_ENEMIES = ConfigEntry(topSection, "Scan enemies through walls on final upgrade", false, "If true the final upgrade will scan scrap AND enemies through walls.");
             VERBOSE_ENEMIES = ConfigEntry(topSection, "Verbose `scan enemies` command", true, "If false `scan enemies` only returns a count of outside and inside enemies, else it returns the count for each enemy type.");
 
-            topSection = "Back Muscles";
+            topSection = exoskeletonScript.UPGRADE_NAME;
             BACK_MUSCLES_ENABLED = ConfigEntry(topSection, "Enable Back Muscles Upgrade", true, "Reduce carry weight");
             BACK_MUSCLES_PRICE = ConfigEntry(topSection, "Price of Back Muscles Upgrade", 715, "");
             CARRY_WEIGHT_REDUCTION = ConfigEntry(topSection, "Carry Weight Multiplier", 0.5f, "Your carry weight is multiplied by this.");
             CARRY_WEIGHT_INCREMENT = ConfigEntry(topSection, "Carry Weight Increment", 0.1f, "Each upgrade subtracts this from the above coefficient.");
-            BACK_MUSCLES_UPGRADE_PRICES = ConfigEntry(topSection, "Price of each additional upgrade", "600,700,800", "");
-            BACK_MUSCLES_INDIVIDUAL = ConfigEntry(topSection,"Individual Purchase", true, "If true: upgrade will apply only to the client that purchased it.");
+            BACK_MUSCLES_UPGRADE_PRICES = ConfigEntry(topSection, BaseUpgrade.PRICES_SECTION, exoskeletonScript.PRICES_DEFAULT, BaseUpgrade.PRICES_DESCRIPTION);
+            BACK_MUSCLES_INDIVIDUAL = ConfigEntry(topSection,BaseUpgrade.INDIVIDUAL_SECTION, BaseUpgrade.INDIVIDUAL_DEFAULT, BaseUpgrade.INDIVIDUAL_DESCRIPTION);
 
             topSection = "Interns";
             INTERN_ENABLED = ConfigEntry(topSection, "Enable hiring of interns", true, "Pay x amount of credits to revive a player.");
             INTERN_PRICE = ConfigEntry(topSection, "Intern Price", 1000, "Default price to hire an intern.");
-            INTERN_INDIVIDUAL = ConfigEntry(topSection, "Individual Purchase", true, "If true: upgrade will apply only to the client that purchased it.");
+            INTERN_INDIVIDUAL = ConfigEntry(topSection, BaseUpgrade.INDIVIDUAL_SECTION, BaseUpgrade.INDIVIDUAL_DEFAULT, BaseUpgrade.INDIVIDUAL_DESCRIPTION);
 
-            topSection = "Fast Encryption";
+            topSection = pagerScript.UPGRADE_NAME;
             PAGER_ENABLED = ConfigEntry(topSection, "Enable Fast Encryption", true, "Upgrades the transmitter.");
             PAGER_PRICE = ConfigEntry(topSection, "Fast Encryption Price", 300, "");
 
-            topSection = "Locksmith";
+            topSection = lockSmithScript.UPGRADE_NAME;
             LOCKSMITH_ENABLED = ConfigEntry(topSection, "Enable Locksmith upgrade", true, "Allows you to pick locked doors by completing a minigame.");
             LOCKSMITH_PRICE = ConfigEntry(topSection, "Locksmith Price", 640, "Default price of Locksmith upgrade.");
-            LOCKSMITH_INDIVIDUAL = ConfigEntry(topSection, "Individual Purchase", true, "If true: upgrade will apply only to the client that purchased it.");
+            LOCKSMITH_INDIVIDUAL = ConfigEntry(topSection, BaseUpgrade.INDIVIDUAL_SECTION, BaseUpgrade.INDIVIDUAL_DEFAULT, BaseUpgrade.INDIVIDUAL_DESCRIPTION);
 
             topSection = "Peeper";
             PEEPER_ENABLED = ConfigEntry(topSection, "Enable Peeper item", true, "An item that will stare at coilheads for you.");
@@ -321,9 +321,9 @@ namespace MoreShipUpgrades.Misc
             topSection = "Walkie";
             WALKIE_ENABLED = ConfigEntry(topSection, "Enable the walkie talkie gps upgrade", true, "Holding a walkie talkie displays location.");
             WALKIE_PRICE = ConfigEntry(topSection, "Walkie GPS Price", 450, "Default price for upgrade.");
-            WALKIE_INDIVIDUAL = ConfigEntry(topSection, "Individual Purchase", true, "If true: upgrade will apply only to the client that purchased it.");
+            WALKIE_INDIVIDUAL = ConfigEntry(topSection, BaseUpgrade.INDIVIDUAL_SECTION, BaseUpgrade.INDIVIDUAL_DEFAULT, BaseUpgrade.INDIVIDUAL_DESCRIPTION);
 
-            topSection = "Hunter";
+            topSection = hunterScript.UPGRADE_NAME;
             HUNTER_ENABLED = ConfigEntry(topSection, "Enable the Hunter upgrade", true, "Collect and sell samples from dead enemies");
             HUNTER_PRICE = ConfigEntry(topSection, "Hunter price", 700, "Default price for upgrade.");
             HUNTER_PRICE2 = ConfigEntry(topSection, "Second Hunter level price", 500, "");
@@ -332,8 +332,8 @@ namespace MoreShipUpgrades.Misc
             topSection = playerHealthScript.UPGRADE_NAME;
             PLAYER_HEALTH_ENABLED = ConfigEntry(topSection, playerHealthScript.ENABLED_SECTION, playerHealthScript.ENABLED_DEFAULT, playerHealthScript.ENABLED_DESCRIPTION);
             PLAYER_HEALTH_PRICE = ConfigEntry(topSection, playerHealthScript.PRICE_SECTION, playerHealthScript.PRICE_DEFAULT, "");
-            PLAYER_HEALTH_INDIVIDUAL = ConfigEntry(topSection, playerHealthScript.INDIVIDUAL_SECTION, playerHealthScript.INDIVIDUAL_DEFAULT, playerHealthScript.INDIVIDUAL_DESCRIPTION);
-            PLAYER_HEALTH_UPGRADE_PRICES = ConfigEntry(topSection, playerHealthScript.UPGRADE_PRICES_SECTION, playerHealthScript.UPGRADE_PRICES_DEFAULT, "");
+            PLAYER_HEALTH_INDIVIDUAL = ConfigEntry(topSection, BaseUpgrade.INDIVIDUAL_SECTION, BaseUpgrade.INDIVIDUAL_DEFAULT, BaseUpgrade.INDIVIDUAL_DESCRIPTION);
+            PLAYER_HEALTH_UPGRADE_PRICES = ConfigEntry(topSection, BaseUpgrade.PRICES_SECTION, playerHealthScript.PRICES_DEFAULT, BaseUpgrade.PRICES_DESCRIPTION);
             PLAYER_HEALTH_ADDITIONAL_HEALTH_UNLOCK = ConfigEntry(topSection, playerHealthScript.ADDITIONAL_HEALTH_UNLOCK_SECTION, playerHealthScript.ADDITIONAL_HEALTH_UNLOCK_DEFAULT, playerHealthScript.ADDITIONAL_HEALTH_UNLOCK_DESCRIPTION);
             PLAYER_HEALTH_ADDITIONAL_HEALTH_INCREMENT = ConfigEntry(topSection, playerHealthScript.ADDITIONAL_HEALTH_INCREMENT_SECTION, playerHealthScript.ADDITIONAL_HEALTH_INCREMENT_DEFAULT, playerHealthScript.ADDITIONAL_HEALTH_INCREMENT_DESCRIPTION);
 

--- a/MoreShipUpgrades/Patches/RedLocustBeesPatch.cs
+++ b/MoreShipUpgrades/Patches/RedLocustBeesPatch.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using MoreShipUpgrades.Misc;
 using MoreShipUpgrades.UpgradeComponents;
 using System;
 using System.Collections.Generic;
@@ -12,6 +13,7 @@ namespace MoreShipUpgrades.Patches
     [HarmonyPatch(typeof(RedLocustBees))]
     internal class RedLocustBeesPatch
     {
+        private static LGULogger logger = new LGULogger(typeof(RedLocustBeesPatch).Name);
         [HarmonyTranspiler]
         [HarmonyPatch("OnCollideWithPlayer")]
         public static IEnumerable<CodeInstruction> OnCollideWithPlayer_Transpiler(IEnumerable<CodeInstruction> instructions)
@@ -39,7 +41,7 @@ namespace MoreShipUpgrades.Patches
                 codes.Insert(i - 8, new CodeInstruction(OpCodes.Call, beeReduceDamage));
                 found = true;
             }
-            if (!found) { Plugin.mls.LogInfo("Did not find DamagePlayer function"); }
+            if (!found) { logger.LogDebug("Did not find DamagePlayer function"); }
             return codes.AsEnumerable();
         }
     }

--- a/MoreShipUpgrades/Plugin.cs
+++ b/MoreShipUpgrades/Plugin.cs
@@ -75,7 +75,7 @@ namespace MoreShipUpgrades
 
             harmony.PatchAll();
 
-            mls.LogInfo("LGU has been patched");
+            mls.LogDebug("LGU has been patched");
         }
 
         // I don't even know if modsync is still used but here we are.
@@ -97,7 +97,7 @@ namespace MoreShipUpgrades
                     catch (Exception e)
                     {
                         // ignore mod if error, removing dependency
-                        mls.LogInfo($"Failed to send info to ModSync, go yell at Minx");
+                        mls.LogDebug($"Failed to send info to ModSync, go yell at Minx");
                     }
                     break;
                 }

--- a/MoreShipUpgrades/UpgradeComponents/beekeeperScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/beekeeperScript.cs
@@ -6,8 +6,11 @@ namespace MoreShipUpgrades.UpgradeComponents
 {
     internal class beekeeperScript : BaseUpgrade
     {
+        public static string UPGRADE_NAME = "Beekeeper";
+        public static string PRICES_DEFAULT = "225,280,340";
         void Start()
         {
+            upgradeName = UPGRADE_NAME;
             DontDestroyOnLoad(gameObject);
             Register();
         }
@@ -19,20 +22,21 @@ namespace MoreShipUpgrades.UpgradeComponents
 
         public override void load()
         {
+            base.load();
             UpgradeBus.instance.beekeeper = true;
-            HUDManager.Instance.chatText.text += "\n<color=#FF0000>Beekeeper is active!</color>";
         }
 
         public override void Register()
         {
-            if(!UpgradeBus.instance.UpgradeObjects.ContainsKey("Beekeeper")) { UpgradeBus.instance.UpgradeObjects.Add("Beekeeper", gameObject); }
+            base.Register();
         }
 
         public override void Unwind()
         {
+            base.Unwind();
+
             UpgradeBus.instance.beeLevel = 0;
             UpgradeBus.instance.beekeeper = false;
-            HUDManager.Instance.chatText.text += "\n<color=#FF0000>Beekeeper has been disabled</color>";
         }
 
         public static int CalculateBeeDamage(int damageNumber)

--- a/MoreShipUpgrades/UpgradeComponents/biggerLungScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/biggerLungScript.cs
@@ -7,9 +7,13 @@ namespace MoreShipUpgrades.UpgradeComponents
 {
     internal class biggerLungScript : BaseUpgrade
     {
+        public static string UPGRADE_NAME = "Bigger Lungs";
+        public static string PRICES_DEFAULT = "350,450,550";
+        private static float DEFAULT_SPRINT_TIME = 11f;
 
         void Start()
         {
+            upgradeName = UPGRADE_NAME;
             DontDestroyOnLoad(gameObject);
             Register();
         }
@@ -22,9 +26,10 @@ namespace MoreShipUpgrades.UpgradeComponents
 
         public override void load()
         {
-            GameNetworkManager.Instance.localPlayerController.sprintTime = UpgradeBus.instance.cfg.SPRINT_TIME_INCREASE; //17
+            base.load();
             UpgradeBus.instance.biggerLungs = true;
-            HUDManager.Instance.chatText.text += "\n<color=#FF0000>Bigger Lungs is active!</color>";
+
+            GameNetworkManager.Instance.localPlayerController.sprintTime = UpgradeBus.instance.cfg.SPRINT_TIME_INCREASE; //17
 
             float amountToIncrement = 0;
             for(int i = 0; i < UpgradeBus.instance.lungLevel; i++)
@@ -37,14 +42,15 @@ namespace MoreShipUpgrades.UpgradeComponents
 
         public override void Unwind()
         {
+            base.Unwind();
+
             UpgradeBus.instance.biggerLungs = false;
-            GameNetworkManager.Instance.localPlayerController.sprintTime = 11f;
-            HUDManager.Instance.chatText.text += "\n<color=#FF0000>Bigger Lungs has been disabled.</color>";
+            GameNetworkManager.Instance.localPlayerController.sprintTime = DEFAULT_SPRINT_TIME;
         }
 
         public override void Register()
         {
-            if(!UpgradeBus.instance.UpgradeObjects.ContainsKey("Bigger Lungs")) { UpgradeBus.instance.UpgradeObjects.Add("Bigger Lungs", gameObject); }
+            base.Register();
         }
     }
 }

--- a/MoreShipUpgrades/UpgradeComponents/exoskeletonScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/exoskeletonScript.cs
@@ -7,9 +7,11 @@ namespace MoreShipUpgrades.UpgradeComponents
 {
     internal class exoskeletonScript : BaseUpgrade
     {
-        
+        public static string UPGRADE_NAME = "Back Muscles";
+        public static string PRICES_DEFAULT = "600,700,800";
         void Start()
         {
+            upgradeName = UPGRADE_NAME;
             DontDestroyOnLoad(gameObject);
             Register();
         }
@@ -22,20 +24,20 @@ namespace MoreShipUpgrades.UpgradeComponents
 
         public override void load()
         {
+            base.load();
             UpgradeBus.instance.exoskeleton = true;
-            HUDManager.Instance.chatText.text += "\n<color=#FF0000>Back Muscles is active!</color>";
             UpdatePlayerWeight();
         }
         public override void Unwind()
         {
+            base.Unwind();
             UpgradeBus.instance.exoskeleton = false;
             UpgradeBus.instance.backLevel = 0;
-            HUDManager.Instance.chatText.text += "\n<color=#FF0000>Back Muscles has been disabled.</color>";
             UpdatePlayerWeight();
         }
         public override void Register()
         {
-            if(!UpgradeBus.instance.UpgradeObjects.ContainsKey("Back Muscles")) { UpgradeBus.instance.UpgradeObjects.Add("Back Muscles", gameObject); }
+            base.Register();
         }
 
         public static float CalculateWeight(float desiredValue, float minimumValue, float maximumValue)
@@ -47,20 +49,18 @@ namespace MoreShipUpgrades.UpgradeComponents
         public static void UpdatePlayerWeight()
         {
             PlayerControllerB player = GameNetworkManager.Instance.localPlayerController;
-            if (UpgradeBus.instance.exoskeleton && player.ItemSlots.Length > 0)
+            if (!(UpgradeBus.instance.exoskeleton && player.ItemSlots.Length > 0)) return;
+
+            UpgradeBus.instance.alteredWeight = 1f;
+            for (int i = 0; i < player.ItemSlots.Length; i++)
             {
-                UpgradeBus.instance.alteredWeight = 1f;
-                for (int i = 0; i < player.ItemSlots.Length; i++)
-                {
-                    GrabbableObject obj = player.ItemSlots[i];
-                    if (obj != null)
-                    {
-                        UpgradeBus.instance.alteredWeight += CalculateWeight(obj.itemProperties.weight - 1f, 0f, 10f);
-                    }
-                }
-                player.carryWeight = UpgradeBus.instance.alteredWeight;
-                if (player.carryWeight < 1f) { player.carryWeight = 1f; }
+                GrabbableObject obj = player.ItemSlots[i];
+                if (obj == null) continue;
+
+                UpgradeBus.instance.alteredWeight += CalculateWeight(obj.itemProperties.weight - 1f, 0f, 10f);
             }
+            player.carryWeight = UpgradeBus.instance.alteredWeight;
+            if (player.carryWeight < 1f) { player.carryWeight = 1f; }
         }
     }   
 

--- a/MoreShipUpgrades/UpgradeComponents/hunterScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/hunterScript.cs
@@ -7,6 +7,8 @@ namespace MoreShipUpgrades.UpgradeComponents
 {
     internal class hunterScript : BaseUpgrade
     {
+        public static string UPGRADE_NAME = "Hunter";
+
         static string[] lvl1 = new string[] { "Hoarding bug", "Centipede" };
         static string[] lvl2 = new string[] { "Bunker Spider", "Hoarding bug", "Centipede", "Baboon Hawk" };
         static string[] lvl3 = new string[] { "Bunker Spider", "Hoarding bug", "Centipede", "Baboon Hawk", "Flowerman", "Crawler", "MouthDog" };
@@ -28,6 +30,7 @@ namespace MoreShipUpgrades.UpgradeComponents
         };
         void Start()
         {
+            upgradeName = UPGRADE_NAME;
             DontDestroyOnLoad(gameObject);
             Register();
         }
@@ -39,18 +42,20 @@ namespace MoreShipUpgrades.UpgradeComponents
 
         public override void load()
         {
+            base.load();
+
             UpgradeBus.instance.hunter = true;
-            HUDManager.Instance.chatText.text += "\n<color=#FF0000>Hunter is active!</color>";
         }
         public override void Unwind()
         {
+            base.Unwind();
+
             UpgradeBus.instance.hunter = false;
             UpgradeBus.instance.huntLevel = 0;
-            HUDManager.Instance.chatText.text += "\n<color=#FF0000>Hunter has been disabled.</color>";
         }
         public override void Register()
         {
-            if(!UpgradeBus.instance.UpgradeObjects.ContainsKey("Hunter")) { UpgradeBus.instance.UpgradeObjects.Add("Hunter", gameObject); }
+            base.Register();
         }
 
         public static string GetHunterInfo(int level, int price)

--- a/MoreShipUpgrades/UpgradeComponents/lightFootedScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/lightFootedScript.cs
@@ -5,8 +5,11 @@ namespace MoreShipUpgrades.UpgradeComponents
 {
     internal class lightFootedScript : BaseUpgrade
     {
+        public static string UPGRADE_NAME = "Light Footed";
+        public static string PRICES_DEFAULT = "175,235,290";
         void Start()
         {
+            upgradeName = UPGRADE_NAME;
             DontDestroyOnLoad(gameObject);
             Register();
         }
@@ -18,18 +21,19 @@ namespace MoreShipUpgrades.UpgradeComponents
 
         public override void load()
         {
+            base.load();
+
             UpgradeBus.instance.softSteps = true;
-            HUDManager.Instance.chatText.text += "\n<color=#FF0000>Light Footed is active!</color>";
         }
         public override void Unwind()
         {
+            base.Unwind();
             UpgradeBus.instance.softSteps = false;
             UpgradeBus.instance.lightLevel = 0;
-            HUDManager.Instance.chatText.text += "\n<color=#FF0000>Light Footed has been disabled.</color>";
         }
         public override void Register()
         {
-            if(!UpgradeBus.instance.UpgradeObjects.ContainsKey("Light Footed")) { UpgradeBus.instance.UpgradeObjects.Add("Light Footed", gameObject); }
+            base.Register();
         }
     }
 }

--- a/MoreShipUpgrades/UpgradeComponents/lightningRodScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/lightningRodScript.cs
@@ -8,35 +8,36 @@ namespace MoreShipUpgrades.UpgradeComponents
     {
         public static string UPGRADE_NAME = "Lightning Rod";
         public static lightningRodScript instance;
+        private static LGULogger logger;
 
         // Configuration
-        public static string ENABLED_SECTION = string.Format("Enable {0} Upgrade", UPGRADE_NAME);
+        public static string ENABLED_SECTION = $"Enable {UPGRADE_NAME} Upgrade";
         public static bool ENABLED_DEFAULT = true;
         public static string ENABLED_DESCRIPTION = "A device which redirects lightning bolts to the ship.";
 
-        public static string PRICE_SECTION = string.Format("{0} Price", UPGRADE_NAME);
+        public static string PRICE_SECTION = $"{UPGRADE_NAME} Price";
         public static int PRICE_DEFAULT = 1000;
 
         public static string ACTIVE_SECTION = "Active on Purchase";
         public static bool ACTIVE_DEFAULT = true;
-        public static string ACTIVE_DESCRIPTION = string.Format("If true: {0} will be active on purchase.", UPGRADE_NAME);
+        public static string ACTIVE_DESCRIPTION = $"If true: {UPGRADE_NAME} will be active on purchase.";
 
         // Chat Messages
         private static string LOAD_COLOUR = "#FF0000";
-        private static string LOAD_MESSAGE = string.Format("\n<color={0}>{1} is active!</color>", LOAD_COLOUR, UPGRADE_NAME);
+        private static string LOAD_MESSAGE = $"\n<color={LOAD_COLOUR}>{UPGRADE_NAME} is active!</color>";
 
         private static string UNLOAD_COLOUR = LOAD_COLOUR;
-        private static string UNLOAD_MESSAGE = string.Format("\n<color={0}>{1} has been disabled</color>", UNLOAD_COLOUR, UPGRADE_NAME);
+        private static string UNLOAD_MESSAGE = $"\n<color={UNLOAD_COLOUR}>{UPGRADE_NAME} has been disabled</color>";
 
         // Toggle
-        private static string ACCESS_DENIED_MESSAGE = string.Format("You don't have access to this command yet. Purchase the '{0}'.\n", lightningRodScript.UPGRADE_NAME);
-        private static string TOGGLE_ON_MESSAGE = string.Format("{0} has been enabled. Lightning bolts will now be redirected to the ship.\n", UPGRADE_NAME);
-        private static string TOGGLE_OFF_MESSAGE = string.Format("{0} has been disabled. Lightning bolts will no longer be redirected to the ship.\n", UPGRADE_NAME);
+        private static string ACCESS_DENIED_MESSAGE = $"You don't have access to this command yet. Purchase the '{UPGRADE_NAME}'.\n";
+        private static string TOGGLE_ON_MESSAGE = $"{UPGRADE_NAME} has been enabled. Lightning bolts will now be redirected to the ship.\n";
+        private static string TOGGLE_OFF_MESSAGE = $"{UPGRADE_NAME} has been disabled. Lightning bolts will no longer be redirected to the ship.\n";
 
         // distance
-        public static string DIST_SECTION = "Effective Distance of lightning rod.";
+        public static string DIST_SECTION = $"Effective Distance of {UPGRADE_NAME}.";
         public static float DIST_DEFAULT = 175f;
-        public static string DIST_DESCRIPTION = string.Format("The closer you are the more likely the rod will reroute lightning.", UPGRADE_NAME);
+        public static string DIST_DESCRIPTION = $"The closer you are the more likely the rod will reroute lightning.";
 
         public bool CanTryInterceptLightning { get; internal set; }
         public bool LightningIntercepted { get; internal set; }
@@ -44,6 +45,7 @@ namespace MoreShipUpgrades.UpgradeComponents
         void Awake()
         {
             instance = this;
+            logger = new LGULogger(UPGRADE_NAME);
         }
 
         void Start()
@@ -83,8 +85,8 @@ namespace MoreShipUpgrades.UpgradeComponents
 
             Terminal terminal = UpgradeBus.instance.GetTerminal();
             float dist = Vector3.Distance(___targetingMetalObject.transform.position, terminal.transform.position);
-            Plugin.mls.LogInfo(string.Format("[{0}] Distance from ship: {1}\n", UPGRADE_NAME, dist));
-            Plugin.mls.LogInfo(string.Format("[{0}] Effective distance of the lightning rod: {1}", UPGRADE_NAME, UpgradeBus.instance.cfg.LIGHTNING_ROD_DIST));
+            logger.LogInfo($"Distance from ship: {dist}");
+            logger.LogInfo($"Effective distance of the lightning rod: {UpgradeBus.instance.cfg.LIGHTNING_ROD_DIST}");
 
             if (dist > UpgradeBus.instance.cfg.LIGHTNING_ROD_DIST) return;
 
@@ -92,11 +94,11 @@ namespace MoreShipUpgrades.UpgradeComponents
             float prob = 1 - dist;
             float rand = Random.value;
 
-            Plugin.mls.LogInfo(string.Format("[{0}] Number to beat: {1}",UPGRADE_NAME, prob));
-            Plugin.mls.LogInfo(string.Format("[{0}] Number: {1}",UPGRADE_NAME, rand));
+            logger.LogInfo($"Number to beat: {prob}");
+            logger.LogInfo($"Number: {rand}");
             if (rand < prob)
             {
-                Plugin.mls.LogInfo(string.Format("[{0}] Planning interception...", UPGRADE_NAME));
+                logger.LogInfo("Planning interception...");
                 __instance.staticElectricityParticle.Stop();
                 instance.LightningIntercepted = true;
                 LGUStore.instance.CoordinateInterceptionClientRpc();
@@ -105,7 +107,7 @@ namespace MoreShipUpgrades.UpgradeComponents
 
         public static void RerouteLightningBolt(ref Vector3 strikePosition, ref StormyWeather __instance)
         {
-            Plugin.mls.LogInfo(string.Format("[{0}] Intercepted Lightning Strike...", UPGRADE_NAME));
+            logger.LogInfo($"Intercepted Lightning Strike...");
             Terminal terminal = UpgradeBus.instance.GetTerminal();
             strikePosition = terminal.transform.position;
             instance.LightningIntercepted = false;

--- a/MoreShipUpgrades/UpgradeComponents/lockSmithScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/lockSmithScript.cs
@@ -10,6 +10,8 @@ namespace MoreShipUpgrades.UpgradeComponents
 {
     public class lockSmithScript : BaseUpgrade
     {
+        public static string UPGRADE_NAME = "Locksmith";
+
         private GameObject pin1, pin2, pin3, pin4, pin5;
         private List<GameObject> pins;
         private List<int> order = new List<int> { 0, 1, 2, 3, 4 };
@@ -20,6 +22,7 @@ namespace MoreShipUpgrades.UpgradeComponents
 
         void Start()
         {
+            upgradeName = UPGRADE_NAME;
             DontDestroyOnLoad(gameObject);
             Register();
             Transform tumbler = transform.GetChild(0).GetChild(0).GetChild(0);
@@ -40,14 +43,15 @@ namespace MoreShipUpgrades.UpgradeComponents
 
         public override void load()
         {
+            base.load();
+
             UpgradeBus.instance.lockSmith = true;
             UpgradeBus.instance.lockScript = this;
-            HUDManager.Instance.chatText.text += "\n<color=#FF0000>Locksmith is active!</color>";
         }
 
         public override void Register()
         {
-            if(!UpgradeBus.instance.UpgradeObjects.ContainsKey("Locksmith")) { UpgradeBus.instance.UpgradeObjects.Add("Locksmith", gameObject); }
+            base.Register();
         }
 
         void Update()
@@ -79,8 +83,9 @@ namespace MoreShipUpgrades.UpgradeComponents
         }
         public override void Unwind()
         {
+            base.Unwind();
+
             UpgradeBus.instance.lockSmith = false;
-            HUDManager.Instance.chatText.text += "\n<color=#FF0000>Locksmith has been disabled.</color>";
         }
         public void StrikePin(int i)
         {

--- a/MoreShipUpgrades/UpgradeComponents/nightVisionScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/nightVisionScript.cs
@@ -19,8 +19,12 @@ namespace MoreShipUpgrades.UpgradeComponents
         private bool batteryExhaustion;
         private Key toggleKey;
 
+        public static string UPGRADE_NAME = "NV Headset Batteries";
+        public static string PRICES_DEFAULT = "300,400,500";
+
         void Start()
         {
+            upgradeName = UPGRADE_NAME;
             DontDestroyOnLoad(gameObject);
             Register();
             batteryBar = transform.GetChild(0).GetChild(0).transform;
@@ -39,7 +43,7 @@ namespace MoreShipUpgrades.UpgradeComponents
 
         public override void Register()
         {
-            if(!UpgradeBus.instance.UpgradeObjects.ContainsKey("NV Headset Batteries")) { UpgradeBus.instance.UpgradeObjects.Add("NV Headset Batteries", gameObject); }
+            base.Register();
         }
 
         void LateUpdate()
@@ -145,10 +149,11 @@ namespace MoreShipUpgrades.UpgradeComponents
         }
         public override void Unwind()
         {
+            base.Unwind();
+
             UpgradeBus.instance.nightVision = false;
             UpgradeBus.instance.nightVisionLevel = 0;
             DisableOnClient();
-            HUDManager.Instance.chatText.text += "\n<color=#FF0000>NV Headset Batteries has been disabled.</color>";
         }
         public void EnableOnClient(bool save = true)
         {

--- a/MoreShipUpgrades/UpgradeComponents/pagerScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/pagerScript.cs
@@ -7,22 +7,26 @@ namespace MoreShipUpgrades.UpgradeComponents
 {
     public class pagerScript : BaseUpgrade
     {
+        public static string UPGRADE_NAME = "Fast Encryption";
+
         void Start()
         {
+            upgradeName = UPGRADE_NAME;
             DontDestroyOnLoad(gameObject);
             Register();
         }
 
         public override void load()
         {
+            base.load();
+
             UpgradeBus.instance.pager = true;
             UpgradeBus.instance.pageScript = this;
-            HUDManager.Instance.chatText.text += "\n<color=#FF0000>Fast Encryption is active!</color>";
         }
 
         public override void Register()
         {
-            if (!UpgradeBus.instance.UpgradeObjects.ContainsKey("Fast Encryption")) { UpgradeBus.instance.UpgradeObjects.Add("Fast Encryption", gameObject); }
+            base.Register();
         }
 
         [ServerRpc(RequireOwnership = false)]

--- a/MoreShipUpgrades/UpgradeComponents/playerHealthScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/playerHealthScript.cs
@@ -14,26 +14,14 @@ namespace MoreShipUpgrades.UpgradeComponents
         private static int DEFAULT_HEALTH = 100;
 
         // Configuration
-        public static string ENABLED_SECTION = string.Format("Enable {0} Upgrade", UPGRADE_NAME);
+        public static string ENABLED_SECTION = $"Enable {UPGRADE_NAME} Upgrade";
         public static bool ENABLED_DEFAULT = true;
         public static string ENABLED_DESCRIPTION = "Increases player's health.";
 
-        public static string PRICE_SECTION = string.Format("{0} Price", UPGRADE_NAME);
+        public static string PRICE_SECTION = $"{UPGRADE_NAME} Price";
         public static int PRICE_DEFAULT = 600;
 
-        public static string INDIVIDUAL_SECTION = "Individual Purchase";
-        public static bool INDIVIDUAL_DEFAULT = false;
-        public static string INDIVIDUAL_DESCRIPTION = "If true: upgrade will apply only to the client that purchased it.";
-
-        // Chat Messages
-        private static string LOAD_COLOUR = "#FF0000";
-        private static string LOAD_MESSAGE = string.Format("\n<color={0}>{1} is active!</color>", LOAD_COLOUR, UPGRADE_NAME);
-
-        private static string UNLOAD_COLOUR = LOAD_COLOUR;
-        private static string UNLOAD_MESSAGE = string.Format("\n<color={0}>{1} has been disabled</color>", UNLOAD_COLOUR, UPGRADE_NAME);
-
-        public static string UPGRADE_PRICES_SECTION = "Price of each additional upgrade";
-        public static string UPGRADE_PRICES_DEFAULT = "300, 450, 600";
+        public static string PRICES_DEFAULT = "300, 450, 600";
 
         public static string ADDITIONAL_HEALTH_UNLOCK_SECTION = "Initial health boost";
         public static int ADDITIONAL_HEALTH_UNLOCK_DEFAULT = 20;
@@ -41,10 +29,11 @@ namespace MoreShipUpgrades.UpgradeComponents
 
         public static string ADDITIONAL_HEALTH_INCREMENT_SECTION = "Additional health boost";
         public static int ADDITIONAL_HEALTH_INCREMENT_DEFAULT = 20;
-        public static string ADDITIONAL_HEALTH_INCREMENT_DESCRIPTION = string.Format("Every time {0} is upgraded this value will be added to the value above.", UPGRADE_NAME);
+        public static string ADDITIONAL_HEALTH_INCREMENT_DESCRIPTION = $"Every time {UPGRADE_NAME} is upgraded this value will be added to the value above.";
 
         void Start()
         {
+            upgradeName = UPGRADE_NAME;
             DontDestroyOnLoad(gameObject);
             UpgradeBus.instance.UpgradeObjects.Add(UPGRADE_NAME, gameObject);
         }
@@ -57,22 +46,24 @@ namespace MoreShipUpgrades.UpgradeComponents
 
         public override void load()
         {
+            base.load();
+
             UpgradeBus.instance.playerHealth = true;
-            HUDManager.Instance.chatText.text += LOAD_MESSAGE;
             LGUStore.instance.UpdatePlayerNewHealthsServerRpc(GameNetworkManager.Instance.localPlayerController.playerSteamId, DEFAULT_HEALTH + UpgradeBus.instance.cfg.PLAYER_HEALTH_ADDITIONAL_HEALTH_UNLOCK + (UpgradeBus.instance.playerHealthLevel * UpgradeBus.instance.cfg.PLAYER_HEALTH_ADDITIONAL_HEALTH_INCREMENT));
         }
 
         public override void Register()
         {
-            if (!UpgradeBus.instance.UpgradeObjects.ContainsKey(UPGRADE_NAME)) { UpgradeBus.instance.UpgradeObjects.Add(UPGRADE_NAME, gameObject); }
+            base.Register();
         }
 
         public override void Unwind()
         {
+            base.Unwind();
+
             UpgradeBus.instance.playerHealthLevel = 0;
             UpgradeBus.instance.playerHealth = false;
-            HUDManager.Instance.chatText.text += UNLOAD_MESSAGE;
-            LGUStore.instance.UpdatePlayerNewHealthsServerRpc(GameNetworkManager.Instance.localPlayerController.playerSteamId, 0);
+            LGUStore.instance.UpdatePlayerNewHealthsServerRpc(GameNetworkManager.Instance.localPlayerController.playerSteamId, DEFAULT_HEALTH);
         }
 
         public static void CheckAdditionalHealth(StartOfRound __instance)

--- a/MoreShipUpgrades/UpgradeComponents/proteinPowderScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/proteinPowderScript.cs
@@ -16,11 +16,11 @@ namespace MoreShipUpgrades.UpgradeComponents
         private static int DEFAULT_HIT_VALUE = 1;
 
         // Configuration
-        public static string ENABLED_SECTION = string.Format("Enable {0} Upgrade", UPGRADE_NAME);
+        public static string ENABLED_SECTION = $"Enable {UPGRADE_NAME} Upgrade";
         public static bool ENABLED_DEFAULT = true;
         public static string ENABLED_DESCRIPTION = "Do more damage with shovels";
 
-        public static string PRICE_SECTION = string.Format("Price of {0} Upgrade", UPGRADE_NAME);
+        public static string PRICE_SECTION = $"Price of {UPGRADE_NAME} Upgrade";
         public static int PRICE_DEFAULT = 1000;
 
         public static string UNLOCK_FORCE_SECTION = "Initial additional hit force";
@@ -31,27 +31,15 @@ namespace MoreShipUpgrades.UpgradeComponents
         public static int INCREMENT_FORCE_DEFAULT = 1;
         public static string INCREMENT_FORCE_DESCRIPTION = "Every time protein powder is upgraded this value will be added to the value above.";
 
-        public static string INDIVIDUAL_SECTION = "Individual Purchase";
-        public static bool INDIVIDUAL_DEFAULT = true;
-        public static string INDIVIDUAL_DESCRIPTION = "If true: upgrade will apply only to the client that purchased it.";
-
-        public static string PRICES_SECTION = "Price of each additional upgrade";
         public static string PRICES_DEFAULT = "700";
-        public static string PRICES_DESCRIPTION = "Value must be seperated by commas EX: '123,321,222'";
 
         public static string CRIT_CHANCE_SECTION = "Chance of dealing a crit which will instakill the enemy.";
         public static float CRIT_CHANCE_DEFAULT = 0.01f;
         public static string CRIT_CHANCE_DESCRIPTION = "This value is only valid when maxed out Protein Powder. Any previous levels will not apply crit.";
 
-        // Chat Messages
-        private static string LOAD_COLOUR = "#FF0000";
-        private static string LOAD_MESSAGE = string.Format("\n<color={0}>{1} is active!</color>", LOAD_COLOUR, UPGRADE_NAME);
-
-        private static string UNLOAD_COLOUR = LOAD_COLOUR;
-        private static string UNLOAD_MESSAGE = string.Format("\n<color={0}>{1} has been disabled</color>", UNLOAD_COLOUR, UPGRADE_NAME);
-
         void Start()
         {
+            upgradeName = UPGRADE_NAME;
             DontDestroyOnLoad(gameObject);
             Register();
         }
@@ -63,20 +51,22 @@ namespace MoreShipUpgrades.UpgradeComponents
 
         public override void load()
         {
+            base.load();
+
             UpgradeBus.instance.proteinPowder = true;
-            HUDManager.Instance.chatText.text += LOAD_MESSAGE;
         }
 
         public override void Register()
         {
-            if(!UpgradeBus.instance.UpgradeObjects.ContainsKey(UPGRADE_NAME)) { UpgradeBus.instance.UpgradeObjects.Add(UPGRADE_NAME, gameObject); }
+            base.Register();
         }
 
         public override void Unwind()
         {
+            base.Unwind();
+
             UpgradeBus.instance.proteinLevel = 0;
             UpgradeBus.instance.proteinPowder = false;
-            HUDManager.Instance.chatText.text += UNLOAD_MESSAGE;
         }
 
         public static int GetShovelHitForce()
@@ -86,11 +76,13 @@ namespace MoreShipUpgrades.UpgradeComponents
 
         private static bool TryToCritEnemy()
         {
-            Plugin.mls.LogInfo(string.Format("Levels purchaseable for Protein Powder: {0}",UpgradeBus.instance.cfg.PROTEIN_UPGRADE_PRICES.Split(',').Length));
-            Plugin.mls.LogInfo("Current level on Protein Powder: " + UpgradeBus.instance.proteinLevel);
+            int maximumLevel = UpgradeBus.instance.cfg.PROTEIN_UPGRADE_PRICES.Split(',').Length;
+            int currentLevel = UpgradeBus.instance.proteinLevel;
 
-            bool reachedLastUpgrade = UpgradeBus.instance.proteinLevel == UpgradeBus.instance.cfg.PROTEIN_UPGRADE_PRICES.Split(',').Length;
-            if (!reachedLastUpgrade) return false;
+            Plugin.mls.LogInfo($"Levels purchaseable for Protein Powder: {maximumLevel}");
+            Plugin.mls.LogInfo($"Current level on Protein Powder: {currentLevel}");
+
+            if (currentLevel != maximumLevel) return false;
 
             return UnityEngine.Random.value < UpgradeBus.instance.cfg.PROTEIN_CRIT_CHANCE;
         }

--- a/MoreShipUpgrades/UpgradeComponents/runningShoeScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/runningShoeScript.cs
@@ -5,8 +5,11 @@ namespace MoreShipUpgrades.UpgradeComponents
 {
     internal class runningShoeScript : BaseUpgrade
     {
+        public static string UPGRADE_NAME = "Running Shoes";
+        public static string PRICES_DEFAULT = "500,750,1000";
         void Start()
         {
+            upgradeName = UPGRADE_NAME;
             DontDestroyOnLoad(gameObject);
             Register();
         }
@@ -19,21 +22,24 @@ namespace MoreShipUpgrades.UpgradeComponents
 
         public override void Unwind()
         {
+            base.Unwind();
+
             UpgradeBus.instance.runningShoes = false;
             UpgradeBus.instance.runningLevel = 0;
             GameNetworkManager.Instance.localPlayerController.movementSpeed = 4.6f;
-            HUDManager.Instance.chatText.text += "\n<color=#FF0000>Running Shoes has been disabled.</color>";
         }
         public override void Register()
         {
-            if(!UpgradeBus.instance.UpgradeObjects.ContainsKey("Running Shoes")) { UpgradeBus.instance.UpgradeObjects.Add("Running Shoes", gameObject); }
+            base.Register();
         }
 
         public override void load()
         {
+            base.load();
+
             UpgradeBus.instance.runningShoes = true;
             GameNetworkManager.Instance.localPlayerController.movementSpeed = UpgradeBus.instance.cfg.MOVEMENT_SPEED;
-            HUDManager.Instance.chatText.text += "\n<color=#FF0000>Running Shoes is active!</color>";
+
             float amountToIncrement = 0;
             for(int i = 0; i < UpgradeBus.instance.runningLevel; i++)
             {

--- a/MoreShipUpgrades/UpgradeComponents/strongLegsScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/strongLegsScript.cs
@@ -5,8 +5,11 @@ namespace MoreShipUpgrades.UpgradeComponents
 {
     internal class strongLegsScript : BaseUpgrade
     {
+        public static string UPGRADE_NAME = "Strong Legs";
+        public static string PRICES_DEFAULT = "150,190,250";
         void Start()
         {
+            upgradeName = UPGRADE_NAME;
             DontDestroyOnLoad(gameObject);
             Register();
         }
@@ -18,21 +21,23 @@ namespace MoreShipUpgrades.UpgradeComponents
 
         public override void Unwind()
         {
+            base.Unwind();
+
             UpgradeBus.instance.strongLegs = false;
             UpgradeBus.instance.legLevel = 0;
             GameNetworkManager.Instance.localPlayerController.jumpForce = 13f;
-            HUDManager.Instance.chatText.text += "\n<color=#FF0000>Better Scanner has been disabled.</color>";
         }
         public override void Register()
         {
-            if(!UpgradeBus.instance.UpgradeObjects.ContainsKey("Strong Legs")) { UpgradeBus.instance.UpgradeObjects.Add("Strong Legs", gameObject); }
+            base.Register();
         }
 
         public override void load()
         {
+            base.load();
+
             UpgradeBus.instance.strongLegs = true;
             GameNetworkManager.Instance.localPlayerController.jumpForce = UpgradeBus.instance.cfg.JUMP_FORCE;
-            HUDManager.Instance.chatText.text += "\n<color=#FF0000>Strong Legs is active!</color>";
             float amountToIncrement = 0;
             for(int i = 0; i < UpgradeBus.instance.legLevel; i++)
             {

--- a/MoreShipUpgrades/UpgradeComponents/strongerScannerScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/strongerScannerScript.cs
@@ -6,9 +6,10 @@ namespace MoreShipUpgrades.UpgradeComponents
 {
     internal class strongerScannerScript : BaseUpgrade
     {
-
+        public static string UPGRADE_NAME = "Better Scanner";
         void Start()
         {
+            upgradeName = UPGRADE_NAME;
             DontDestroyOnLoad(gameObject);
             Register();
         }
@@ -20,25 +21,25 @@ namespace MoreShipUpgrades.UpgradeComponents
 
         public override void load()
         {
+            base.load();
+
             UpgradeBus.instance.scannerUpgrade = true;
-            HUDManager.Instance.chatText.text += "\n<color=#FF0000>Better Scanner is active!</color>";
         }
         public override void Unwind()
         {
+            base.Unwind();
+
             UpgradeBus.instance.scannerUpgrade = false;
             UpgradeBus.instance.scanLevel = 0;
-            HUDManager.Instance.chatText.text += "\n<color=#FF0000>Better Scanner has been disabled.</color>";
         }
         public override void Register()
         {
-            Debug.Log("SLKDJF");
-            if(!UpgradeBus.instance.UpgradeObjects.ContainsKey("Better Scanner")) { UpgradeBus.instance.UpgradeObjects.Add("Better Scanner", gameObject); }
+            base.Register();
         }
 
         public static void AddScannerNodeToValve(ref SteamValveHazard steamValveHazard)
         {
-            if (UpgradeBus.instance.scanLevel < 0) return;
-            Plugin.mls.LogInfo("Adding scan node to the steam valve");
+            if (!UpgradeBus.instance.scannerUpgrade) return;
             GameObject ScanNodeObject = Instantiate(GameObject.Find("ScanNode"), steamValveHazard.transform.position, Quaternion.Euler(Vector3.zero), steamValveHazard.transform);
             ScanNodeProperties node = ScanNodeObject.GetComponent<ScanNodeProperties>();
             node.headerText = "Bursted Steam Valve";

--- a/MoreShipUpgrades/UpgradeComponents/terminalFlashScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/terminalFlashScript.cs
@@ -8,8 +8,11 @@ namespace MoreShipUpgrades.UpgradeComponents
 {
     public class terminalFlashScript : BaseUpgrade
     {
+        public static string UPGRADE_NAME = "Discombobulator";
+        public static string PRICES_DEFAULT = "330,460,620";
         void Start()
         {
+            upgradeName = UPGRADE_NAME;
             DontDestroyOnLoad(gameObject);
             Register();
         }
@@ -24,7 +27,7 @@ namespace MoreShipUpgrades.UpgradeComponents
 
         public override void Register()
         {
-            if(!UpgradeBus.instance.UpgradeObjects.ContainsKey("Discombobulator")) { UpgradeBus.instance.UpgradeObjects.Add("Discombobulator", gameObject); }
+            base.Register();
         }
 
         public override void Increment()
@@ -34,9 +37,10 @@ namespace MoreShipUpgrades.UpgradeComponents
 
         public override void Unwind()
         {
+            base.Unwind();
+
             UpgradeBus.instance.terminalFlash = false;
             UpgradeBus.instance.discoLevel = 0;
-            HUDManager.Instance.chatText.text += "\n<color=#FF0000>Discombobulator has been disabled.</color>";
         }
 
         [ServerRpc(RequireOwnership = false)]

--- a/MoreShipUpgrades/UpgradeComponents/trapDestroyerScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/trapDestroyerScript.cs
@@ -7,27 +7,31 @@ namespace MoreShipUpgrades.UpgradeComponents
 {
     public class trapDestroyerScript : BaseUpgrade
     {
+        public static string UPGRADE_NAME = "Malware Broadcaster";
         void Start()
         {
+            upgradeName = UPGRADE_NAME;
             DontDestroyOnLoad(gameObject);
             Register();
         }
 
         public override void load()
         {
+            base.load();
+
             UpgradeBus.instance.DestroyTraps = true;
             UpgradeBus.instance.trapHandler = this;
-            HUDManager.Instance.chatText.text += "\n<color=#FF0000>Malware Broadcaster is active!</color>";
         }
 
         public override void Unwind()
         {
+            base.Unwind();
+
             UpgradeBus.instance.DestroyTraps = false;
-            HUDManager.Instance.chatText.text += "\n<color=#FF0000>Malware Broadcaster has been disabled.</color>";
         }
         public override void Register()
         {
-            if(!UpgradeBus.instance.UpgradeObjects.ContainsKey("Malware Broadcaster")) { UpgradeBus.instance.UpgradeObjects.Add("Malware Broadcaster", gameObject); }
+            base.Register();
         }
 
         [ServerRpc(RequireOwnership = false)]

--- a/MoreShipUpgrades/UpgradeComponents/walkieScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/walkieScript.cs
@@ -9,10 +9,13 @@ namespace MoreShipUpgrades.UpgradeComponents
 {
     public class walkieScript : BaseUpgrade
     {
+        public static string UPGRADE_NAME = "Walkie GPS";
+
         private GameObject canvas;
         private Text x, y, z, time;
         void Start()
         {
+            upgradeName = UPGRADE_NAME;
             DontDestroyOnLoad(gameObject);
             Register();
             UpgradeBus.instance.walkieHandler = this;
@@ -25,59 +28,59 @@ namespace MoreShipUpgrades.UpgradeComponents
 
         public override void load()
         {
+            base.load();
+
             UpgradeBus.instance.walkies = true;
-            HUDManager.Instance.chatText.text += "\n<color=#FF0000>Walkie Talkies now have GPS!</color>";
         }
 
         public override void Register()
         {
-            if(!UpgradeBus.instance.UpgradeObjects.ContainsKey("Walkie GPS")) { UpgradeBus.instance.UpgradeObjects.Add("Walkie GPS", gameObject); }
+            base.Register();
         }
 
         public override void Unwind()
         {
+            base.Unwind();
+
             UpgradeBus.instance.walkies = false;
-            HUDManager.Instance.chatText.text += "\n<color=#FF0000>GPS Walkies have been disabled</color>";
         }
 
         public void Update()
         {
-            if(UpgradeBus.instance.walkieUIActive)
-            {
-                Vector3 pos = GameNetworkManager.Instance.localPlayerController.transform.position;
-                x.text = $"X: {pos.x.ToString("F1")}";
-                y.text = $"Y: {pos.y.ToString("F1")}";
-                z.text = $"Z: {pos.z.ToString("F1")}";
+            if (!UpgradeBus.instance.walkieUIActive) return;
 
-                int num = (int)(TimeOfDay.Instance.normalizedTimeOfDay * (60f * TimeOfDay.Instance.numberOfHours)) + 360;
-                int num2 = (int)Mathf.Floor((float)(num / 60));
-                string amPM = "AM";
-                string text = "";
-                if (num2 >= 24)
-                {
-                    text = "12:00 AM";
-                }
-                if (num2 > 12)
-                {
-                    amPM = "PM";
-                }
-                if (num2 > 12)
-                {
-                    num2 %= 12;
-                }
-                int num3 = num % 60;
-                text = string.Format("{0:00}:{1:00}", num2, num3).TrimStart('0') + amPM;
-                time.text = text;           
+            Vector3 pos = GameNetworkManager.Instance.localPlayerController.transform.position;
+            x.text = $"X: {pos.x.ToString("F1")}";
+            y.text = $"Y: {pos.y.ToString("F1")}";
+            z.text = $"Z: {pos.z.ToString("F1")}";
+
+            int num = (int)(TimeOfDay.Instance.normalizedTimeOfDay * (60f * TimeOfDay.Instance.numberOfHours)) + 360;
+            int num2 = (int)Mathf.Floor((float)(num / 60));
+            string amPM = "AM";
+            string text = "";
+            if (num2 >= 24)
+            {
+                text = "12:00 AM";
             }
+            if (num2 > 12)
+            {
+                amPM = "PM";
+            }
+            if (num2 > 12)
+            {
+                num2 %= 12;
+            }
+            int num3 = num % 60;
+            text = string.Format("{0:00}:{1:00}", num2, num3).TrimStart('0') + amPM;
+            time.text = text;
         }
 
         public void WalkieActive()
         {
-            if(!canvas.activeInHierarchy)
-            {
-                UpgradeBus.instance.walkieUIActive = true;
-                canvas.SetActive(true);
-            }
+            if (canvas.activeInHierarchy) return;
+
+            UpgradeBus.instance.walkieUIActive = true;
+            canvas.SetActive(true);
         }
 
         public void WalkieDeactivate()


### PR DESCRIPTION
Made "BaseUpgrade" have the strings related to Individual status and prices' configurations, since all upgrades had the same string. 
BaseUpgrade's methods now do the send message to chat where it uses a variable that stores the derived's upgrade name and the register. 
Moved all prices' default of each upgrade to their respective scripts. Passed LogInfo to LogDebug to not overload the console with useless logs such as loading assets.
Remove string.Format from logs since it's computionally costly than doing $"string" way.