### PR TITLE
Implementation of Bigger Lungs' stamina regen increase and reduction of stamina cost on jumps

### DIFF
--- a/MoreShipUpgrades/Misc/PluginConfig.cs
+++ b/MoreShipUpgrades/Misc/PluginConfig.cs
@@ -71,6 +71,8 @@ namespace MoreShipUpgrades.Misc
         public int PLAYER_HEALTH_PRICE { get; set; }
 
         // attributes
+        public float BIGGER_LUNGS_STAMINA_REGEN_INCREASE { get; set; }
+        public float BIGGER_LUNGS_JUMP_STAMINA_COST_DECREASE { get; set; }
         public int PROTEIN_INCREMENT { get; set; }
         public int HUNTER_PRICE2 { get; set; }
         public int HUNTER_PRICE3 { get; set; }
@@ -210,6 +212,8 @@ namespace MoreShipUpgrades.Misc
             SPRINT_TIME_INCREMENT = ConfigEntry(topSection, "SprintTime Increment", 1.25f,"How much the above value is increased on upgrade.");
             BIGGER_LUNGS_UPGRADE_PRICES = ConfigEntry(topSection, "Price of each additional upgrade", "350,450,550", "");
             BIGGER_LUNGS_INDIVIDUAL = ConfigEntry(topSection, "Individual Purchase", true, "If true: upgrade will apply only to the client that purchased it.");
+            BIGGER_LUNGS_STAMINA_REGEN_INCREASE = ConfigEntry(topSection, "Stamina Regeneration Increase", 1.05f, "Increase of stamina regeneration applied past level 1");
+            BIGGER_LUNGS_JUMP_STAMINA_COST_DECREASE = ConfigEntry(topSection, "Stamina cost decrease on jumps", 0.90f, "Multiplied with the vanilla cost of jumping");
 
             topSection = "Running Shoes";
             RUNNING_SHOES_ENABLED = ConfigEntry(topSection, "Enable Running Shoes Upgrade", true, "Run Faster");

--- a/MoreShipUpgrades/UpgradeComponents/biggerLungScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/biggerLungScript.cs
@@ -7,6 +7,9 @@ namespace MoreShipUpgrades.UpgradeComponents
 {
     internal class biggerLungScript : BaseUpgrade
     {
+        PlayerControllerB localPlayer;
+        private static LGULogger logger = new LGULogger("Bigger Lungs");
+        private static float DEFAULT_SPRINT_TIME = 11f;
 
         void Start()
         {
@@ -17,12 +20,14 @@ namespace MoreShipUpgrades.UpgradeComponents
         public override void Increment()
         {
             UpgradeBus.instance.lungLevel++;
-            GameNetworkManager.Instance.localPlayerController.sprintTime += UpgradeBus.instance.cfg.SPRINT_TIME_INCREMENT;  //17
+            PlayerControllerB player = GetLocalPlayer();
+            player.sprintTime += UpgradeBus.instance.cfg.SPRINT_TIME_INCREMENT;  //17
         }
 
         public override void load()
         {
-            GameNetworkManager.Instance.localPlayerController.sprintTime = UpgradeBus.instance.cfg.SPRINT_TIME_INCREASE; //17
+            PlayerControllerB player = GetLocalPlayer();
+            player.sprintTime = UpgradeBus.instance.cfg.SPRINT_TIME_INCREASE; //17
             UpgradeBus.instance.biggerLungs = true;
             HUDManager.Instance.chatText.text += "\n<color=#FF0000>Bigger Lungs is active!</color>";
 
@@ -32,19 +37,39 @@ namespace MoreShipUpgrades.UpgradeComponents
                 amountToIncrement += UpgradeBus.instance.cfg.SPRINT_TIME_INCREMENT;
             }
 
-            GameNetworkManager.Instance.localPlayerController.sprintTime += amountToIncrement;
+            localPlayer.sprintTime += amountToIncrement;
         }
 
         public override void Unwind()
         {
+            PlayerControllerB player = GetLocalPlayer();
+            player.sprintTime = DEFAULT_SPRINT_TIME;
             UpgradeBus.instance.biggerLungs = false;
-            GameNetworkManager.Instance.localPlayerController.sprintTime = 11f;
             HUDManager.Instance.chatText.text += "\n<color=#FF0000>Bigger Lungs has been disabled.</color>";
         }
 
         public override void Register()
         {
             if(!UpgradeBus.instance.UpgradeObjects.ContainsKey("Bigger Lungs")) { UpgradeBus.instance.UpgradeObjects.Add("Bigger Lungs", gameObject); }
+        }
+
+        private PlayerControllerB GetLocalPlayer()
+        {
+            if (localPlayer == null) localPlayer = GameNetworkManager.Instance.localPlayerController;
+
+            return localPlayer;
+        }
+
+        public static float ApplyPossibleIncreasedStaminaRegen(float regenValue)
+        {
+            if (!UpgradeBus.instance.biggerLungs || UpgradeBus.instance.lungLevel < 0) return regenValue;
+            return regenValue*UpgradeBus.instance.cfg.BIGGER_LUNGS_STAMINA_REGEN_INCREASE;
+        }
+
+        public static float ApplyPossibleReducedJumpStaminaCost(float jumpCost)
+        {
+            if (!UpgradeBus.instance.biggerLungs || UpgradeBus.instance.lungLevel < 1) return jumpCost;
+            return jumpCost * UpgradeBus.instance.cfg.BIGGER_LUNGS_JUMP_STAMINA_COST_DECREASE;
         }
     }
 }


### PR DESCRIPTION
Added configuration values for both Stamina regeneration rate increase and stamina cost decrease on jumps related to Bigger Lungs. Through transpilers, we pick up the intended value that represents the each of these and change it according to the upgrade.