### PR TITLE
Refactored Stimpack Upgrade to be as compatible as possible with other mods that influence player's health

### DIFF
--- a/MoreShipUpgrades/Managers/LGUStore.cs
+++ b/MoreShipUpgrades/Managers/LGUStore.cs
@@ -209,18 +209,23 @@ namespace MoreShipUpgrades.Managers
         }
 
         [ServerRpc(RequireOwnership = false)]
-        public void UpdatePlayerNewHealthsServerRpc(ulong id, int health) 
+        public void PlayerHealthUpdateLevelServerRpc(ulong id, int level) 
         {
-            UpdatePlayerNewHealthsClientRpc(id, health);
+            PlayerHealthUpdateLevelClientRpc(id, level);
         }
 
         [ClientRpc]
-        private void UpdatePlayerNewHealthsClientRpc(ulong id, int health)
+        private void PlayerHealthUpdateLevelClientRpc(ulong id, int level)
         {
-            if (UpgradeBus.instance.playerHPs.ContainsKey(id))
-                UpgradeBus.instance.playerHPs[id] = health;
-            else UpgradeBus.instance.playerHPs.Add(id, health);
-            playerHealthScript.UpdateMaxHealth(GameNetworkManager.Instance.localPlayerController);
+            if (level == -1)
+            {
+                UpgradeBus.instance.playerHealthLevels.Remove(id);
+                return;
+            }
+
+            if (UpgradeBus.instance.playerHealthLevels.ContainsKey(id))
+                UpgradeBus.instance.playerHealthLevels[id] = level;
+            else UpgradeBus.instance.playerHealthLevels.Add(id, level);
         }
 
         [ServerRpc(RequireOwnership = false)]

--- a/MoreShipUpgrades/Managers/UpgradeBus.cs
+++ b/MoreShipUpgrades/Managers/UpgradeBus.cs
@@ -87,7 +87,7 @@ namespace MoreShipUpgrades.Managers
             { nightVisionScript.UPGRADE_NAME, (level, price) => nightVisionScript.GetNightVisionInfo(level, price) },
         };
 
-        public Dictionary<ulong, int> playerHPs = new Dictionary<ulong, int>();
+        public Dictionary<ulong, int> playerHealthLevels = new Dictionary<ulong, int>();
 
         public bool increaseHivePrice = false;
 

--- a/MoreShipUpgrades/Patches/PlayerControllerBPatcher.cs
+++ b/MoreShipUpgrades/Patches/PlayerControllerBPatcher.cs
@@ -54,8 +54,8 @@ namespace MoreShipUpgrades.Patches
                 if (!(codes[i + 1] != null && codes[i + 1].opcode == OpCodes.Call && codes[i + 1].operand.ToString() == "Int32 Clamp(Int32, Int32, Int32)")) continue;
                 if (!(codes[i + 2] != null && codes[i + 2].opcode == OpCodes.Stfld && codes[i + 2].operand.ToString() == "System.Int32 health")) continue;
 
-                //Mathf.Clamp(health - damageNumber, 0, playerHealthScript.CheckForAdditionalHealth())
-                codes[i] = new CodeInstruction(OpCodes.Call, maximumHealthMethod); 
+                //Mathf.Clamp(health - damageNumber, 0, playerHealthScript.CheckForAdditionalHealth(100))
+                codes.Insert(i + 1, new CodeInstruction(OpCodes.Call, maximumHealthMethod));
                 foundHealthMaximum = true;
 
                 if (foundHealthMaximum) break;

--- a/MoreShipUpgrades/Patches/StartOfRoundPatcher.cs
+++ b/MoreShipUpgrades/Patches/StartOfRoundPatcher.cs
@@ -69,14 +69,14 @@ namespace MoreShipUpgrades.Patches
                         codes[i + 1].opcode == OpCodes.Ldc_I4_0 &&
                         codes[i + 2].opcode == OpCodes.Callvirt && codes[i + 2].operand.ToString() == "Void UpdateHealthUI(Int32, Boolean)")
                     {
-                        codes[i] = new CodeInstruction(OpCodes.Call, maximumHealthMethod);
+                        codes.Insert(i+1, new CodeInstruction(OpCodes.Call, maximumHealthMethod));
                         updateHealth = true;
                     }
                 }
                 if (!(codes[i].opcode == OpCodes.Ldc_I4_S && codes[i].operand.ToString() == "100")) continue;
                 if (!(codes[i + 1].opcode == OpCodes.Stfld && codes[i + 1].operand.ToString() == "System.Int32 health")) continue;
 
