### PR TITLE
Changed logic of Running Shoes, Bigger Lungs and Strong Legs configuration values

### DIFF
--- a/MoreShipUpgrades/Managers/UpgradeBus.cs
+++ b/MoreShipUpgrades/Managers/UpgradeBus.cs
@@ -70,9 +70,9 @@ namespace MoreShipUpgrades.Managers
         {
             { exoskeletonScript.UPGRADE_NAME, level => (instance.cfg.CARRY_WEIGHT_REDUCTION - (level * instance.cfg.CARRY_WEIGHT_INCREMENT)) * 100 },
             { terminalFlashScript.UPGRADE_NAME, level => instance.cfg.DISCOMBOBULATOR_STUN_DURATION + (level * instance.cfg.DISCOMBOBULATOR_INCREMENT) },
-            { strongLegsScript.UPGRADE_NAME, level =>  instance.cfg.JUMP_FORCE + (level * instance.cfg.JUMP_FORCE_INCREMENT) - 13f },
-            { runningShoeScript.UPGRADE_NAME, level => instance.cfg.MOVEMENT_SPEED + (level * instance.cfg.MOVEMENT_INCREMENT) - 4.6f },
-            { biggerLungScript.UPGRADE_NAME, level => instance.cfg.SPRINT_TIME_INCREASE + (level * instance.cfg.SPRINT_TIME_INCREMENT) - 11f },
+            { strongLegsScript.UPGRADE_NAME, level =>  instance.cfg.JUMP_FORCE_UNLOCK + (level * instance.cfg.JUMP_FORCE_INCREMENT) },
+            { runningShoeScript.UPGRADE_NAME, level => instance.cfg.MOVEMENT_SPEED_UNLOCK + (level * instance.cfg.MOVEMENT_INCREMENT) },
+            { biggerLungScript.UPGRADE_NAME, level => instance.cfg.SPRINT_TIME_INCREASE_UNLOCK + (level * instance.cfg.SPRINT_TIME_INCREMENT) },
             { proteinPowderScript.UPGRADE_NAME, level => instance.cfg.PROTEIN_UNLOCK_FORCE + 1 + (instance.cfg.PROTEIN_INCREMENT * level) },
             { beekeeperScript.UPGRADE_NAME, level => 100 * (instance.cfg.BEEKEEPER_DAMAGE_MULTIPLIER - (level * instance.cfg.BEEKEEPER_DAMAGE_MULTIPLIER_INCREMENT)) },
             { playerHealthScript.UPGRADE_NAME, level => instance.cfg.PLAYER_HEALTH_ADDITIONAL_HEALTH_UNLOCK + (level)*instance.cfg.PLAYER_HEALTH_ADDITIONAL_HEALTH_INCREMENT },

--- a/MoreShipUpgrades/Misc/CommandParser.cs
+++ b/MoreShipUpgrades/Misc/CommandParser.cs
@@ -194,6 +194,7 @@ namespace MoreShipUpgrades.Misc
             UpgradeBus.instance.UpgradeObjects[customNode.Name].GetComponent<BaseUpgrade>().Unwind();
             LGUStore.instance.UpdateLGUSaveServerRpc(GameNetworkManager.Instance.localPlayerController.playerSteamId, JsonConvert.SerializeObject(new SaveInfo()));
             customNode.Unlocked = false;
+            customNode.CurrentUpgrade = 0;
             return DisplayTerminalMessage($"Unwinding {customNode.Name.ToLower()}\n\n");
         }
 

--- a/MoreShipUpgrades/Misc/PluginConfig.cs
+++ b/MoreShipUpgrades/Misc/PluginConfig.cs
@@ -77,9 +77,9 @@ namespace MoreShipUpgrades.Misc
         public int HUNTER_PRICE2 { get; set; }
         public int HUNTER_PRICE3 { get; set; }
         public bool KEEP_ITEMS_ON_TELE { get; set; }
