### PR TITLE
Changed Sick Beats way of checking to remove effect

### DIFF
--- a/MoreShipUpgrades/Managers/LGUStore.cs
+++ b/MoreShipUpgrades/Managers/LGUStore.cs
@@ -342,6 +342,7 @@ namespace MoreShipUpgrades.Managers
             UpgradeBus.instance.hunter = saveInfo.hunter;
             UpgradeBus.instance.playerHealth = saveInfo.playerHealth;
             UpgradeBus.instance.wearingHelmet = saveInfo.wearingHelmet;
+            UpgradeBus.instance.sickBeats = saveInfo.sickBeats;
 
             UpgradeBus.instance.beeLevel = saveInfo.beeLevel;
             UpgradeBus.instance.huntLevel = saveInfo.huntLevel;
@@ -627,6 +628,7 @@ namespace MoreShipUpgrades.Managers
         public bool hunter = UpgradeBus.instance.hunter;
         public bool playerHealth = UpgradeBus.instance.playerHealth;
         public bool wearingHelmet = UpgradeBus.instance.wearingHelmet;
+        public bool sickBeats = UpgradeBus.instance.sickBeats;
 
         public int beeLevel = UpgradeBus.instance.beeLevel;
         public int huntLevel = UpgradeBus.instance.huntLevel;

--- a/MoreShipUpgrades/MoreShipUpgrades.csproj
+++ b/MoreShipUpgrades/MoreShipUpgrades.csproj
@@ -42,6 +42,7 @@
 	  </Reference>
 	  <Reference Include="Unity.Netcode.Components">
 	    <HintPath>D:\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Unity.Netcode.Components.dll</HintPath>
+	  </Reference>
 	  <Reference Include="Unity.Netcode.Runtime">
 	    <HintPath>D:\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Unity.Netcode.Runtime.dll</HintPath>
 	  </Reference>

--- a/MoreShipUpgrades/MoreShipUpgrades.csproj
+++ b/MoreShipUpgrades/MoreShipUpgrades.csproj
@@ -42,7 +42,6 @@
 	  </Reference>
 	  <Reference Include="Unity.Netcode.Components">
 	    <HintPath>D:\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Unity.Netcode.Components.dll</HintPath>
-	  </Reference>
 	  <Reference Include="Unity.Netcode.Runtime">
 	    <HintPath>D:\SteamLibrary\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Unity.Netcode.Runtime.dll</HintPath>
 	  </Reference>

--- a/MoreShipUpgrades/Patches/PlayerControllerBPatcher.cs
+++ b/MoreShipUpgrades/Patches/PlayerControllerBPatcher.cs
@@ -32,10 +32,6 @@ namespace MoreShipUpgrades.Patches
                 if (!UpgradeBus.instance.cfg.NIGHT_VISION_DROP_ON_DEATH) return;
                 LGUStore.instance.SpawnNightVisionItemOnDeathServerRpc(__instance.transform.position);
             }
-            UpgradeBus.instance.staminaDrainCoefficient = 1f;
-            UpgradeBus.instance.incomingDamageCoefficient = 1f;
-            UpgradeBus.instance.damageBoost = 0;
-            if (BeatScript.PreviousMovementSpeed > 0) __instance.movementSpeed = BeatScript.PreviousMovementSpeed;
         }
 
         [HarmonyPatch("DamagePlayer")]
@@ -245,6 +241,13 @@ namespace MoreShipUpgrades.Patches
             if (!UpgradeBus.instance.sickBeats || __instance != GameNetworkManager.Instance.localPlayerController) return;
             UpgradeBus.instance.boomBoxes.RemoveAll(b => b == null);
             bool result = false;
+            if (__instance.isPlayerDead)
+            {
+                if (!UpgradeBus.instance.EffectsActive) return; // No need to do anything
+                UpgradeBus.instance.EffectsActive = result;
+                BeatScript.HandlePlayerEffects(__instance);
+                return; // Clean all effects from Sick Beats since the player's dead
+            }
             foreach(BoomboxItem boom in UpgradeBus.instance.boomBoxes)
             {
                 if (!boom.isPlayingMusic)

--- a/MoreShipUpgrades/UpgradeComponents/BeatScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/BeatScript.cs
@@ -7,7 +7,7 @@ namespace MoreShipUpgrades.UpgradeComponents
     public class BeatScript : BaseUpgrade
     {
         public static string UPGRADE_NAME = "Sick Beats";
-        public static float PreviousMovementSpeed;
+        private static LGULogger logger = new LGULogger(UPGRADE_NAME);
 
         void Start()
         {
@@ -39,21 +39,20 @@ namespace MoreShipUpgrades.UpgradeComponents
             UpgradeBus.instance.BoomboxIcon.SetActive(UpgradeBus.instance.EffectsActive);
             if(UpgradeBus.instance.EffectsActive)
             {
-                if (UpgradeBus.instance.cfg.BEATS_SPEED)
-                {
-                    PreviousMovementSpeed = player.movementSpeed; // I don't like this
-                    player.movementSpeed += UpgradeBus.instance.cfg.BEATS_SPEED_INC;
-                }
-                if(UpgradeBus.instance.cfg.BEATS_STAMINA) UpgradeBus.instance.staminaDrainCoefficient = UpgradeBus.instance.cfg.BEATS_STAMINA_CO;
+                logger.LogDebug("Applying effects!");
+                logger.LogDebug($"Updating player's movement speed ({player.movementSpeed})");
+                if (UpgradeBus.instance.cfg.BEATS_SPEED) player.movementSpeed += UpgradeBus.instance.cfg.BEATS_SPEED_INC;
+                logger.LogDebug($"Updated player's movement speed ({player.movementSpeed})");
+                if (UpgradeBus.instance.cfg.BEATS_STAMINA) UpgradeBus.instance.staminaDrainCoefficient = UpgradeBus.instance.cfg.BEATS_STAMINA_CO;
                 if(UpgradeBus.instance.cfg.BEATS_DEF) UpgradeBus.instance.incomingDamageCoefficient = UpgradeBus.instance.cfg.BEATS_DEF_CO;
                 if(UpgradeBus.instance.cfg.BEATS_DMG) UpgradeBus.instance.damageBoost = UpgradeBus.instance.cfg.BEATS_DMG_INC;
             }
             else
             {
-                if (UpgradeBus.instance.cfg.BEATS_SPEED)
-                {
-                    player.movementSpeed = PreviousMovementSpeed; // but it should be fine...           right? 
-                }
+                logger.LogDebug("Removing effects!");
+                logger.LogDebug($"Updating player's movement speed ({player.movementSpeed})");
+                if (UpgradeBus.instance.cfg.BEATS_SPEED) player.movementSpeed -= UpgradeBus.instance.cfg.BEATS_SPEED_INC;
+                logger.LogDebug($"Updated player's movement speed ({player.movementSpeed})");
                 UpgradeBus.instance.staminaDrainCoefficient = 1f;
                 UpgradeBus.instance.incomingDamageCoefficient = 1f;
                 UpgradeBus.instance.damageBoost = 0;


### PR DESCRIPTION
- Instead of changing whenever a player dies, just look at Update to see if the player is dead or not to remove the effects (if they had any). Also no point checking for boomboxes if the player's dead.
- Though a suggestion would be to make a circular collider for this as we only need to know when they get in and out of the area of the boombox. I will look more into this later.
- Sick beats wasn't being saved, fixed that issue too.