### PR TITLE
Changing reset functions' logic to just remove the increments done by each upgrade on the player instead of setting to default vanilla value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ MoreShipUpgrades/Properties/
 /.vs/
 MoreShipUpgrades/MoreShipUpgrades.csproj
 NetcodePatcher-2.4.0/
+**.user

--- a/MoreShipUpgrades/Managers/UpgradeBus.cs
+++ b/MoreShipUpgrades/Managers/UpgradeBus.cs
@@ -62,6 +62,7 @@ namespace MoreShipUpgrades.Managers
         public GameObject modStorePrefab;
         public TerminalNode modStoreInterface;
         public Terminal terminal;
+        public PlayerControllerB localPlayer;
 
         public List<CustomTerminalNode> terminalNodes = new List<CustomTerminalNode>();
 
@@ -119,7 +120,11 @@ namespace MoreShipUpgrades.Managers
 
             return terminal;
         }
-
+        public PlayerControllerB GetLocalPlayer()
+        {
+            if (localPlayer == null) localPlayer = GameNetworkManager.Instance.localPlayerController;
+            return localPlayer;
+        }
         public TerminalNode ConstructNode()
         {
             modStoreInterface = ScriptableObject.CreateInstance<TerminalNode>();
@@ -142,6 +147,7 @@ namespace MoreShipUpgrades.Managers
 
         public void ResetAllValues(bool wipeObjRefs = true)
         {
+            ResetPlayerAttributes();
             DestroyTraps = false;
             scannerUpgrade = false;
             nightVision = false;
@@ -185,13 +191,18 @@ namespace MoreShipUpgrades.Managers
                 node.CurrentUpgrade = 0;
                 if(node.Name == nightVisionScript.UPGRADE_NAME) { node.Unlocked = true; }
             }
-            PlayerControllerB[] players = GameObject.FindObjectsOfType<PlayerControllerB>();
-            foreach (PlayerControllerB player in players)
-            {
-                player.movementSpeed = 4.6f;
-                player.sprintTime = 11;
-                player.jumpForce = 13;
-            }
+
+        }
+
+        private void ResetPlayerAttributes()
+        {
+            PlayerControllerB player = GameNetworkManager.Instance.localPlayerController;
+            if (player == null) return; // Disconnecting the game
+
+            logger.LogDebug($"Resetting {player.playerUsername}'s attributes");
+            if (runningShoes) runningShoeScript.ResetRunningShoesBuff(ref player);
+            if (biggerLungs) biggerLungScript.ResetBiggerLungsBuff(ref player);
+            if (strongLegs) strongLegsScript.ResetStrongLegsBuff(ref player);
         }
 
         internal void GenerateSales(int seed = -1)

--- a/MoreShipUpgrades/Plugin.cs
+++ b/MoreShipUpgrades/Plugin.cs
@@ -72,7 +72,6 @@ namespace MoreShipUpgrades
             
             SetupPerks();
 
-
             harmony.PatchAll();
 
             mls.LogDebug("LGU has been patched");

--- a/MoreShipUpgrades/UpgradeComponents/strongLegsScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/strongLegsScript.cs
@@ -1,4 +1,5 @@
-﻿using MoreShipUpgrades.Managers;
+﻿using GameNetcodeStuff;
+using MoreShipUpgrades.Managers;
 using MoreShipUpgrades.Misc;
 
 namespace MoreShipUpgrades.UpgradeComponents
@@ -9,7 +10,8 @@ namespace MoreShipUpgrades.UpgradeComponents
         private static LGULogger logger;
         public static string PRICES_DEFAULT = "150,190,250";
         private int currentLevel = 0; // For "Load LGU" issues
-        private bool active = false;
+        private static bool active = false;
+
         void Start()
         {
             upgradeName = UPGRADE_NAME;
@@ -20,16 +22,18 @@ namespace MoreShipUpgrades.UpgradeComponents
 
         public override void Increment()
         {
+            PlayerControllerB player = UpgradeBus.instance.GetLocalPlayer();
+            player.jumpForce += UpgradeBus.instance.cfg.JUMP_FORCE_INCREMENT;
             UpgradeBus.instance.legLevel++;
             currentLevel++;
-            GameNetworkManager.Instance.localPlayerController.jumpForce += UpgradeBus.instance.cfg.JUMP_FORCE_INCREMENT;
         }
 
         public override void Unwind()
         {
             base.Unwind();
-
-            GameNetworkManager.Instance.localPlayerController.jumpForce -= (UpgradeBus.instance.cfg.JUMP_FORCE_UNLOCK + (UpgradeBus.instance.legLevel * UpgradeBus.instance.cfg.JUMP_FORCE_INCREMENT));
+            PlayerControllerB player = UpgradeBus.instance.GetLocalPlayer();
+            logger.LogDebug($"Adding {UpgradeBus.instance.cfg.JUMP_FORCE_INCREMENT} to the player's jump force...");
+            if (UpgradeBus.instance.strongLegs) ResetStrongLegsBuff(ref player);
             UpgradeBus.instance.strongLegs = false;
             UpgradeBus.instance.legLevel = 0;
             active = false;
@@ -45,7 +49,12 @@ namespace MoreShipUpgrades.UpgradeComponents
             base.load();
 
             UpgradeBus.instance.strongLegs = true;
-            if (!active)GameNetworkManager.Instance.localPlayerController.jumpForce += UpgradeBus.instance.cfg.JUMP_FORCE_UNLOCK;
+            PlayerControllerB player = UpgradeBus.instance.GetLocalPlayer();
+            if (!active)
+            {
+                logger.LogDebug($"Adding {UpgradeBus.instance.cfg.JUMP_FORCE_UNLOCK} to the player's jump force...");
+                player.jumpForce += UpgradeBus.instance.cfg.JUMP_FORCE_UNLOCK;
+            }
             float amountToIncrement = 0;
             for(int i = 1; i < UpgradeBus.instance.legLevel+1; i++)
             {
@@ -55,11 +64,22 @@ namespace MoreShipUpgrades.UpgradeComponents
                 amountToIncrement += UpgradeBus.instance.cfg.JUMP_FORCE_INCREMENT;
             }
 
-            GameNetworkManager.Instance.localPlayerController.jumpForce += amountToIncrement;
+            player.jumpForce += amountToIncrement;
             active = true;
             currentLevel = UpgradeBus.instance.legLevel;
         }
-
+        public static void ResetStrongLegsBuff(ref PlayerControllerB player)
+        {
+            float jumpForceRemoval = UpgradeBus.instance.cfg.JUMP_FORCE_UNLOCK;
+            for (int i = 0; i < UpgradeBus.instance.legLevel; i++)
+            {
+                jumpForceRemoval += UpgradeBus.instance.cfg.JUMP_FORCE_INCREMENT;
+            }
+            logger.LogDebug($"Removing {player.playerUsername}'s jump force boost ({player.jumpForce}) with a boost of {jumpForceRemoval}");
+            player.jumpForce -= jumpForceRemoval;
+            logger.LogDebug($"Upgrade reset on {player.playerUsername}");
+            active = false;
+        }
         public static int ReduceFallDamage(int defaultValue)
         {
             if (!(UpgradeBus.instance.strongLegs && UpgradeBus.instance.legLevel == UpgradeBus.instance.cfg.STRONG_LEGS_UPGRADE_PRICES.Split(',').Length)) return defaultValue;


### PR DESCRIPTION
This should allow compatibility with mods that also alter the same parameters. 

Health upgrade still needs to be looked at.