-        public float SPRINT_TIME_INCREASE { get; set; }
-        public float MOVEMENT_SPEED { get; set; }
-        public float JUMP_FORCE { get; set; }
+        public float SPRINT_TIME_INCREASE_UNLOCK { get; set; }
+        public float MOVEMENT_SPEED_UNLOCK { get; set; }
+        public float JUMP_FORCE_UNLOCK { get; set; }
         public bool DESTROY_TRAP { get; set; }
         public float DISARM_TIME { get; set; }
         public bool EXPLODE_TRAP { get; set; }
@@ -216,8 +216,8 @@ namespace MoreShipUpgrades.Misc
             topSection = biggerLungScript.UPGRADE_NAME;
             BIGGER_LUNGS_ENABLED = ConfigEntry(topSection, "Enable Bigger Lungs Upgrade", true, "More Stamina");
             BIGGER_LUNGS_PRICE = ConfigEntry(topSection, "Price of Bigger Lungs Upgrade", 600, "");
-            SPRINT_TIME_INCREASE = ConfigEntry(topSection, "SprintTime value", 17f, "Vanilla value is 11");
-            SPRINT_TIME_INCREMENT = ConfigEntry(topSection, "SprintTime Increment", 1.25f,"How much the above value is increased on upgrade.");
+            SPRINT_TIME_INCREASE_UNLOCK = ConfigEntry(topSection, "Sprint Time Unlock", 6f, "Amount of sprint time gained when unlocking the upgrade.\nDefault vanilla value is 11f.");
+            SPRINT_TIME_INCREMENT = ConfigEntry(topSection, "Sprint Time Increment", 1.25f,"Amount of sprint time gained when increasing the level of upgrade.");
             BIGGER_LUNGS_UPGRADE_PRICES = ConfigEntry(topSection, BaseUpgrade.PRICES_SECTION, biggerLungScript.PRICES_DEFAULT, BaseUpgrade.PRICES_DESCRIPTION);
             BIGGER_LUNGS_INDIVIDUAL = ConfigEntry(topSection, BaseUpgrade.INDIVIDUAL_SECTION, BaseUpgrade.INDIVIDUAL_DEFAULT, BaseUpgrade.INDIVIDUAL_DESCRIPTION);
             BIGGER_LUNGS_STAMINA_REGEN_INCREASE = ConfigEntry(topSection, "Stamina Regeneration Increase", 1.05f, "Increase of stamina regeneration applied past level 1");
@@ -226,7 +226,7 @@ namespace MoreShipUpgrades.Misc
             topSection = runningShoeScript.UPGRADE_NAME;
             RUNNING_SHOES_ENABLED = ConfigEntry(topSection, "Enable Running Shoes Upgrade", true, "Run Faster");
             RUNNING_SHOES_PRICE = ConfigEntry(topSection, "Price of Running Shoes Upgrade", 650, "");
-            MOVEMENT_SPEED = ConfigEntry(topSection, "Movement Speed Value", 6f, "Vanilla value is 4.6");
+            MOVEMENT_SPEED_UNLOCK = ConfigEntry(topSection, "Movement Speed Unlock", 1.4f, "Value added to player's movement speed when first purchased.\nDefault vanilla value is 4.6f.");
             MOVEMENT_INCREMENT = ConfigEntry(topSection, "Movement Speed Increment", 0.5f, "How much the above value is increased on upgrade.");
             RUNNING_SHOES_UPGRADE_PRICES = ConfigEntry(topSection, BaseUpgrade.PRICES_SECTION, biggerLungScript.PRICES_DEFAULT, BaseUpgrade.PRICES_DESCRIPTION);
             RUNNING_SHOES_INDIVIDUAL = ConfigEntry(topSection, BaseUpgrade.INDIVIDUAL_SECTION, BaseUpgrade.INDIVIDUAL_DEFAULT, BaseUpgrade.INDIVIDUAL_DESCRIPTION);
