### PR TITLE
Implementation of "Extend Deadline <days>" command, implemented "IComparable" interface on CustomTerminalNode

### DIFF
--- a/MoreShipUpgrades/Managers/UpgradeBus.cs
+++ b/MoreShipUpgrades/Managers/UpgradeBus.cs
@@ -54,6 +54,7 @@ namespace MoreShipUpgrades.Managers
         public terminalFlashScript flashScript = null;
         public lockSmithScript lockScript = null;
         public defibScript internScript = null;
+        public ExtendDeadlineScript extendScript = null;
         public walkieScript walkieHandler = null;
 
         public Color nightVisColor;
@@ -292,6 +293,8 @@ namespace MoreShipUpgrades.Managers
             SetupPagerTerminalNode();
 
             SetupLocksmithTerminalNode();
+            SetupExtendDeadlineTerminalNode();
+            terminalNodes.Sort();
         }
 
         private void SetupBeekeperTerminalNode()
@@ -437,6 +440,14 @@ namespace MoreShipUpgrades.Managers
                                     cfg.INTERN_ENABLED,
                                     cfg.INTERN_PRICE,
                                     string.Format(AssetBundleHandler.GetInfoFromJSON("Interns"), cfg.INTERN_PRICE));
+        }
+        private void SetupExtendDeadlineTerminalNode()
+        {
+            SetupOneTimeTerminalNode("Extend Deadline",
+                                    true,
+                                    cfg.EXTEND_DEADLINE_ENABLED,
+                                    cfg.EXTEND_DEADLINE_PRICE,
+                                    "Extends the deadline by a specified amount of days.");
         }
         private void SetupPagerTerminalNode()
         {

--- a/MoreShipUpgrades/Misc/AssetBundleHandler.cs
+++ b/MoreShipUpgrades/Misc/AssetBundleHandler.cs
@@ -42,6 +42,7 @@ namespace MoreShipUpgrades.Misc
             { pagerScript.UPGRADE_NAME, "Assets/ShipUpgrades/Pager.prefab" },
             { lockSmithScript.UPGRADE_NAME, "Assets/ShipUpgrades/LockSmith.prefab" },
             { playerHealthScript.UPGRADE_NAME, "Assets/ShipUpgrades/PlayerHealth.prefab" },
+            { ExtendDeadlineScript.UPGRADE_NAME, "Assets/ShipUpgrades/ExtendDeadline.prefab" },
 
             { "Advanced Portable Tele", "Assets/ShipUpgrades/TpButtonAdv.asset" },
             { "Portable Tele", "Assets/ShipUpgrades/TpButton.asset" },

--- a/MoreShipUpgrades/Misc/CommandParser.cs
+++ b/MoreShipUpgrades/Misc/CommandParser.cs
@@ -377,10 +377,13 @@ namespace MoreShipUpgrades.Misc
                 default: return outputNode;
             }
         }
-        private static TerminalNode ExecuteExtendDeadlineCommand(string daysString, ref Terminal terminal)
+        private static TerminalNode ExecuteExtendDeadlineCommand(string daysString, ref Terminal terminal, ref TerminalNode outputNode)
         {
+            if (!UpgradeBus.instance.cfg.EXTEND_DEADLINE_ENABLED) return outputNode;
+
             if (daysString == "")
                 return DisplayTerminalMessage($"You need to specify how many days you wish to extend the deadline for: \"extend deadline <days>\"");
+
             if (!(int.TryParse(daysString, out int days) && days > 0)) 
                 return DisplayTerminalMessage($"Invalid value ({daysString}) inserted to extend the deadline.\n");
 
@@ -397,7 +400,7 @@ namespace MoreShipUpgrades.Misc
         {
             switch(secondWord)
             {
-                case "deadline": return ExecuteExtendDeadlineCommand(thirdWord, ref terminal);
+                case "deadline": return ExecuteExtendDeadlineCommand(thirdWord, ref terminal, ref outputNode);
                 default: return outputNode;
             }
         }

--- a/MoreShipUpgrades/Misc/CommandParser.cs
+++ b/MoreShipUpgrades/Misc/CommandParser.cs
@@ -377,11 +377,34 @@ namespace MoreShipUpgrades.Misc
                 default: return outputNode;
             }
         }
