### PR TITLE
Multiples fixes and changes to wheelbarrow's and contract's behaviours

### DIFF
--- a/MoreShipUpgrades/Patches/HUDManagerPatcher.cs
+++ b/MoreShipUpgrades/Patches/HUDManagerPatcher.cs
@@ -1,6 +1,7 @@
 ﻿using GameNetcodeStuff;
 using HarmonyLib;
 using MoreShipUpgrades.Managers;
+using MoreShipUpgrades.UpgradeComponents.Items.Wheelbarrow;
 using UnityEngine;
 
 namespace MoreShipUpgrades.Patches
@@ -12,6 +13,7 @@ namespace MoreShipUpgrades.Patches
         [HarmonyPatch("MeetsScanNodeRequirements")]
         private static void alterReqs(ScanNodeProperties node, ref bool __result, PlayerControllerB playerScript)
         {
+            if (node.GetComponentInParent<WheelbarrowScript>() != null && (node.headerText != "Shopping Cart" && node.headerText != "Wheelbarrow")) { __result = false; return; }
             if (!UpgradeBus.instance.scannerUpgrade) { return; }
             if (node == null) { __result = false; return; }
             bool throughWall = Physics.Linecast(playerScript.gameplayCamera.transform.position, node.transform.position, 256, QueryTriggerInteraction.Ignore);

--- a/MoreShipUpgrades/Patches/HoarderBugAIPatcher.cs
+++ b/MoreShipUpgrades/Patches/HoarderBugAIPatcher.cs
@@ -10,7 +10,7 @@ namespace MoreShipUpgrades.Patches
         [HarmonyPatch("IsHoarderBugAngry")]
         private static void MakeHoarderBugSwarmAngry(ref bool __result)
         {
-            if (UpgradeBus.instance.contractLevel == "None") return;
+            if (UpgradeBus.instance.contractType != "exterminator") return;
 
             if(UpgradeBus.instance.contractLevel == RoundManager.Instance.currentLevel.PlanetName)
             {

--- a/MoreShipUpgrades/Plugin.cs
+++ b/MoreShipUpgrades/Plugin.cs
@@ -127,7 +127,7 @@ namespace MoreShipUpgrades
         {
             Item bomb = AssetBundleHandler.TryLoadItemAsset(ref bundle, root + "BombItem.asset");
             if (bomb == null) return;
-
+            bomb.isConductiveMetal = false;
             ContractObject coNest = bomb.spawnPrefab.AddComponent<ContractObject>();
             coNest.contractType = "defusal";
 

--- a/MoreShipUpgrades/UpgradeComponents/BombDefusalScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/BombDefusalScript.cs
@@ -138,6 +138,7 @@ namespace MoreShipUpgrades.UpgradeComponents
                     // win
                     armed = false;
                     grabBox.enabled = true;
+                    audio.Stop();
                     this.enabled = false;
                 }
             }

--- a/MoreShipUpgrades/UpgradeComponents/Items/Wheelbarrow/ScrapWheelbarrow.cs
+++ b/MoreShipUpgrades/UpgradeComponents/Items/Wheelbarrow/ScrapWheelbarrow.cs
@@ -14,7 +14,6 @@ namespace MoreShipUpgrades.UpgradeComponents.Items.Wheelbarrow
             base.Start();
             maximumAmountItems = UpgradeBus.instance.cfg.SCRAP_WHEELBARROW_MAXIMUM_AMOUNT_ITEMS;
             weightReduceMultiplier = UpgradeBus.instance.cfg.SCRAP_WHEELBARROW_WEIGHT_REDUCTION_MULTIPLIER;
-            defaultWeight = itemProperties.weight;
             Enum.TryParse(typeof(Restrictions), UpgradeBus.instance.cfg.SCRAP_WHEELBARROW_RESTRICTION_MODE, out object parsedRestriction);
             if (parsedRestriction == null)
             {

--- a/MoreShipUpgrades/UpgradeComponents/Items/Wheelbarrow/StoreWheelbarrow.cs
+++ b/MoreShipUpgrades/UpgradeComponents/Items/Wheelbarrow/StoreWheelbarrow.cs
@@ -18,7 +18,6 @@ namespace MoreShipUpgrades.UpgradeComponents.Items.Wheelbarrow
             if (wheel == null) logger.LogError($"Couldn't find the wheel's {nameof(GameObject)} to perform rotations");
             maximumAmountItems = UpgradeBus.instance.cfg.WHEELBARROW_MAXIMUM_AMOUNT_ITEMS;
             weightReduceMultiplier = UpgradeBus.instance.cfg.WHEELBARROW_WEIGHT_REDUCTION_MULTIPLIER;
-            defaultWeight = itemProperties.weight;
             Enum.TryParse(typeof(Restrictions), UpgradeBus.instance.cfg.WHEELBARROW_RESTRICTION_MODE, out object parsedRestriction);
             if (parsedRestriction == null)
             {


### PR DESCRIPTION
# Contracts
- Stopped the ticking sound after the bomb has been defused
- Hoarding bugs will only get angry when the contract type saved with "exterminator" (if the contract type is not reset after completing it, it will start making them angry, make sure that it resets)

# Wheelbarrows
- Fixed the issue with wheelbarrow and shopping cart not being saved (making a deep copy of their itemProperties would make them be unable to be saved thus disappearing after relog)
- This also means that I had to change its total weight logic as it was using itemProperties as a mean to store all items' weight.
- Items while being carried in a wheelbarrow will not have their scan nodes displayed in the player's HUD.