### PR TITLE
Corrections needed due to Load LGU causing the attributes to be always increasing.

### DIFF
--- a/MoreShipUpgrades/UpgradeComponents/runningShoeScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/runningShoeScript.cs
@@ -7,10 +7,14 @@ namespace MoreShipUpgrades.UpgradeComponents
     internal class runningShoeScript : BaseUpgrade
     {
         public static string UPGRADE_NAME = "Running Shoes";
+        private static LGULogger logger;
         public static string PRICES_DEFAULT = "500,750,1000";
+        private int currentLevel = 0; // For "Load LGU" issues
+        private bool active = false;
         void Start()
         {
             upgradeName = UPGRADE_NAME;
+            logger = new LGULogger(UPGRADE_NAME);
             DontDestroyOnLoad(gameObject);
             Register();
         }
@@ -19,6 +23,7 @@ namespace MoreShipUpgrades.UpgradeComponents
         {
             GameNetworkManager.Instance.localPlayerController.movementSpeed += UpgradeBus.instance.cfg.MOVEMENT_INCREMENT;
             UpgradeBus.instance.runningLevel++;
+            currentLevel++;
         }
 
         public override void Unwind()
@@ -28,6 +33,8 @@ namespace MoreShipUpgrades.UpgradeComponents
             GameNetworkManager.Instance.localPlayerController.movementSpeed -= (UpgradeBus.instance.cfg.MOVEMENT_SPEED_UNLOCK + (UpgradeBus.instance.runningLevel * UpgradeBus.instance.cfg.MOVEMENT_INCREMENT));
             UpgradeBus.instance.runningShoes = false;
             UpgradeBus.instance.runningLevel = 0;
+            active = false;
+            currentLevel = 0;
         }
         public override void Register()
         {
@@ -39,15 +46,20 @@ namespace MoreShipUpgrades.UpgradeComponents
             base.load();
 
             UpgradeBus.instance.runningShoes = true;
-            GameNetworkManager.Instance.localPlayerController.movementSpeed += UpgradeBus.instance.cfg.MOVEMENT_SPEED_UNLOCK;
+            if (!active) GameNetworkManager.Instance.localPlayerController.movementSpeed += UpgradeBus.instance.cfg.MOVEMENT_SPEED_UNLOCK;
 
             float amountToIncrement = 0;
-            for(int i = 0; i < UpgradeBus.instance.runningLevel; i++)
+            for(int i = 1; i < UpgradeBus.instance.runningLevel+1; i++)
             {
+                if (i <= currentLevel) continue;
+
+                logger.LogDebug($"Adding {UpgradeBus.instance.cfg.MOVEMENT_INCREMENT} to the player's movement speed...");
                 amountToIncrement += UpgradeBus.instance.cfg.MOVEMENT_INCREMENT;
             }
 
             GameNetworkManager.Instance.localPlayerController.movementSpeed += amountToIncrement;
+            active = true;
+            currentLevel = UpgradeBus.instance.runningLevel;
         }
 
         public static float ApplyPossibleReducedNoiseRange(float defaultValue)

--- a/MoreShipUpgrades/UpgradeComponents/strongLegsScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/strongLegsScript.cs
@@ -6,10 +6,14 @@ namespace MoreShipUpgrades.UpgradeComponents
     internal class strongLegsScript : BaseUpgrade
     {
         public static string UPGRADE_NAME = "Strong Legs";
+        private static LGULogger logger;
         public static string PRICES_DEFAULT = "150,190,250";
+        private int currentLevel = 0; // For "Load LGU" issues
+        private bool active = false;
         void Start()
         {
             upgradeName = UPGRADE_NAME;
+            logger = new LGULogger(UPGRADE_NAME);
             DontDestroyOnLoad(gameObject);
             Register();
         }
@@ -17,6 +21,7 @@ namespace MoreShipUpgrades.UpgradeComponents
         public override void Increment()
         {
             UpgradeBus.instance.legLevel++;
+            currentLevel++;
             GameNetworkManager.Instance.localPlayerController.jumpForce += UpgradeBus.instance.cfg.JUMP_FORCE_INCREMENT;
         }
 
@@ -27,6 +32,8 @@ namespace MoreShipUpgrades.UpgradeComponents
             GameNetworkManager.Instance.localPlayerController.jumpForce -= (UpgradeBus.instance.cfg.JUMP_FORCE_UNLOCK + (UpgradeBus.instance.legLevel * UpgradeBus.instance.cfg.JUMP_FORCE_INCREMENT));
             UpgradeBus.instance.strongLegs = false;
             UpgradeBus.instance.legLevel = 0;
+            active = false;
+            currentLevel = 0;
         }
         public override void Register()
         {
@@ -38,14 +45,19 @@ namespace MoreShipUpgrades.UpgradeComponents
             base.load();
 
             UpgradeBus.instance.strongLegs = true;
-            GameNetworkManager.Instance.localPlayerController.jumpForce += UpgradeBus.instance.cfg.JUMP_FORCE_UNLOCK;
+            if (!active)GameNetworkManager.Instance.localPlayerController.jumpForce += UpgradeBus.instance.cfg.JUMP_FORCE_UNLOCK;
             float amountToIncrement = 0;
-            for(int i = 0; i < UpgradeBus.instance.legLevel; i++)
+            for(int i = 1; i < UpgradeBus.instance.legLevel+1; i++)
             {
+                if (i <= currentLevel) continue;
+
+                logger.LogDebug($"Adding {UpgradeBus.instance.cfg.JUMP_FORCE_INCREMENT} to the player's jump force...");
                 amountToIncrement += UpgradeBus.instance.cfg.JUMP_FORCE_INCREMENT;
             }
 
             GameNetworkManager.Instance.localPlayerController.jumpForce += amountToIncrement;
+            active = true;
+            currentLevel = UpgradeBus.instance.legLevel;
         }
 
         public static int ReduceFallDamage(int defaultValue)


### PR DESCRIPTION
For correcting the code merged [related to Running Shoes, Bigger Lungs and Strong Legs](https://github.com/Malcolm-Q/LC-LateGameUpgrades/pull/136) for "Load LGU" calling load method of BaseUpgrade which always has "+=" instead of the old "=" at the beginning to reset the value. This way, we will only increment by the necessary amount when syncing upgrades between players.