@@ -235,7 +235,7 @@ namespace MoreShipUpgrades.Misc
             topSection = strongLegsScript.UPGRADE_NAME;
             STRONG_LEGS_ENABLED = ConfigEntry(topSection, "Enable Strong Legs Upgrade", true, "Jump Higher");
             STRONG_LEGS_PRICE = ConfigEntry(topSection, "Price of Strong Legs Upgrade", 300, "");
-            JUMP_FORCE = ConfigEntry(topSection, "Jump Force", 16f, "Vanilla value is 13");
+            JUMP_FORCE_UNLOCK = ConfigEntry(topSection, "Jump Force Unlock", 3f, "Amount of jump force added when unlocking the upgrade.\nDefault vanilla value is 13f.");
             JUMP_FORCE_INCREMENT = ConfigEntry(topSection, "Jump Force Increment", 0.75f, "How much the above value is increased on upgrade.");
             STRONG_LEGS_UPGRADE_PRICES = ConfigEntry(topSection, BaseUpgrade.PRICES_SECTION, strongLegsScript.PRICES_DEFAULT, BaseUpgrade.PRICES_DESCRIPTION);
             STRONG_LEGS_INDIVIDUAL = ConfigEntry(topSection, BaseUpgrade.INDIVIDUAL_SECTION, BaseUpgrade.INDIVIDUAL_DEFAULT, BaseUpgrade.INDIVIDUAL_DESCRIPTION);

--- a/MoreShipUpgrades/Patches/DeleteButtonPatcher.cs
+++ b/MoreShipUpgrades/Patches/DeleteButtonPatcher.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using MoreShipUpgrades.Misc;
 using System.IO;
 using UnityEngine;
 
@@ -7,13 +8,14 @@ namespace MoreShipUpgrades.Patches
     [HarmonyPatch(typeof(DeleteFileButton))]
     internal class DeleteButtonPatcher
     {
+        private static LGULogger logger = new LGULogger(nameof(DeleteButtonPatcher));
         [HarmonyPostfix]
         [HarmonyPatch("DeleteFile")]
         private static void deleteLGUFile(DeleteFileButton __instance)
         {
             string filePath = Path.Combine(Application.persistentDataPath, $"LGU_{__instance.fileToDelete}.json");
             if (!File.Exists(filePath)) return;
-
+            logger.LogDebug($"Deleting LGU file located at {filePath}");
             File.Delete(filePath);
         }
     }