-                codes[i] = new CodeInstruction(OpCodes.Call, maximumHealthMethod);
+                codes.Insert(i + 1, new CodeInstruction(OpCodes.Call, maximumHealthMethod));
                 if (!first) first = true;
                 else if (!second) second = true;
                 else third = true;

--- a/MoreShipUpgrades/UpgradeComponents/MedkitScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/MedkitScript.cs
@@ -31,7 +31,7 @@ namespace MoreShipUpgrades.UpgradeComponents
             }
             if (!Mouse.current.leftButton.isPressed) return;
 
-            int health = UpgradeBus.instance.playerHPs.ContainsKey(playerHeldBy.playerSteamId) ? UpgradeBus.instance.playerHPs[playerHeldBy.playerSteamId] : 100;
+            int health = UpgradeBus.instance.playerHealthLevels.ContainsKey(playerHeldBy.playerSteamId) ? playerHealthScript.GetHealthFromPlayer(100, playerHeldBy.playerSteamId) : 100;
             if(playerHeldBy.health >= health)
             {
                 audio.PlayOneShot(error);

--- a/MoreShipUpgrades/UpgradeComponents/defibScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/defibScript.cs
@@ -49,8 +49,8 @@ namespace MoreShipUpgrades.UpgradeComponents
         private void ReviveTargetedPlayerClientRpc()
         {
             PlayerControllerB player = StartOfRound.Instance.mapScreen.targetedPlayer;
-            bool playerRegistered = UpgradeBus.instance.playerHPs.ContainsKey(player.playerSteamId);
-            int health = playerRegistered ? UpgradeBus.instance.playerHPs[player.playerSteamId] : 100;
+            bool playerRegistered = UpgradeBus.instance.playerHealthLevels.ContainsKey(player.playerSteamId);
+            int health = playerRegistered ? playerHealthScript.GetHealthFromPlayer(100, player.playerSteamId) : 100;
             player.ResetPlayerBloodObjects(player.isPlayerDead);
 
             if (player.isPlayerDead || player.isPlayerControlled)

--- a/MoreShipUpgrades/UpgradeComponents/playerHealthScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/playerHealthScript.cs
@@ -46,7 +46,7 @@ namespace MoreShipUpgrades.UpgradeComponents
             logger.LogDebug($"Adding {UpgradeBus.instance.cfg.PLAYER_HEALTH_ADDITIONAL_HEALTH_INCREMENT} to the player's health...");
             UpgradeBus.instance.playerHealthLevel++;
             previousLevel++;
-            LGUStore.instance.PlayerHealthUpdateLevelServerRpc(GameNetworkManager.Instance.localPlayerController.playerSteamId, UpgradeBus.instance.playerHealthLevel);
+            LGUStore.instance.PlayerHealthUpdateLevelServerRpc(player.playerSteamId, UpgradeBus.instance.playerHealthLevel);
         }
 
         public override void load()
@@ -72,7 +72,7 @@ namespace MoreShipUpgrades.UpgradeComponents
 
             player.health += amountToIncrement;
             previousLevel = UpgradeBus.instance.playerHealthLevel;
-            LGUStore.instance.PlayerHealthUpdateLevelServerRpc(GameNetworkManager.Instance.localPlayerController.playerSteamId, UpgradeBus.instance.playerHealthLevel);
+            LGUStore.instance.PlayerHealthUpdateLevelServerRpc(player.playerSteamId, UpgradeBus.instance.playerHealthLevel);
         }
 
         public override void Register()
@@ -90,12 +90,13 @@ namespace MoreShipUpgrades.UpgradeComponents
             UpgradeBus.instance.playerHealth = false;
             previousLevel = 0;
             active = false;
-            LGUStore.instance.PlayerHealthUpdateLevelServerRpc(GameNetworkManager.Instance.localPlayerController.playerSteamId, -1);
+            LGUStore.instance.PlayerHealthUpdateLevelServerRpc(player.playerSteamId, -1);
         }
         public static int CheckForAdditionalHealth(int health)
         {
-            if (!UpgradeBus.instance.playerHealthLevels.ContainsKey(GameNetworkManager.Instance.localPlayerController.playerSteamId)) return health;
-            int currentLevel = UpgradeBus.instance.playerHealthLevels[GameNetworkManager.Instance.localPlayerController.playerSteamId];
+            PlayerControllerB player = UpgradeBus.instance.GetLocalPlayer();
+            if (!UpgradeBus.instance.playerHealthLevels.ContainsKey(player.playerSteamId)) return health;
+            int currentLevel = UpgradeBus.instance.playerHealthLevels[player.playerSteamId];
 
             return health + UpgradeBus.instance.cfg.PLAYER_HEALTH_ADDITIONAL_HEALTH_UNLOCK + currentLevel * UpgradeBus.instance.cfg.PLAYER_HEALTH_ADDITIONAL_HEALTH_INCREMENT;
         }