+        private static TerminalNode ExecuteExtendDeadlineCommand(string daysString, ref Terminal terminal)
+        {
+            if (!(int.TryParse(daysString, out int days) && days > 0)) 
+                return DisplayTerminalMessage($"Invalid value ({daysString}) inserted to extend the deadline.\n");
+
+            if (terminal.groupCredits < days * UpgradeBus.instance.cfg.EXTEND_DEADLINE_PRICE) 
+                return DisplayTerminalMessage($"Not enough credits to purchase the proposed deadline extension.\n Total price: {days * UpgradeBus.instance.cfg.EXTEND_DEADLINE_PRICE}\n Current credits: {terminal.groupCredits}\n");
+
+            terminal.groupCredits -= days * UpgradeBus.instance.cfg.EXTEND_DEADLINE_PRICE;
+            LGUStore.instance.SyncCreditsServerRpc(terminal.groupCredits);
+            UpgradeBus.instance.extendScript.ExtendDeadlineClientRpc(days);
+
+            return DisplayTerminalMessage($"Extended the deadline by {days} day{(days == 1 ? "" : "s")}");
+        }
+        private static TerminalNode ExecuteExtendCommands(string secondWord, string thirdWord, ref Terminal terminal, ref TerminalNode outputNode)
+        {
+            switch(secondWord)
+            {
+                case "deadline": return ExecuteExtendDeadlineCommand(thirdWord, ref terminal);
+                default: return outputNode;
+            }
+        }
         public static void ParseLGUCommands(string fullText, ref Terminal terminal, ref TerminalNode outputNode)
         {
             string[] textArray = fullText.Split();
             string firstWord = textArray[0].ToLower();
             string secondWord = textArray.Length > 1 ? textArray[1].ToLower() : "";
+            string thirdWord = textArray.Length > 2 ? textArray[2].ToLower() : "";
             switch(firstWord)
             {
                 case "help": if (!outputNode.displayText.Contains(">LATEGAME\nDisplays information related with Lategame-Upgrades mod\n")) outputNode.displayText += ">LATEGAME\nDisplays information related with Lategame-Upgrades mod\n"; return;
@@ -397,6 +420,7 @@ namespace MoreShipUpgrades.Misc
                 case "synccredits": outputNode = ExecuteSyncCredits(ref terminal); return;
                 case "intern":
                 case "interns": outputNode = ExecuteInternsCommand(ref terminal); return;
+                case "extend": outputNode = ExecuteExtendCommands(secondWord, thirdWord, ref terminal, ref outputNode); return;
                 case "load": outputNode = ExecuteLoadCommands(secondWord, fullText, ref terminal, ref outputNode); return;
                 case "scan": outputNode = ExecuteScanCommands(secondWord, ref outputNode); return;
                 case "transmit": outputNode = ExecuteTransmitMessage(fullText.Substring(firstWord.Length+1), ref outputNode); return;

--- a/MoreShipUpgrades/Misc/CommandParser.cs
+++ b/MoreShipUpgrades/Misc/CommandParser.cs
@@ -379,6 +379,8 @@ namespace MoreShipUpgrades.Misc
         }
         private static TerminalNode ExecuteExtendDeadlineCommand(string daysString, ref Terminal terminal)
         {
+            if (daysString == "")
+                return DisplayTerminalMessage($"You need to specify how many days you wish to extend the deadline for: \"extend deadline <days>\"");
             if (!(int.TryParse(daysString, out int days) && days > 0)) 
                 return DisplayTerminalMessage($"Invalid value ({daysString}) inserted to extend the deadline.\n");
 

--- a/MoreShipUpgrades/Misc/CustomTerminalNode.cs
+++ b/MoreShipUpgrades/Misc/CustomTerminalNode.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace MoreShipUpgrades.Misc
 {
-    public class CustomTerminalNode
+    public class CustomTerminalNode : IComparable
     {
         public string Name;
         public int[] Prices;
@@ -41,6 +41,14 @@ namespace MoreShipUpgrades.Misc
                 Prices,
                 MaxUpgrade
             );
+        }
+
+        public int CompareTo(object obj)
+        {
+            if (obj == null) return -1;
+            if (obj is not CustomTerminalNode) return -1;
+            CustomTerminalNode other = obj as CustomTerminalNode;
+            return Name.CompareTo(other.Name);
         }
     }
 }