--- a/MoreShipUpgrades/Patches/GameNetworkManagerPatcher.cs
+++ b/MoreShipUpgrades/Patches/GameNetworkManagerPatcher.cs
@@ -8,10 +8,12 @@ namespace MoreShipUpgrades.Patches
     [HarmonyPatch(typeof(GameNetworkManager))]
     internal class GameNetworkManagerPatcher
     {
+        private static LGULogger logger = new LGULogger(nameof(GameNetworkManagerPatcher));
         [HarmonyPostfix]
         [HarmonyPatch("Disconnect")]
         private static void ResetUpgradeBus()
         {
+            logger.LogDebug("Resetting the Upgrade Bus due to disconnecting...");
             BaseUpgrade[] upgradeObjects = Object.FindObjectsOfType<BaseUpgrade>();
             foreach (BaseUpgrade upgrade in upgradeObjects)
             {
@@ -25,6 +27,7 @@ namespace MoreShipUpgrades.Patches
         private static void saveLGU(GameNetworkManager __instance)
         {
             if (!__instance.isHostingGame) return;
+            logger.LogDebug("Saving the LGU upgrades unto a json file...");
             LGUStore.instance.ServerSaveFileServerRpc();
         }
     }

--- a/MoreShipUpgrades/Patches/InteractTriggerPatcher.cs
+++ b/MoreShipUpgrades/Patches/InteractTriggerPatcher.cs
@@ -1,6 +1,7 @@
 ﻿using GameNetcodeStuff;
 using HarmonyLib;
 using MoreShipUpgrades.Managers;
+using MoreShipUpgrades.Misc;
 using Unity.Netcode;
 using UnityEngine;
 
@@ -9,6 +10,7 @@ namespace MoreShipUpgrades.Patches
     [HarmonyPatch(typeof(InteractTrigger))]
     internal class InteractTriggerPatcher
     {
+        private static LGULogger logger = new LGULogger(nameof(InteractTriggerPatcher));
         [HarmonyPrefix]
         [HarmonyPatch("OnTriggerEnter")]
         private static bool pickDoor(InteractTrigger __instance, Collider other)
@@ -22,6 +24,8 @@ namespace MoreShipUpgrades.Patches
             if(!door.isLocked) { return true; }
             if(UpgradeBus.instance.lockScript.gameObject.transform.GetChild(0).gameObject.activeInHierarchy) return true;
 
+
+            logger.LogDebug("Starting lockpicking minigame...");
             UpgradeBus.instance.lockScript.currentDoor = door;
             UpgradeBus.instance.lockScript.BeginLockPick();
             UpgradeBus.instance.lockScript.timesStruck = 0;

--- a/MoreShipUpgrades/Patches/RedLocustBeesPatch.cs
+++ b/MoreShipUpgrades/Patches/RedLocustBeesPatch.cs
@@ -41,7 +41,7 @@ namespace MoreShipUpgrades.Patches
                 codes.Insert(i - 8, new CodeInstruction(OpCodes.Call, beeReduceDamage));
                 found = true;
             }
-            if (!found) { logger.LogDebug("Did not find DamagePlayer function"); }
+            if (!found) { logger.LogError("Did not find DamagePlayer function"); }
             return codes.AsEnumerable();
         }
 
@@ -64,6 +64,7 @@ namespace MoreShipUpgrades.Patches
                 codes.Insert(i + 1, new CodeInstruction(OpCodes.Call, beeIncreaseHiveValue));
                 found = true;
             }
+            if (!found) { logger.LogError("Did not find the hive scrap value..."); }
             return codes.AsEnumerable();
         }
     }

--- a/MoreShipUpgrades/Patches/SandSpiderAIPatcher.cs
+++ b/MoreShipUpgrades/Patches/SandSpiderAIPatcher.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using MoreShipUpgrades.Misc;
 using System.Collections.Generic;
 using System.Linq;
 using static System.Reflection.Emit.OpCodes;
@@ -8,6 +9,7 @@ namespace MoreShipUpgrades.Patches
     [HarmonyPatch(typeof(SandSpiderAI))]
     internal class SandSpiderAIPatcher
     {
+        private static LGULogger logger = new LGULogger(nameof(SandSpiderAIPatcher));
         /// <summary>
         /// Transpiler for the HitEnemy function of SandSpiderAI script.
         /// This is only here for when the developer of the game solves the issue of the health decrease being affected by force instead of only being decremented by one.
@@ -30,7 +32,7 @@ namespace MoreShipUpgrades.Patches
                 codes[i] = new CodeInstruction(Ldarg_1);
                 found = true;
             }
-
+            if (!found) { logger.LogError("Did not find the health decrease instruction..."); }
             return codes.AsEnumerable();
         }
     }

--- a/MoreShipUpgrades/Patches/ShovelPatcher.cs
+++ b/MoreShipUpgrades/Patches/ShovelPatcher.cs
@@ -1,5 +1,6 @@
 ﻿using HarmonyLib;
 using MoreShipUpgrades.Managers;
+using MoreShipUpgrades.Misc;
 using MoreShipUpgrades.UpgradeComponents;
 using System;
 using System.Collections.Generic;
@@ -13,6 +14,7 @@ namespace MoreShipUpgrades.Patches
     [HarmonyPatch(typeof(Shovel))]
     internal class ShovelPatcher
     {
+        private static LGULogger logger = new LGULogger(nameof(ShovelPatcher));
         [HarmonyTranspiler]
         [HarmonyPatch("HitShovel")]
         public static IEnumerable<CodeInstruction> HitShovelTranspiler(IEnumerable<CodeInstruction> instructions)
@@ -29,6 +31,7 @@ namespace MoreShipUpgrades.Patches
                 codes.Insert(i+1, new CodeInstruction(OpCodes.Call, proteinHitFoce));
                 found = true;
             }
