### PR TITLE
Added Configuration to the Hunter Upgrade

### DIFF
--- a/MoreShipUpgrades/Managers/UpgradeBus.cs
+++ b/MoreShipUpgrades/Managers/UpgradeBus.cs
@@ -387,11 +387,12 @@ namespace MoreShipUpgrades.Managers
         }
         private void SetupHunterTerminalNode()
         {
+            hunterScript.SetupTierList();
             SetupMultiplePurchasableTerminalNode(hunterScript.UPGRADE_NAME,
                                                 true,
                                                 cfg.HUNTER_ENABLED,
                                                 cfg.HUNTER_PRICE,
-                                                new int[] { cfg.HUNTER_PRICE2, cfg.HUNTER_PRICE3 });
+                                                ParseUpgradePrices(cfg.HUNTER_UPGRADE_PRICES));
         }
         private void SetupBetterScannerTerminalNode()
         {

--- a/MoreShipUpgrades/Misc/AssetBundleHandler.cs
+++ b/MoreShipUpgrades/Misc/AssetBundleHandler.cs
@@ -15,13 +15,13 @@ namespace MoreShipUpgrades.Misc
         private static Dictionary<string, string> infoJSON;
         public static Dictionary<string, string> samplePaths = new Dictionary<string, string>()
         {
-            { "Centipede", "Assets/ShipUpgrades/Samples/SnareFleaSample.asset" },
-            { "Bunker Spider", "Assets/ShipUpgrades/Samples/BunkerSpiderSample.asset" },
-            { "Hoarding bug", "Assets/ShipUpgrades/Samples/HoardingBugSample.asset" },
-            { "Flowerman", "Assets/ShipUpgrades/Samples/BrackenSample.asset" },
-            { "MouthDog", "Assets/ShipUpgrades/Samples/EyelessDogSample.asset" },
-            { "Baboon hawk", "Assets/ShipUpgrades/Samples/BaboonHawkSample.asset" },
-            { "Crawler", "Assets/ShipUpgrades/Samples/ThumperSample.asset" },
+            { "centipede", "Assets/ShipUpgrades/Samples/SnareFleaSample.asset" },
+            { "bunker spider", "Assets/ShipUpgrades/Samples/BunkerSpiderSample.asset" },
+            { "hoarding bug", "Assets/ShipUpgrades/Samples/HoardingBugSample.asset" },
+            { "flowerman", "Assets/ShipUpgrades/Samples/BrackenSample.asset" },
+            { "mouthdog", "Assets/ShipUpgrades/Samples/EyelessDogSample.asset" },
+            { "baboon hawk", "Assets/ShipUpgrades/Samples/BaboonHawkSample.asset" },
+            { "crawler", "Assets/ShipUpgrades/Samples/ThumperSample.asset" },
         };
         private static Dictionary<string, string> assetPaths = new Dictionary<string, string>()
         {

--- a/MoreShipUpgrades/Misc/PluginConfig.cs
+++ b/MoreShipUpgrades/Misc/PluginConfig.cs
@@ -2,6 +2,7 @@
 using System;
 using Newtonsoft.Json;
 using MoreShipUpgrades.UpgradeComponents;
+using System.Collections.Generic;
 
 
 namespace MoreShipUpgrades.Misc
@@ -74,8 +75,6 @@ namespace MoreShipUpgrades.Misc
         public float BIGGER_LUNGS_STAMINA_REGEN_INCREASE { get; set; }
         public float BIGGER_LUNGS_JUMP_STAMINA_COST_DECREASE { get; set; }
         public int PROTEIN_INCREMENT { get; set; }
-        public int HUNTER_PRICE2 { get; set; }
-        public int HUNTER_PRICE3 { get; set; }
         public bool KEEP_ITEMS_ON_TELE { get; set; }
         public float SPRINT_TIME_INCREASE { get; set; }
         public float MOVEMENT_SPEED { get; set; }
@@ -135,6 +134,8 @@ namespace MoreShipUpgrades.Misc
         public string DISCO_UPGRADE_PRICES { get; set; }
         public string PROTEIN_UPGRADE_PRICES { get; set; }
         public string PLAYER_HEALTH_UPGRADE_PRICES { get; set; }
+        public string HUNTER_UPGRADE_PRICES { get; set; }
+        public string HUNTER_SAMPLE_TIERS {  get; set; }
         public bool SHARED_UPGRADES { get; set; }
         public bool WALKIE_ENABLED { get; set; }
         public bool WALKIE_INDIVIDUAL { get; set; }
@@ -164,13 +165,27 @@ namespace MoreShipUpgrades.Misc
         public int DISCOMBOBULATOR_DAMAGE_INCREASE { get; set; }
         public float STRONG_LEGS_REDUCE_FALL_DAMAGE_MULTIPLIER { get; set; }
         public bool KEEP_UPGRADES_AFTER_FIRED_CUTSCENE { get; set; }
+        public int SNARE_FLEA_SAMPLE_MINIMUM_VALUE { get; set; }
+        public int SNARE_FLEA_SAMPLE_MAXIMUM_VALUE { get; set; }
+        public int BUNKER_SPIDER_SAMPLE_MINIMUM_VALUE { get; set; }
+        public int BUNKER_SPIDER_SAMPLE_MAXIMUM_VALUE { get; set; }
+        public int HOARDING_BUG_SAMPLE_MINIMUM_VALUE { get; set; }
+        public int HOARDING_BUG_SAMPLE_MAXIMUM_VALUE { get; set; }
+        public int BRACKEN_SAMPLE_MINIMUM_VALUE { get; set; }
+        public int BRACKEN_SAMPLE_MAXIMUM_VALUE { get; set; }
+        public int EYELESS_DOG_SAMPLE_MINIMUM_VALUE { get; set; }
+        public int EYELESS_DOG_SAMPLE_MAXIMUM_VALUE { get; set; }
+        public int BABOON_HAWK_SAMPLE_MINIMUM_VALUE { get; set; }
+        public int BABOON_HAWK_SAMPLE_MAXIMUM_VALUE { get; set; }
+        public int THUMPER_SAMPLE_MINIMUM_VALUE { get; set; }
+        public int THUMPER_SAMPLE_MAXIMUM_VALUE { get; set; }
 
         public PluginConfig(ConfigFile cfg)
         {
             configFile = cfg;
         }
 
-        private T ConfigEntry<T>(string section, string key, T defaultVal, string description)
+        private T ConfigEntry<T>(string section, string key, T defaultVal, string description = "")
         {
             return configFile.Bind(section, key, defaultVal, description).Value;
         }
@@ -336,8 +351,25 @@ namespace MoreShipUpgrades.Misc
             topSection = hunterScript.UPGRADE_NAME;
             HUNTER_ENABLED = ConfigEntry(topSection, "Enable the Hunter upgrade", true, "Collect and sell samples from dead enemies");
             HUNTER_PRICE = ConfigEntry(topSection, "Hunter price", 700, "Default price for upgrade.");
-            HUNTER_PRICE2 = ConfigEntry(topSection, "Second Hunter level price", 500, "");
-            HUNTER_PRICE3 = ConfigEntry(topSection, "Third Hunter level price", 600, "");
+            HUNTER_UPGRADE_PRICES = ConfigEntry(topSection, BaseUpgrade.PRICES_SECTION, "500,600", BaseUpgrade.PRICES_DESCRIPTION);
+            HUNTER_SAMPLE_TIERS = ConfigEntry(topSection,
+                                            "Samples dropping at each tier",
+                                            "Hoarding Bug, Centipede-Bunker Spider, Baboon hawk-Flowerman, MouthDog, Crawler",
+                                            "Specifies at which tier of Hunter do each sample start dropping from. Each tier is separated with a dash ('-') and each list of monsters will be separated with a comma (',')\nSupported Enemies: Hoarding Bug, Centipede (Snare Flea),Bunker Spider, Baboon Hawk, Crawler (Half/Thumper), Flowerman (Bracken) and MouthDog (Eyeless Dog)");
+            SNARE_FLEA_SAMPLE_MINIMUM_VALUE = ConfigEntry(topSection, "Minimum scrap value of a Snare Flea sample", 35);
+            SNARE_FLEA_SAMPLE_MAXIMUM_VALUE = ConfigEntry(topSection, "Maximum scrap value of a Snare Flea sample", 60);
+            BUNKER_SPIDER_SAMPLE_MINIMUM_VALUE = ConfigEntry(topSection, "Minimum scrap value of a Bunker Spider sample", 65);
+            BUNKER_SPIDER_SAMPLE_MAXIMUM_VALUE = ConfigEntry(topSection, "Maximum scrap value of a Bunker Spider sample", 95);
+            HOARDING_BUG_SAMPLE_MINIMUM_VALUE = ConfigEntry(topSection, "Minimum scrap value of a Hoarding Bug sample", 45);
+            HOARDING_BUG_SAMPLE_MAXIMUM_VALUE = ConfigEntry(topSection, "Maximum scrap value of a Hoarding Bug sample", 75);
+            BRACKEN_SAMPLE_MINIMUM_VALUE = ConfigEntry(topSection, "Minimum scrap value of a Bracken sample", 80);
+            BRACKEN_SAMPLE_MAXIMUM_VALUE = ConfigEntry(topSection, "Maximum scrap value of a Bracken sample", 125);
+            EYELESS_DOG_SAMPLE_MINIMUM_VALUE = ConfigEntry(topSection, "Minimum scrap value of a Eyeless Dog sample", 100);
+            EYELESS_DOG_SAMPLE_MAXIMUM_VALUE = ConfigEntry(topSection, "Maximum scrap value of a Eyeless Dog sample", 150);
+            BABOON_HAWK_SAMPLE_MINIMUM_VALUE = ConfigEntry(topSection, "Minimum scrap value of a Baboon Hawk sample", 75);
+            BABOON_HAWK_SAMPLE_MAXIMUM_VALUE = ConfigEntry(topSection, "Maximum scrap value of a Baboon Hawk sample", 115);
+            THUMPER_SAMPLE_MINIMUM_VALUE = ConfigEntry(topSection, "Minimum scrap value of a Half sample", 80);
+            THUMPER_SAMPLE_MAXIMUM_VALUE = ConfigEntry(topSection, "Maximum scrap value of a Half sample", 125);
 
             topSection = playerHealthScript.UPGRADE_NAME;
             PLAYER_HEALTH_ENABLED = ConfigEntry(topSection, playerHealthScript.ENABLED_SECTION, playerHealthScript.ENABLED_DEFAULT, playerHealthScript.ENABLED_DESCRIPTION);

--- a/MoreShipUpgrades/Patches/EnemyAIPatcher.cs
+++ b/MoreShipUpgrades/Patches/EnemyAIPatcher.cs
@@ -20,10 +20,11 @@ namespace MoreShipUpgrades.Patches
             if (currentEnemy == __instance.NetworkObject.NetworkObjectId) return;
             currentEnemy = __instance.NetworkObject.NetworkObjectId;
             string name = __instance.enemyType.enemyName;
-            if (!(UpgradeBus.instance.hunter && hunterScript.tiers[UpgradeBus.instance.huntLevel].Contains(name))) return;
+
+            if (!(UpgradeBus.instance.hunter && hunterScript.tiers[UpgradeBus.instance.huntLevel].Contains(name.ToLower()))) return;
 
             logger.LogDebug($"Spawning sample for {name}");
-            GameObject go = Object.Instantiate(UpgradeBus.instance.samplePrefabs[name],__instance.transform.position + Vector3.up,Quaternion.identity);
+            GameObject go = Object.Instantiate(UpgradeBus.instance.samplePrefabs[name.ToLower()],__instance.transform.position + Vector3.up,Quaternion.identity);
             PhysicsProp prop = go.GetComponent<PhysicsProp>();
             int value = Random.Range(prop.itemProperties.minValue, prop.itemProperties.maxValue);
             go.GetComponent<NetworkObject>().Spawn();

--- a/MoreShipUpgrades/Plugin.cs
+++ b/MoreShipUpgrades/Plugin.cs
@@ -130,6 +130,26 @@ namespace MoreShipUpgrades
         }
         private void SetupSamples()
         {
+            Dictionary<string, int> MINIMUM_VALUES = new Dictionary<string, int>()
+            {
+                { "centipede", cfg.SNARE_FLEA_SAMPLE_MINIMUM_VALUE },
+                { "bunker spider", cfg.BUNKER_SPIDER_SAMPLE_MINIMUM_VALUE },
+                { "hoarding bug", cfg.HOARDING_BUG_SAMPLE_MINIMUM_VALUE },
+                { "flowerman", cfg.BRACKEN_SAMPLE_MINIMUM_VALUE },
+                { "mouthdog", cfg.EYELESS_DOG_SAMPLE_MINIMUM_VALUE },
+                { "baboon hawk", cfg.BABOON_HAWK_SAMPLE_MINIMUM_VALUE },
+                { "crawler", cfg.THUMPER_SAMPLE_MINIMUM_VALUE },
+            };
+            Dictionary<string, int> MAXIMUM_VALUES = new Dictionary<string, int>()
+            {
+                { "centipede", cfg.SNARE_FLEA_SAMPLE_MAXIMUM_VALUE },
+                { "bunker spider", cfg.BUNKER_SPIDER_SAMPLE_MAXIMUM_VALUE },
+                { "hoarding bug", cfg.HOARDING_BUG_SAMPLE_MAXIMUM_VALUE },
+                { "flowerman", cfg.BRACKEN_SAMPLE_MAXIMUM_VALUE },
+                { "mouthdog", cfg.EYELESS_DOG_SAMPLE_MAXIMUM_VALUE },
+                { "baboon hawk", cfg.BABOON_HAWK_SAMPLE_MAXIMUM_VALUE },
+                { "crawler", cfg.THUMPER_SAMPLE_MAXIMUM_VALUE },
+            };
             foreach (string creatureName in AssetBundleHandler.samplePaths.Keys)
             {
                 Item sample = AssetBundleHandler.GetItemObject(creatureName);
@@ -137,6 +157,8 @@ namespace MoreShipUpgrades
                 sampleScript.grabbable = true;
                 sampleScript.grabbableToEnemies = true;
                 sampleScript.itemProperties = sample;
+                sampleScript.itemProperties.minValue = MINIMUM_VALUES[creatureName];
+                sampleScript.itemProperties.maxValue = MAXIMUM_VALUES[creatureName];
                 LethalLib.Modules.NetworkPrefabs.RegisterNetworkPrefab(sample.spawnPrefab);
                 UpgradeBus.instance.samplePrefabs.Add(creatureName, sample.spawnPrefab);
             }

--- a/MoreShipUpgrades/UpgradeComponents/hunterScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/hunterScript.cs
@@ -1,5 +1,6 @@
 ﻿using MoreShipUpgrades.Managers;
 using MoreShipUpgrades.Misc;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -8,26 +9,44 @@ namespace MoreShipUpgrades.UpgradeComponents
     internal class hunterScript : BaseUpgrade
     {
         public static string UPGRADE_NAME = "Hunter";
-
-        static string[] lvl1 = new string[] { "Hoarding bug", "Centipede" };
-        static string[] lvl2 = new string[] { "Bunker Spider", "Hoarding bug", "Centipede", "Baboon hawk" };
-        static string[] lvl3 = new string[] { "Bunker Spider", "Hoarding bug", "Centipede", "Baboon hawk", "Flowerman", "Crawler", "MouthDog" };
+        private static LGULogger logger = new LGULogger(UPGRADE_NAME);
         static Dictionary<string, string> monsterNames = new Dictionary<string, string>()
             {
-            { "Hoarding bug", "Hoarding Bug" },
-            { "Centipede", "Snare Flea" },
-            { "Bunker Spider", "Bunker Spider" },
-            { "Baboon hawk", "Baboon Hawk" },
-            { "Flowerman", "Bracken" },
-            { "Crawler", "Half/Thumper" },
-            { "MouthDog", "Eyeless Dog" },
+            { "hoarding", "Hoarding Bug" },
+            { "hoarding bug", "Hoarding Bug" },
+            { "snare", "Snare Flea" },
+            { "flea", "Snare Flea" },
+            { "snare flea", "Snare Flea" },
+            { "centipede", "Snare Flea" },
+            { "bunker spider", "Bunker Spider" },
+            { "bunker", "Bunker Spider" },
+            { "bunk", "Bunker Spider" },
+            { "spider", "Bunker Spider" },
+            { "baboon hawk", "Baboon Hawk" },
+            { "baboon", "Baboon Hawk" },
+            { "hawk", "Baboon Hawk" },
+            { "flowerman", "Bracken" },
+            { "bracken", "Bracken" },
+            { "crawler", "Half/Thumper" },
+            { "half", "Half/Thumper" },
+            { "thumper", "Half/Thumper" },
+            { "mouthdog", "Eyeless Dog" },
+            { "eyeless dog", "Eyeless Dog" },
+            { "eyeless", "Eyeless Dog" },
+            { "dog", "Eyeless Dog" },
             };
-        static public Dictionary<int, string[]> tiers = new Dictionary<int, string[]>
+        static public Dictionary<int, string[]> tiers;
+        public static void SetupTierList()
         {
-            {0,  lvl1 },
-            {1, lvl2 },
-            {2, lvl3 },
-        };
+            logger = new LGULogger(UPGRADE_NAME);
+            tiers = new Dictionary<int, string[]>();
+            string[] tiersList = UpgradeBus.instance.cfg.HUNTER_SAMPLE_TIERS.ToLower().Split('-');
+            tiers[0] = tiersList[0].Split(",");
+            for (int i = 1; i < tiersList.Length; i++)
+            {
+                tiers[i] = tiers[i - 1].Concat(tiersList[i].Split(",")).ToArray();
+            }
+        }
         void Start()
         {
             upgradeName = UPGRADE_NAME;
@@ -66,7 +85,9 @@ namespace MoreShipUpgrades.UpgradeComponents
             string result = "";
             foreach (string monsterTypeName in enems.Split(", "))
             {
-                result += monsterNames[monsterTypeName] + ", ";
+                logger.LogDebug(monsterTypeName.Trim().ToLower());
+                logger.LogDebug(monsterNames[monsterTypeName.Trim().ToLower()]);
+                result += monsterNames[monsterTypeName.Trim().ToLower()] + ", ";
             }
             result = result.Substring(0, result.Length - 2);
             result += "\n";


### PR DESCRIPTION
Namely how many tiers it can have (through the amount of prices inserted in the configuration); At which tier each sample can spawn at (through a list of lists where each tier is separated by dashes and each sample is separated by commas) And the minimum/maximum scrap value each sample can have.

Implemented for given [suggestion](https://github.com/Malcolm-Q/LC-LateGameUpgrades/issues/83)