### PR TITLE
Implementation of Strong Legs' last level applying damage reduction when falling from high heights

### DIFF
--- a/MoreShipUpgrades/Misc/PluginConfig.cs
+++ b/MoreShipUpgrades/Misc/PluginConfig.cs
@@ -161,6 +161,7 @@ namespace MoreShipUpgrades.Misc
         public int DISCOMBOBULATOR_DAMAGE_LEVEL { get; set; }
         public int DISCOMBOBULATOR_INITIAL_DAMAGE {  get; set; }
         public int DISCOMBOBULATOR_DAMAGE_INCREASE { get; set; }
+        public float STRONG_LEGS_REDUCE_FALL_DAMAGE_MULTIPLIER { get; set; }
 
         public PluginConfig(ConfigFile cfg)
         {
@@ -235,6 +236,7 @@ namespace MoreShipUpgrades.Misc
             JUMP_FORCE_INCREMENT = ConfigEntry(topSection, "Jump Force Increment", 0.75f, "How much the above value is increased on upgrade.");
             STRONG_LEGS_UPGRADE_PRICES = ConfigEntry(topSection, BaseUpgrade.PRICES_SECTION, strongLegsScript.PRICES_DEFAULT, BaseUpgrade.PRICES_DESCRIPTION);
             STRONG_LEGS_INDIVIDUAL = ConfigEntry(topSection, BaseUpgrade.INDIVIDUAL_SECTION, BaseUpgrade.INDIVIDUAL_DEFAULT, BaseUpgrade.INDIVIDUAL_DESCRIPTION);
+            STRONG_LEGS_REDUCE_FALL_DAMAGE_MULTIPLIER = ConfigEntry(topSection, "Damage mitigation when falling", 0.5f, "Multiplier applied on fall damage that you wish to ignore when reached max level");
 
             topSection = trapDestroyerScript.UPGRADE_NAME;
             MALWARE_BROADCASTER_ENABLED = ConfigEntry(topSection, "Enable Malware Broadcaster Upgrade", true, "Explode Map Hazards");

--- a/MoreShipUpgrades/UpgradeComponents/strongLegsScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/strongLegsScript.cs
@@ -47,6 +47,10 @@ namespace MoreShipUpgrades.UpgradeComponents
             GameNetworkManager.Instance.localPlayerController.jumpForce += amountToIncrement;
         }
 
-
+        public static int ReduceFallDamage(int defaultValue)
+        {
+            if (!(UpgradeBus.instance.strongLegs && UpgradeBus.instance.legLevel == UpgradeBus.instance.cfg.STRONG_LEGS_UPGRADE_PRICES.Split(',').Length)) return defaultValue;
+            return (int)(defaultValue * (1.0f - UpgradeBus.instance.cfg.STRONG_LEGS_REDUCE_FALL_DAMAGE_MULTIPLIER));
+        }
     }
 }


### PR DESCRIPTION
The multiplier that serves as the damage mitigation of fall damage is configurable.

It will still play the damagePlayer animation but it won't actually hurt the player in terms of health.