--- a/MoreShipUpgrades/UpgradeComponents/playerHealthScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/playerHealthScript.cs
@@ -10,9 +10,9 @@ namespace MoreShipUpgrades.UpgradeComponents
     internal class playerHealthScript : BaseUpgrade
     {
         public static string UPGRADE_NAME = "Stimpack";
-
-        private static int DEFAULT_HEALTH = 100;
-
+        private static bool active;
+        private int previousLevel;
+        private static LGULogger logger;
         // Configuration
         public static string ENABLED_SECTION = $"Enable {UPGRADE_NAME} Upgrade";
         public static bool ENABLED_DEFAULT = true;
@@ -36,20 +36,43 @@ namespace MoreShipUpgrades.UpgradeComponents
             upgradeName = UPGRADE_NAME;
             DontDestroyOnLoad(gameObject);
             UpgradeBus.instance.UpgradeObjects.Add(UPGRADE_NAME, gameObject);
+            logger = new LGULogger(UPGRADE_NAME);
         }
 
         public override void Increment()
         {
+            PlayerControllerB player = UpgradeBus.instance.GetLocalPlayer();
+            player.health += UpgradeBus.instance.cfg.PLAYER_HEALTH_ADDITIONAL_HEALTH_INCREMENT;
+            logger.LogDebug($"Adding {UpgradeBus.instance.cfg.PLAYER_HEALTH_ADDITIONAL_HEALTH_INCREMENT} to the player's health...");
             UpgradeBus.instance.playerHealthLevel++;
-            LGUStore.instance.UpdatePlayerNewHealthsServerRpc(GameNetworkManager.Instance.localPlayerController.playerSteamId, DEFAULT_HEALTH + UpgradeBus.instance.cfg.PLAYER_HEALTH_ADDITIONAL_HEALTH_UNLOCK + (UpgradeBus.instance.playerHealthLevel * UpgradeBus.instance.cfg.PLAYER_HEALTH_ADDITIONAL_HEALTH_INCREMENT));
+            previousLevel++;
+            LGUStore.instance.PlayerHealthUpdateLevelServerRpc(GameNetworkManager.Instance.localPlayerController.playerSteamId, UpgradeBus.instance.playerHealthLevel);
         }
 
         public override void load()
         {
+            PlayerControllerB player = UpgradeBus.instance.GetLocalPlayer();
+            if (!active)
+            {
+                logger.LogDebug($"Adding {UpgradeBus.instance.cfg.PLAYER_HEALTH_ADDITIONAL_HEALTH_UNLOCK} to the player's health on unlock...");
+                player.health += UpgradeBus.instance.cfg.PLAYER_HEALTH_ADDITIONAL_HEALTH_UNLOCK;
+            }
             base.load();
 
             UpgradeBus.instance.playerHealth = true;
-            LGUStore.instance.UpdatePlayerNewHealthsServerRpc(GameNetworkManager.Instance.localPlayerController.playerSteamId, DEFAULT_HEALTH + UpgradeBus.instance.cfg.PLAYER_HEALTH_ADDITIONAL_HEALTH_UNLOCK + (UpgradeBus.instance.playerHealthLevel * UpgradeBus.instance.cfg.PLAYER_HEALTH_ADDITIONAL_HEALTH_INCREMENT));
+            active = true;
+
+            int amountToIncrement = 0;
+            for (int i = 1; i < UpgradeBus.instance.playerHealthLevel + 1; i++)
+            {
+                if (i <= previousLevel) continue;
+                logger.LogDebug($"Adding {UpgradeBus.instance.cfg.PLAYER_HEALTH_ADDITIONAL_HEALTH_INCREMENT} to the player's health on increment...");
+                amountToIncrement += UpgradeBus.instance.cfg.PLAYER_HEALTH_ADDITIONAL_HEALTH_INCREMENT;
+            }
+
+            player.health += amountToIncrement;
+            previousLevel = UpgradeBus.instance.playerHealthLevel;
+            LGUStore.instance.PlayerHealthUpdateLevelServerRpc(GameNetworkManager.Instance.localPlayerController.playerSteamId, UpgradeBus.instance.playerHealthLevel);
         }
 
         public override void Register()