--- a/MoreShipUpgrades/Misc/PluginConfig.cs
+++ b/MoreShipUpgrades/Misc/PluginConfig.cs
@@ -28,6 +28,8 @@ namespace MoreShipUpgrades.Misc
         public bool LIGHTNING_ROD_ENABLED { get; set; }
         public bool HUNTER_ENABLED { get; set; }
         public bool PLAYER_HEALTH_ENABLED { get; set; }
+        public bool PEEPER_ENABLED { get; set; }
+        public bool EXTEND_DEADLINE_ENABLED { get; set; }
 
         // individual or shared
         public bool ADVANCED_TELE_INDIVIDUAL { get; set; }
@@ -48,7 +50,6 @@ namespace MoreShipUpgrades.Misc
         public bool MALWARE_BROADCASTER_INDIVIDUAL { get; set; }
         public bool INTERN_INDIVIDUAL { get; set; }
         public bool LOCKSMITH_INDIVIDUAL { get; set; }
-        public bool PEEPER_ENABLED { get; set; }
 
         // prices
         public int PEEPER_PRICE { get; set; }
@@ -69,6 +70,7 @@ namespace MoreShipUpgrades.Misc
         public int WALKIE_PRICE { get; set; }
         public int LIGHTNING_ROD_PRICE { get; set; }
         public int PLAYER_HEALTH_PRICE { get; set; }
+        public int EXTEND_DEADLINE_PRICE { get; set; }
 
         // attributes
         public float BIGGER_LUNGS_STAMINA_REGEN_INCREASE { get; set; }
@@ -222,7 +224,11 @@ namespace MoreShipUpgrades.Misc
             BIGGER_LUNGS_INDIVIDUAL = ConfigEntry(topSection, BaseUpgrade.INDIVIDUAL_SECTION, BaseUpgrade.INDIVIDUAL_DEFAULT, BaseUpgrade.INDIVIDUAL_DESCRIPTION);
             BIGGER_LUNGS_STAMINA_REGEN_INCREASE = ConfigEntry(topSection, "Stamina Regeneration Increase", 1.05f, "Increase of stamina regeneration applied past level 1");
             BIGGER_LUNGS_JUMP_STAMINA_COST_DECREASE = ConfigEntry(topSection, "Stamina cost decrease on jumps", 0.90f, "Multiplied with the vanilla cost of jumping");
-          
+
+            topSection = "Extend Deadline";
+            EXTEND_DEADLINE_ENABLED = ConfigEntry(topSection, "Enable Extend Deadline Purchase", true, "Increments the amount of days before deadline is reached.");
+            EXTEND_DEADLINE_PRICE = ConfigEntry(topSection, "Extend Deadline Price", 1500, "Price of each day extension requested in the terminal.");
+
             topSection = runningShoeScript.UPGRADE_NAME;
             RUNNING_SHOES_ENABLED = ConfigEntry(topSection, "Enable Running Shoes Upgrade", true, "Run Faster");
             RUNNING_SHOES_PRICE = ConfigEntry(topSection, "Price of Running Shoes Upgrade", 650, "");

--- a/MoreShipUpgrades/Patches/RoundManagerPatcher.cs
+++ b/MoreShipUpgrades/Patches/RoundManagerPatcher.cs
@@ -1,5 +1,4 @@
 ﻿using HarmonyLib;
-using MoreShipUpgrades.Managers;
 using MoreShipUpgrades.Misc;
 
 namespace MoreShipUpgrades.Patches