+            if (!found) { logger.LogError($"Did not find the hit force of the shovel to influence with {proteinPowderScript.UPGRADE_NAME}"); }
             return codes.AsEnumerable();
         }
     }

--- a/MoreShipUpgrades/Patches/SpringManAIPatcher.cs
+++ b/MoreShipUpgrades/Patches/SpringManAIPatcher.cs
@@ -5,12 +5,14 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Reflection.Emit;
 using System.Reflection;
+using MoreShipUpgrades.Misc;
 
 namespace MoreShipUpgrades.Patches
 {
     [HarmonyPatch(typeof(SpringManAI))]
     internal class SpringManAIPatcher
     {
+        private static LGULogger logger = new LGULogger(nameof(SpringManAIPatcher));
         [HarmonyPrefix]
         [HarmonyPatch("DoAIInterval")]
         private static void DoAllIntervalPrefix(ref SpringManAI __instance)
@@ -42,7 +44,7 @@ namespace MoreShipUpgrades.Patches
 
                 if (foundStopMovementFlag) break;
             }
-            if (!foundStopMovementFlag) Plugin.mls.LogError("Could not find the attribution of flag that stops movement");
+            if (!foundStopMovementFlag) logger.LogError("Could not find the attribution of flag that stops movement");
             return codes;
         }
     }

--- a/MoreShipUpgrades/Patches/StormyWeatherPatcher.cs
+++ b/MoreShipUpgrades/Patches/StormyWeatherPatcher.cs
@@ -1,5 +1,6 @@
 ﻿using HarmonyLib;
 using MoreShipUpgrades.Managers;
+using MoreShipUpgrades.Misc;
 using MoreShipUpgrades.UpgradeComponents;
 using UnityEngine;
 

--- a/MoreShipUpgrades/UpgradeComponents/biggerLungScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/biggerLungScript.cs
@@ -11,7 +11,6 @@ namespace MoreShipUpgrades.UpgradeComponents
         private static LGULogger logger = new LGULogger(UPGRADE_NAME);
         public static string UPGRADE_NAME = "Bigger Lungs";
         public static string PRICES_DEFAULT = "350,450,550";