@@ -59,32 +82,47 @@ namespace MoreShipUpgrades.UpgradeComponents
 
         public override void Unwind()
         {
+            PlayerControllerB player = UpgradeBus.instance.GetLocalPlayer();
+            if (active) ResetStimpackBuff(ref player);
             base.Unwind();
 
             UpgradeBus.instance.playerHealthLevel = 0;
             UpgradeBus.instance.playerHealth = false;
-            LGUStore.instance.UpdatePlayerNewHealthsServerRpc(GameNetworkManager.Instance.localPlayerController.playerSteamId, DEFAULT_HEALTH);
+            previousLevel = 0;
+            active = false;
+            LGUStore.instance.PlayerHealthUpdateLevelServerRpc(GameNetworkManager.Instance.localPlayerController.playerSteamId, -1);
         }
-
-        public static void CheckAdditionalHealth(StartOfRound __instance)
+        public static int CheckForAdditionalHealth(int health)
         {
-            PlayerControllerB[] players = __instance.allPlayerScripts;
-            foreach (PlayerControllerB player in players)
+            if (!UpgradeBus.instance.playerHealthLevels.ContainsKey(GameNetworkManager.Instance.localPlayerController.playerSteamId)) return health;
+            int currentLevel = UpgradeBus.instance.playerHealthLevels[GameNetworkManager.Instance.localPlayerController.playerSteamId];
+
+            return health + UpgradeBus.instance.cfg.PLAYER_HEALTH_ADDITIONAL_HEALTH_UNLOCK + currentLevel * UpgradeBus.instance.cfg.PLAYER_HEALTH_ADDITIONAL_HEALTH_INCREMENT;
+        }
+        /// <summary>
+        /// Returns the maximum health possible for the player with given steam identifier
+        /// 
+        /// Precondition: playerHealthLevels contains the steam identifier as a key
+        /// </summary>
+        /// <param name="health">Health before applying the Stimpack upgrade</param>
+        /// <param name="steamId">Identifier of the client through steam</param>
+        /// <returns>Health of the player after applying the Stimpack effects</returns>
+        public static int GetHealthFromPlayer(int health, ulong steamId)
+        {
+            int currentLevel = UpgradeBus.instance.playerHealthLevels[steamId];
+            return health + UpgradeBus.instance.cfg.PLAYER_HEALTH_ADDITIONAL_HEALTH_UNLOCK + (currentLevel * UpgradeBus.instance.cfg.PLAYER_HEALTH_ADDITIONAL_HEALTH_INCREMENT);
+        }
+        public static void ResetStimpackBuff(ref PlayerControllerB player)
+        {
+            int healthRemoval = UpgradeBus.instance.cfg.PLAYER_HEALTH_ADDITIONAL_HEALTH_UNLOCK;
+            for (int i = 0; i < UpgradeBus.instance.playerHealthLevel; i++)
             {
-                UpdateMaxHealth(player);
+                healthRemoval += UpgradeBus.instance.cfg.PLAYER_HEALTH_ADDITIONAL_HEALTH_INCREMENT;
             }
-        }
-        public static int CheckForAdditionalHealth()
-        {
-            if (UpgradeBus.instance.playerHPs.ContainsKey(GameNetworkManager.Instance.localPlayerController.playerSteamId))
-               return UpgradeBus.instance.playerHPs[GameNetworkManager.Instance.localPlayerController.playerSteamId];
-            return DEFAULT_HEALTH;
-        }
-
-        public static void UpdateMaxHealth(PlayerControllerB player)
-        {
-            if (UpgradeBus.instance.playerHPs.ContainsKey(player.playerSteamId))
-                player.health = UpgradeBus.instance.playerHPs[player.playerSteamId];
+            logger.LogDebug($"Removing {player.playerUsername}'s health boost ({player.health}) with a boost of {healthRemoval}");
+            player.health -= healthRemoval;
+            logger.LogDebug($"Upgrade reset on {player.playerUsername}");
+            active = false;
         }
     }
 }


### PR DESCRIPTION
Changed:
- PlayerHPs to store player's Stimpack levels instead
- Intern will now check the level and see how much health it needs to give to the revived player
- Medkit does the same thing as above
- For compatibility with other health increasing mods, we would have to know how they influence the base health to change the values accordingly in Intern and Medkit.
- Changed respective transpilers to add instruction codes instead of replacing them (replace would force our own health value)
- PlayerHealthScript's logic has been rewritten to match Running Shoe's in terms of += and -= instead of forcing our own health value through Stimpack