@@ -7,6 +6,35 @@ namespace MoreShipUpgrades.Patches
     [HarmonyPatch(typeof(RoundManager))]
     internal class RoundManagerPatcher
     {
+        private static int previousDaysDeadline = TimeOfDay.Instance.daysUntilDeadline;
+        private static int DEFAULT_DAYS_DEADLINE = 3;
+        private static bool savedPrevious = false;
+        private static LGULogger logger = new LGULogger(nameof(RoundManagerPatcher));
 
+        /// <summary>
+        /// Shoutout to ustaalon (https://github.com/ustaalon) for pointing out the issue when increasing the amount of days before deadline affecting
+        /// the enemy spawning
+        /// </summary>
+        [HarmonyPatch("PlotOutEnemiesForNextHour")]
+        [HarmonyPatch("AdvanceHourAndSpawnNewBatchOfEnemies")]
+        [HarmonyPrefix]
+        public static void ChangeDaysForEnemySpawns()
+        {
+            logger.LogDebug("Changing deadline to allow spawning enemies.");
+            previousDaysDeadline = TimeOfDay.Instance.daysUntilDeadline;
+            TimeOfDay.Instance.daysUntilDeadline %= DEFAULT_DAYS_DEADLINE;
+            savedPrevious = true;
+        }
+
+        [HarmonyPatch("PlotOutEnemiesForNextHour")]
+        [HarmonyPatch("AdvanceHourAndSpawnNewBatchOfEnemies")]
+        [HarmonyPostfix]
+        public static void UndoChangeDaysForEnemySpawns()
+        {
+            if (!savedPrevious) return;
+            TimeOfDay.Instance.daysUntilDeadline = previousDaysDeadline;
+            savedPrevious = false;
+
+        }
     }
 }

--- a/MoreShipUpgrades/Plugin.cs
+++ b/MoreShipUpgrades/Plugin.cs
@@ -313,6 +313,7 @@ namespace MoreShipUpgrades
             SetupLocksmith();
             SetupPlayerHealth();
             SetupHunter();
+            SetupExtendDeadline();
         }
         private void SetupBeekeeper()
         {
@@ -385,6 +386,10 @@ namespace MoreShipUpgrades
         private void SetupPlayerHealth()
         {
             SetupGenericPerk<playerHealthScript>(playerHealthScript.UPGRADE_NAME);
+        }
+        private void SetupExtendDeadline()
+        {
+            SetupGenericPerk<ExtendDeadlineScript>(ExtendDeadlineScript.UPGRADE_NAME);
         }
         /// <summary>
         /// Generic function where it adds a script (specificed through the type) into an GameObject asset 

--- a/MoreShipUpgrades/UpgradeComponents/ExtendDeadlineScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/ExtendDeadlineScript.cs
@@ -1,0 +1,35 @@
+﻿using MoreShipUpgrades.Managers;
+using MoreShipUpgrades.Misc;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Unity.Netcode;
+
+namespace MoreShipUpgrades.UpgradeComponents
+{
+    public class ExtendDeadlineScript : BaseUpgrade
+    {
+        public static string UPGRADE_NAME = "Extend Deadline";
+        public static string ENABLED_SECTION = $"Enable {UPGRADE_NAME}";
+        void Start()
+        {
+            upgradeName = UPGRADE_NAME;
+            DontDestroyOnLoad(gameObject);
+            Register();
+            UpgradeBus.instance.extendScript = this;
+        }
+
+        public override void Register()
+        {
+            base.Register();
+        }
+
+        [ClientRpc]
+        public void ExtendDeadlineClientRpc(int days)
+        {
+            TimeOfDay.Instance.timeUntilDeadline += TimeOfDay.Instance.totalTime * days;
+            TimeOfDay.Instance.UpdateProfitQuotaCurrentTime();
+            TimeOfDay.Instance.SyncTimeClientRpc(TimeOfDay.Instance.globalTime, (int)TimeOfDay.Instance.timeUntilDeadline);
+        }
+    }
+}


### PR DESCRIPTION
- Displayed in the ``lgu`` and ``lategame store`` command with the name of ``Extend Deadline``
- Info of "Extend Deadline" tells the user that they can increase the days before deadline by x amount (so long as they have the credits for it)
- Allows the lobby to purchase x amount of days to go scavenging for more scrap.
- Configuration
- Enabled (default: true)
- Price of each day ( default: 1500)

Since it was given as a [suggestion](https://github.com/Malcolm-Q/LC-LateGameUpgrades/issues/127) 