-        private static float DEFAULT_SPRINT_TIME = 11f;
 
         void Start()
         {
@@ -24,13 +23,13 @@ namespace MoreShipUpgrades.UpgradeComponents
         {
             UpgradeBus.instance.lungLevel++;
             PlayerControllerB player = GetLocalPlayer();
-            player.sprintTime += UpgradeBus.instance.cfg.SPRINT_TIME_INCREMENT;  //17
+            player.sprintTime += UpgradeBus.instance.cfg.SPRINT_TIME_INCREMENT;
         }
 
         public override void load()
         {
             PlayerControllerB player = GetLocalPlayer();
-            player.sprintTime = UpgradeBus.instance.cfg.SPRINT_TIME_INCREASE; //17
+            player.sprintTime += UpgradeBus.instance.cfg.SPRINT_TIME_INCREASE_UNLOCK;
             UpgradeBus.instance.biggerLungs = true;
             base.load();
 
@@ -46,7 +45,7 @@ namespace MoreShipUpgrades.UpgradeComponents
         public override void Unwind()
         {
             PlayerControllerB player = GetLocalPlayer();
-            player.sprintTime = DEFAULT_SPRINT_TIME;
+            player.sprintTime -= (UpgradeBus.instance.cfg.SPRINT_TIME_INCREASE_UNLOCK + (UpgradeBus.instance.lungLevel * UpgradeBus.instance.cfg.SPRINT_TIME_INCREMENT));
             base.Unwind();
 
             UpgradeBus.instance.biggerLungs = false;

--- a/MoreShipUpgrades/UpgradeComponents/lightningRodScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/lightningRodScript.cs
@@ -85,8 +85,8 @@ namespace MoreShipUpgrades.UpgradeComponents
 
             Terminal terminal = UpgradeBus.instance.GetTerminal();
             float dist = Vector3.Distance(___targetingMetalObject.transform.position, terminal.transform.position);
-            logger.LogInfo($"Distance from ship: {dist}");
-            logger.LogInfo($"Effective distance of the lightning rod: {UpgradeBus.instance.cfg.LIGHTNING_ROD_DIST}");
+            logger.LogDebug($"Distance from ship: {dist}");
+            logger.LogDebug($"Effective distance of the lightning rod: {UpgradeBus.instance.cfg.LIGHTNING_ROD_DIST}");
 
             if (dist > UpgradeBus.instance.cfg.LIGHTNING_ROD_DIST) return;
 
@@ -94,11 +94,11 @@ namespace MoreShipUpgrades.UpgradeComponents
             float prob = 1 - dist;
             float rand = Random.value;
 
-            logger.LogInfo($"Number to beat: {prob}");
-            logger.LogInfo($"Number: {rand}");
+            logger.LogDebug($"Number to beat: {prob}");
+            logger.LogDebug($"Number: {rand}");
             if (rand < prob)
             {
-                logger.LogInfo("Planning interception...");
+                logger.LogDebug("Planning interception...");
                 __instance.staticElectricityParticle.Stop();
                 instance.LightningIntercepted = true;
                 LGUStore.instance.CoordinateInterceptionClientRpc();
@@ -107,7 +107,7 @@ namespace MoreShipUpgrades.UpgradeComponents
 
         public static void RerouteLightningBolt(ref Vector3 strikePosition, ref StormyWeather __instance)
         {
-            logger.LogInfo($"Intercepted Lightning Strike...");
+            logger.LogDebug($"Intercepted Lightning Strike...");
             Terminal terminal = UpgradeBus.instance.GetTerminal();
             strikePosition = terminal.transform.position;
             instance.LightningIntercepted = false;

--- a/MoreShipUpgrades/UpgradeComponents/runningShoeScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/runningShoeScript.cs
@@ -25,9 +25,9 @@ namespace MoreShipUpgrades.UpgradeComponents
         {
             base.Unwind();
 
+            GameNetworkManager.Instance.localPlayerController.movementSpeed -= (UpgradeBus.instance.cfg.MOVEMENT_SPEED_UNLOCK + (UpgradeBus.instance.runningLevel * UpgradeBus.instance.cfg.MOVEMENT_INCREMENT));
             UpgradeBus.instance.runningShoes = false;
             UpgradeBus.instance.runningLevel = 0;
-            GameNetworkManager.Instance.localPlayerController.movementSpeed = 4.6f;
         }
         public override void Register()
         {
@@ -39,7 +39,7 @@ namespace MoreShipUpgrades.UpgradeComponents
             base.load();
 
             UpgradeBus.instance.runningShoes = true;
-            GameNetworkManager.Instance.localPlayerController.movementSpeed = UpgradeBus.instance.cfg.MOVEMENT_SPEED;
+            GameNetworkManager.Instance.localPlayerController.movementSpeed += UpgradeBus.instance.cfg.MOVEMENT_SPEED_UNLOCK;
 
             float amountToIncrement = 0;
             for(int i = 0; i < UpgradeBus.instance.runningLevel; i++)

--- a/MoreShipUpgrades/UpgradeComponents/strongLegsScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/strongLegsScript.cs
@@ -17,15 +17,16 @@ namespace MoreShipUpgrades.UpgradeComponents
         public override void Increment()
         {
             UpgradeBus.instance.legLevel++;
+            GameNetworkManager.Instance.localPlayerController.jumpForce += UpgradeBus.instance.cfg.JUMP_FORCE_INCREMENT;
         }
 
         public override void Unwind()
         {
             base.Unwind();
 
+            GameNetworkManager.Instance.localPlayerController.jumpForce -= (UpgradeBus.instance.cfg.JUMP_FORCE_UNLOCK + (UpgradeBus.instance.legLevel * UpgradeBus.instance.cfg.JUMP_FORCE_INCREMENT));
             UpgradeBus.instance.strongLegs = false;
             UpgradeBus.instance.legLevel = 0;
-            GameNetworkManager.Instance.localPlayerController.jumpForce = 13f;
         }
         public override void Register()
         {
@@ -37,7 +38,7 @@ namespace MoreShipUpgrades.UpgradeComponents
             base.load();
 
             UpgradeBus.instance.strongLegs = true;
-            GameNetworkManager.Instance.localPlayerController.jumpForce = UpgradeBus.instance.cfg.JUMP_FORCE;
+            GameNetworkManager.Instance.localPlayerController.jumpForce += UpgradeBus.instance.cfg.JUMP_FORCE_UNLOCK;
             float amountToIncrement = 0;
             for(int i = 0; i < UpgradeBus.instance.legLevel; i++)
             {

--- a/MoreShipUpgrades/UpgradeComponents/strongerScannerScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/strongerScannerScript.cs
@@ -7,6 +7,11 @@ namespace MoreShipUpgrades.UpgradeComponents
     internal class strongerScannerScript : BaseUpgrade
     {
         public static string UPGRADE_NAME = "Better Scanner";
+        private static LGULogger logger;
+        void Awake()
+        {
+            logger = new LGULogger(UPGRADE_NAME);
+        }
         void Start()
         {
             upgradeName = UPGRADE_NAME;
@@ -40,6 +45,7 @@ namespace MoreShipUpgrades.UpgradeComponents
         public static void AddScannerNodeToValve(ref SteamValveHazard steamValveHazard)
         {
             if (!UpgradeBus.instance.scannerUpgrade) return;
+            logger.LogDebug("Inserting a Scan Node on a broken steam valve...");
             GameObject ScanNodeObject = Instantiate(GameObject.Find("ScanNode"), steamValveHazard.transform.position, Quaternion.Euler(Vector3.zero), steamValveHazard.transform);
             ScanNodeProperties node = ScanNodeObject.GetComponent<ScanNodeProperties>();
             node.headerText = "Bursted Steam Valve";
@@ -50,6 +56,7 @@ namespace MoreShipUpgrades.UpgradeComponents
 
         public static void RemoveScannerNodeFromValve(ref SteamValveHazard steamValveHazard)
         {
+            logger.LogDebug("Removing the Scan Node from a fixed steam valve...");
             Destroy(steamValveHazard.gameObject.GetComponentInChildren<ScanNodeProperties>());
         }
         public static string GetBetterScannerInfo(int level, int price)

--- a/MoreShipUpgrades/UpgradeComponents/terminalFlashScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/terminalFlashScript.cs
@@ -59,7 +59,7 @@ namespace MoreShipUpgrades.UpgradeComponents
         [ClientRpc]
         private void PlayAudioAndUpdateCooldownClientRpc()
         {
-            Terminal terminal = GameObject.Find("TerminalScript").GetComponent<Terminal>();
+            Terminal terminal = UpgradeBus.instance.GetTerminal();
             terminal.terminalAudio.maxDistance = 100f;
             terminal.terminalAudio.PlayOneShot(UpgradeBus.instance.flashNoise);
             StartCoroutine(ResetRange(terminal));


### PR DESCRIPTION
- All the initial values of each upgrade are now what's added to the player's respective attributes. This allows compatibility between mods that want to change the player's attributes without any upgrades (only on start, mods that change these attributes with a set rather than adding or removing will nullify any effects of the upgrades til server restart).
- Strong Legs was not applying the jump force increment whenever it was upgrade past the first level. It only loaded back with proper value when the lobby was restarted.
- Changed any LogInfo to LogDebug to not clutter the user's console with lightning catching logs.
- Added LogDebugs in relevant areas to know when something is working properly or not.
- Added LogErrors in transpilers when it's not found sufficient instruction codes to do the necessary effects in the game.
- Changed the info calculations to reflect the changes from configuration