### PR TITLE
Fixes in Wheelbarrow and Scavenger

### DIFF
--- a/MoreShipUpgrades/Plugin.cs
+++ b/MoreShipUpgrades/Plugin.cs
@@ -223,6 +223,7 @@ namespace MoreShipUpgrades
             Item scav = AssetBundleHandler.TryLoadItemAsset(ref bundle, root + "ScavItem.asset");
             if (scav == null) return;
 
+            scav.weight = UpgradeBus.instance.cfg.CONTRACT_EXTRACT_WEIGHT;
             ContractObject co = scav.spawnPrefab.AddComponent<ContractObject>();
             co.contractType = "extraction";
 

--- a/MoreShipUpgrades/UpgradeComponents/ExtractPlayerScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/ExtractPlayerScript.cs
@@ -23,7 +23,6 @@ namespace MoreShipUpgrades.UpgradeComponents
         {
             prop = GetComponent<PhysicsProp>();
             prop.scrapValue = UpgradeBus.instance.cfg.CONTRACT_EXTRACT_REWARD;
-            prop.itemProperties.weight = UpgradeBus.instance.cfg.CONTRACT_EXTRACT_WEIGHT;
 
             ScanNodeProperties node = GetComponentInChildren<ScanNodeProperties>();
             node.scrapValue = UpgradeBus.instance.cfg.CONTRACT_EXTRACT_REWARD;


### PR DESCRIPTION
# Wheelbarrow
- Changed the total weight calculation to be synced with everyone and not applying more than once (aka the RPCs are probably deemed useless but I can't bother cleaning that up right now)
# Lost Scavenger
- Changed the variable attribution of itemProperties.weight from after being inserted in allItemsList to before to not cause any instance of this item to not save.