### PR TITLE
Implementation of Doors Hydraulic Battery Boost upgrade (named "Shutter Batteries")

### DIFF
--- a/MoreShipUpgrades/Managers/LGUStore.cs
+++ b/MoreShipUpgrades/Managers/LGUStore.cs
@@ -40,6 +40,7 @@ namespace MoreShipUpgrades.Managers
             {hunterScript.UPGRADE_NAME, SaveInfo => SaveInfo.hunter },
             {lightningRodScript.UPGRADE_NAME, SaveInfo => SaveInfo.lightningRod },
             {playerHealthScript.UPGRADE_NAME, SaveInfo => SaveInfo.playerHealth },
+            {DoorsHydraulicsBattery.UPGRADE_NAME, SaveInfo => SaveInfo.doorsHydraulicsBattery },
         };
 
         private static Dictionary<string, Func<SaveInfo, int>> levelConditions = new Dictionary<string, Func<SaveInfo, int>>
@@ -60,6 +61,7 @@ namespace MoreShipUpgrades.Managers
             { hunterScript.UPGRADE_NAME, SaveInfo => SaveInfo.huntLevel },
             { lightningRodScript.UPGRADE_NAME, saveInfo => 0},
             { playerHealthScript.UPGRADE_NAME, saveInfo => saveInfo.playerHealthLevel },
+            { DoorsHydraulicsBattery.UPGRADE_NAME, saveInfo => saveInfo.doorsHydraulicsBatteryLevel},
         };
         private bool retrievedCfg;
         private bool receivedSave;
@@ -344,6 +346,7 @@ namespace MoreShipUpgrades.Managers
             UpgradeBus.instance.playerHealth = saveInfo.playerHealth;
             UpgradeBus.instance.wearingHelmet = saveInfo.wearingHelmet;
             UpgradeBus.instance.sickBeats = saveInfo.sickBeats;
+            UpgradeBus.instance.doorsHydraulicsBattery = saveInfo.doorsHydraulicsBattery;
 
             UpgradeBus.instance.beeLevel = saveInfo.beeLevel;
             UpgradeBus.instance.huntLevel = saveInfo.huntLevel;
@@ -357,6 +360,7 @@ namespace MoreShipUpgrades.Managers
             UpgradeBus.instance.scanLevel = saveInfo.scanLevel;
             UpgradeBus.instance.nightVisionLevel = saveInfo.nightVisionLevel;
             UpgradeBus.instance.playerHealthLevel = saveInfo.playerHealthLevel;
+            UpgradeBus.instance.doorsHydraulicsBatteryLevel = saveInfo.doorsHydraulicsBatteryLevel;
 
             UpgradeBus.instance.contractLevel = saveInfo.contractLevel;
             UpgradeBus.instance.contractType = saveInfo.contractType;
@@ -647,6 +651,7 @@ namespace MoreShipUpgrades.Managers
         public bool playerHealth = UpgradeBus.instance.playerHealth;
         public bool wearingHelmet = UpgradeBus.instance.wearingHelmet;
         public bool sickBeats = UpgradeBus.instance.sickBeats;
+        public bool doorsHydraulicsBattery = UpgradeBus.instance.doorsHydraulicsBattery;
 
         public int beeLevel = UpgradeBus.instance.beeLevel;
         public int huntLevel = UpgradeBus.instance.huntLevel;
@@ -659,6 +664,7 @@ namespace MoreShipUpgrades.Managers
         public int legLevel = UpgradeBus.instance.legLevel;
         public int nightVisionLevel = UpgradeBus.instance.nightVisionLevel;
         public int playerHealthLevel = UpgradeBus.instance.playerHealthLevel;
+        public int doorsHydraulicsBatteryLevel = UpgradeBus.instance.doorsHydraulicsBatteryLevel;
         public string contractType = UpgradeBus.instance.contractType;
         public string contractLevel = UpgradeBus.instance.contractLevel;
         public Dictionary<string, float> SaleData = UpgradeBus.instance.SaleData;

--- a/MoreShipUpgrades/Managers/UpgradeBus.cs
+++ b/MoreShipUpgrades/Managers/UpgradeBus.cs
@@ -39,6 +39,7 @@ namespace MoreShipUpgrades.Managers
         public bool lightningRodActive = false;
         public bool hunter = false;
         public bool playerHealth = false;
+        public bool doorsHydraulicsBattery = false;
 
         public int lungLevel = 0;
         public int helmetHits = 0;
@@ -52,6 +53,7 @@ namespace MoreShipUpgrades.Managers
         public int scanLevel = 0;
         public int nightVisionLevel = 0;
         public int playerHealthLevel = 0;
+        public int doorsHydraulicsBatteryLevel = 0;
 
         public float flashCooldown = 0f;
         public float alteredWeight = 1f;
@@ -77,6 +79,7 @@ namespace MoreShipUpgrades.Managers
         public TerminalNode modStoreInterface;
         public Terminal terminal;
         public PlayerControllerB localPlayer;
+        private HangarShipDoor hangarDoors;
 
         public List<BoomboxItem> boomBoxes = new List<BoomboxItem>();
 
@@ -94,6 +97,7 @@ namespace MoreShipUpgrades.Managers
             { proteinPowderScript.UPGRADE_NAME, level => instance.cfg.PROTEIN_UNLOCK_FORCE + 1 + (instance.cfg.PROTEIN_INCREMENT * level) },
             { beekeeperScript.UPGRADE_NAME, level => 100 * (instance.cfg.BEEKEEPER_DAMAGE_MULTIPLIER - (level * instance.cfg.BEEKEEPER_DAMAGE_MULTIPLIER_INCREMENT)) },
             { playerHealthScript.UPGRADE_NAME, level => instance.cfg.PLAYER_HEALTH_ADDITIONAL_HEALTH_UNLOCK + (level)*instance.cfg.PLAYER_HEALTH_ADDITIONAL_HEALTH_INCREMENT },
+            { DoorsHydraulicsBattery.UPGRADE_NAME, level => instance.cfg.DOOR_HYDRAULICS_BATTERY_INITIAL + (level)*instance.cfg.DOOR_HYDRAULICS_BATTERY_INCREMENTAL },
         };
 
         public Dictionary<string, Item> ItemsToSync = new Dictionary<string, Item>();
@@ -155,6 +159,11 @@ namespace MoreShipUpgrades.Managers
             if (localPlayer == null) localPlayer = GameNetworkManager.Instance.localPlayerController;
             return localPlayer;
         }
+        public HangarShipDoor GetShipDoors()
+        {
+            if (hangarDoors == null) hangarDoors = FindObjectOfType<HangarShipDoor>();
+            return hangarDoors;
+        }
         public TerminalNode ConstructNode()
         {
             modStoreInterface = ScriptableObject.CreateInstance<TerminalNode>();
@@ -178,6 +187,7 @@ namespace MoreShipUpgrades.Managers
         public void ResetAllValues(bool wipeObjRefs = true)
         {
             ResetPlayerAttributes();
+            ResetShipAttributes();
             EffectsActive = false;
             DestroyTraps = false;
             scannerUpgrade = false;
@@ -240,6 +250,14 @@ namespace MoreShipUpgrades.Managers
             if (cfg.BIGGER_LUNGS_ENABLED && biggerLungs) biggerLungScript.ResetBiggerLungsBuff(ref player);
             if (cfg.STRONG_LEGS_ENABLED && strongLegs) strongLegsScript.ResetStrongLegsBuff(ref player);
             if (cfg.PLAYER_HEALTH_ENABLED && playerHealth) playerHealthScript.ResetStimpackBuff(ref player);
+        }
+        private void ResetShipAttributes()
+        {
+            HangarShipDoor shipDoors = GetShipDoors();
+            if (shipDoors == null) return; // Very edge case
+
+            logger.LogDebug($"Resetting the ship's attributes");
+            if (cfg.DOOR_HYDRAULICS_BATTERY_ENABLED && doorsHydraulicsBattery) DoorsHydraulicsBattery.ResetDoorsHydraulicsBattery(ref shipDoors);
         }
 
         internal void GenerateSales(int seed = -1) // TODO: Save sales
@@ -388,8 +406,19 @@ namespace MoreShipUpgrades.Managers
             SetupLocksmithTerminalNode();
 
             SetupSickBeatsTerminalNode();
-        }
 
+            SetupShutterBatteriesTerminalNode();
+            terminalNodes.Sort();
+        }
+        private void SetupShutterBatteriesTerminalNode()
+        {
+            SetupMultiplePurchasableTerminalNode(DoorsHydraulicsBattery.UPGRADE_NAME,
+                                                true,
+                                                cfg.DOOR_HYDRAULICS_BATTERY_ENABLED,
+                                                cfg.DOOR_HYDRAULICS_BATTERY_PRICE,
+                                                ParseUpgradePrices(cfg.DOOR_HYDRAULICS_BATTERY_PRICES),
+                                                "LVL {0} - ${1} - Increases the door's hydraulic capacity to remain closed by {2} units\n");
+        }
         private void SetupSickBeatsTerminalNode()
         {
             string txt = $"Sick Beats - ${cfg.BEATS_PRICE}\nPlayers within a {cfg.BEATS_RADIUS} unit radius from an active boombox will have the following effects:\n\n";

--- a/MoreShipUpgrades/Managers/UpgradeBus.cs
+++ b/MoreShipUpgrades/Managers/UpgradeBus.cs
@@ -187,7 +187,7 @@ namespace MoreShipUpgrades.Managers
         public void ResetAllValues(bool wipeObjRefs = true)
         {
             ResetPlayerAttributes();
-            ResetShipAttributes();
+            ResetShipAttributesServerRpc();
             EffectsActive = false;
             DestroyTraps = false;
             scannerUpgrade = false;
@@ -239,7 +239,7 @@ namespace MoreShipUpgrades.Managers
             }
 
         }
-
+        private 
         private void ResetPlayerAttributes()
         {
             PlayerControllerB player = GameNetworkManager.Instance.localPlayerController;
@@ -251,13 +251,17 @@ namespace MoreShipUpgrades.Managers
             if (cfg.STRONG_LEGS_ENABLED && strongLegs) strongLegsScript.ResetStrongLegsBuff(ref player);
             if (cfg.PLAYER_HEALTH_ENABLED && playerHealth) playerHealthScript.ResetStimpackBuff(ref player);
         }
-        private void ResetShipAttributes()
+        private void ResetShipAttributesClientRpc()
         {
             HangarShipDoor shipDoors = GetShipDoors();
             if (shipDoors == null) return; // Very edge case
 
             logger.LogDebug($"Resetting the ship's attributes");
             if (cfg.DOOR_HYDRAULICS_BATTERY_ENABLED && doorsHydraulicsBattery) DoorsHydraulicsBattery.ResetDoorsHydraulicsBattery(ref shipDoors);
+        }
+        private void ResetShipAttributesServerRpc()
+        {
+            ResetShipAttributesClientRpc();
         }
 
         internal void GenerateSales(int seed = -1) // TODO: Save sales

--- a/MoreShipUpgrades/Misc/AssetBundleHandler.cs
+++ b/MoreShipUpgrades/Misc/AssetBundleHandler.cs
@@ -48,6 +48,7 @@ namespace MoreShipUpgrades.Misc
             { lockSmithScript.UPGRADE_NAME, root+"LockSmith.prefab" },
             { playerHealthScript.UPGRADE_NAME, root+"PlayerHealth.prefab" },
             { ExtendDeadlineScript.UPGRADE_NAME, root+"ExtendDeadline.prefab" },
+            { DoorsHydraulicsBattery.UPGRADE_NAME, root+"DoorsHydraulicsBattery.prefab" },
 
             { "Advanced Portable Tele", "Assets/ShipUpgrades/TpButtonAdv.asset" },
             { "Portable Tele", "Assets/ShipUpgrades/TpButton.asset" },

--- a/MoreShipUpgrades/Misc/PluginConfig.cs
+++ b/MoreShipUpgrades/Misc/PluginConfig.cs
@@ -35,6 +35,7 @@ namespace MoreShipUpgrades.Misc
         public bool EXTEND_DEADLINE_ENABLED { get; set; }
         public bool WHEELBARROW_ENABLED { get; set; }
         public bool SCRAP_WHEELBARROW_ENABLED { get; set; }
+        public bool DOOR_HYDRAULICS_BATTERY_ENABLED {  get; set; }
 
         // individual or shared
         public bool ADVANCED_TELE_INDIVIDUAL { get; set; }
@@ -78,6 +79,7 @@ namespace MoreShipUpgrades.Misc
         public int EXTEND_DEADLINE_PRICE { get; set; }
         public int CONTRACT_PRICE { get; set; }
         public int WHEELBARROW_PRICE { get; set; }
+        public int DOOR_HYDRAULICS_BATTERY_PRICE { get; set; }
 
         // attributes
         public float BIGGER_LUNGS_STAMINA_REGEN_INCREASE { get; set; }
@@ -232,6 +234,9 @@ namespace MoreShipUpgrades.Misc
         public float SCRAP_WHEELBARROW_RARITY { get; set; }
         public bool SCRAP_WHEELBARROW_PLAY_NOISE {  get; set; }
         public float SCAV_VOLUME { get; set; }
+        public string DOOR_HYDRAULICS_BATTERY_PRICES { get; set; }
+        public float DOOR_HYDRAULICS_BATTERY_INITIAL { get; set; }
+        public float DOOR_HYDRAULICS_BATTERY_INCREMENTAL {  get; set; }
 
         public PluginConfig(ConfigFile cfg)
         {
@@ -479,6 +484,13 @@ namespace MoreShipUpgrades.Misc
             DIVEKIT_PRICE = ConfigEntry(topSection, "price", 650, "Price for Diving Kit.");
             DIVEKIT_WEIGHT = ConfigEntry(topSection, "Item weight", 1.65f, "-1 and multiply by 100 (1.65 = 65 lbs)");
             DIVEKIT_TWO_HANDED = ConfigEntry(topSection, "Two Handed Item", true, "One or two handed item.");
+
+            topSection = DoorsHydraulicsBattery.UPGRADE_NAME;
+            DOOR_HYDRAULICS_BATTERY_ENABLED = ConfigEntry(topSection, DoorsHydraulicsBattery.ENABLED_SECTION, true, DoorsHydraulicsBattery.ENABLED_DESCRIPTION);
+            DOOR_HYDRAULICS_BATTERY_PRICE = ConfigEntry(topSection, DoorsHydraulicsBattery.PRICE_SECTION, DoorsHydraulicsBattery.PRICE_DEFAULT);
+            DOOR_HYDRAULICS_BATTERY_PRICES = ConfigEntry(topSection, BaseUpgrade.PRICES_SECTION, DoorsHydraulicsBattery.PRICES_DEFAULT, BaseUpgrade.PRICES_DESCRIPTION);
+            DOOR_HYDRAULICS_BATTERY_INITIAL = ConfigEntry(topSection, DoorsHydraulicsBattery.INITIAL_SECTION, DoorsHydraulicsBattery.INITIAL_DEFAULT, DoorsHydraulicsBattery.INITIAL_DESCRIPTION);
+            DOOR_HYDRAULICS_BATTERY_INCREMENTAL = ConfigEntry(topSection, DoorsHydraulicsBattery.INCREMENTAL_SECTION, DoorsHydraulicsBattery.INCREMENTAL_DEFAULT, DoorsHydraulicsBattery.INCREMENTAL_DESCRIPTION);
 
             topSection = "Wheelbarrow";
             WHEELBARROW_ENABLED = ConfigEntry(topSection, "Enable the Wheelbarrow Item", true, "Allows you to buy a wheelbarrow to carry items outside of your inventory");

--- a/MoreShipUpgrades/Plugin.cs
+++ b/MoreShipUpgrades/Plugin.cs
@@ -636,6 +636,7 @@ namespace MoreShipUpgrades
             SetupContract();
             SetupSickBeats();
             SetupExtendDeadline();
+            SetupDoorsHydraulicsBattery();
         }
 
         private void SetupSickBeats()
@@ -723,6 +724,10 @@ namespace MoreShipUpgrades
         private void SetupExtendDeadline()
         {
             SetupGenericPerk<ExtendDeadlineScript>(ExtendDeadlineScript.UPGRADE_NAME);
+        }
+        private void SetupDoorsHydraulicsBattery()
+        {
+            SetupGenericPerk<DoorsHydraulicsBattery>(DoorsHydraulicsBattery.UPGRADE_NAME);
         }
         /// <summary>
         /// Generic function where it adds a script (specificed through the type) into an GameObject asset 

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/DoorsHydraulicsBattery.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/DoorsHydraulicsBattery.cs
@@ -1,0 +1,101 @@
+﻿using GameNetcodeStuff;
+using MoreShipUpgrades.Managers;
+using MoreShipUpgrades.Misc;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
+{
+    internal class DoorsHydraulicsBattery : BaseUpgrade
+    {
+        private static LGULogger logger;
+        public const string UPGRADE_NAME = "Shutter Batteries";
+        public const string PRICES_DEFAULT = "200,300,400";
+
+        public static string ENABLED_SECTION = $"Enable {UPGRADE_NAME}";
+        public static string ENABLED_DESCRIPTION = "Increases the amount of time the doors can remain shut";
+
+        public static string PRICE_SECTION = $"Price of {UPGRADE_NAME}";
+        public static int PRICE_DEFAULT = 300;
+
+        public static string INITIAL_SECTION = $"Initial battery boost";
+        public static float INITIAL_DEFAULT = 5f;
+        public static string INITIAL_DESCRIPTION = $"Initial battery boost for the doors' lock on first purchase";
+
+        public static string INCREMENTAL_SECTION = $"Incremental battery boost";
+        public static float INCREMENTAL_DEFAULT = 5f;
+        public static string INCREMENTAL_DESCRIPTION = $"Incremental battery boost for the doors' lock after purchase";
+
+
+        private static bool active;
+        private int currentLevel;
+
+        void Start()
+        {
+            upgradeName = UPGRADE_NAME;
+            logger = new LGULogger(upgradeName);
+            DontDestroyOnLoad(gameObject);
+            Register();
+        }
+        public override void load()
+        {
+            HangarShipDoor shipDoors = UpgradeBus.instance.GetShipDoors();
+            if (!active)
+            {
+                logger.LogDebug($"Adding initial {UpgradeBus.instance.cfg.DOOR_HYDRAULICS_BATTERY_INITIAL} to the door's power duration...");
+                shipDoors.doorPowerDuration += UpgradeBus.instance.cfg.DOOR_HYDRAULICS_BATTERY_INITIAL;
+            }
+            UpgradeBus.instance.doorsHydraulicsBattery = true;
+            active = true;
+            base.load();
+
+            float amountToIncrement = 0;
+            for (int i = 1; i < UpgradeBus.instance.doorsHydraulicsBatteryLevel + 1; i++)
+            {
+                if (i <= currentLevel) continue;
+                logger.LogDebug($"Adding incremental {UpgradeBus.instance.cfg.DOOR_HYDRAULICS_BATTERY_INCREMENTAL} to the door's power duration...");
+                amountToIncrement += UpgradeBus.instance.cfg.DOOR_HYDRAULICS_BATTERY_INCREMENTAL;
+            }
+            logger.LogDebug(amountToIncrement);
+            logger.LogDebug(shipDoors.doorPowerDuration);
+            shipDoors.doorPowerDuration += amountToIncrement;
+            currentLevel = UpgradeBus.instance.doorsHydraulicsBatteryLevel;
+        }
+
+
+        public override void Increment()
+        {
+            HangarShipDoor shipDoors = UpgradeBus.instance.GetShipDoors();
+            shipDoors.doorPowerDuration += UpgradeBus.instance.cfg.DOOR_HYDRAULICS_BATTERY_INCREMENTAL;
+            logger.LogDebug($"Adding incremental {UpgradeBus.instance.cfg.DOOR_HYDRAULICS_BATTERY_INCREMENTAL} to the ship door's battery...");
+            UpgradeBus.instance.doorsHydraulicsBatteryLevel++;
+            currentLevel++;
+        }
+
+        public override void Unwind()
+        {
+            HangarShipDoor shipDoors = UpgradeBus.instance.GetShipDoors();
+            if (active) ResetDoorsHydraulicsBattery(ref shipDoors);
+            base.Unwind();
+
+            UpgradeBus.instance.doorsHydraulicsBattery = false;
+            UpgradeBus.instance.doorsHydraulicsBatteryLevel = 0;
+            active = false;
+            currentLevel = 0;
+        }
+        public static void ResetDoorsHydraulicsBattery(ref HangarShipDoor shipDoors)
+        {
+            float doorsBatteryRemoval = UpgradeBus.instance.cfg.DOOR_HYDRAULICS_BATTERY_INITIAL;
+            for (int i = 0; i < UpgradeBus.instance.doorsHydraulicsBatteryLevel; i++)
+            {
+                doorsBatteryRemoval += UpgradeBus.instance.cfg.DOOR_HYDRAULICS_BATTERY_INCREMENTAL;
+            }
+            logger.LogDebug($"Removing ship door's battery boost ({shipDoors.doorPowerDuration}) with a boost of {doorsBatteryRemoval}");
+            shipDoors.doorPowerDuration -= doorsBatteryRemoval;
+            logger.LogDebug($"Upgrade reset on ship doors");
+            active = false;
+        }
+
+    }
+}

--- a/UnityFiles/ShipUpgrades/DoorsHydraulicsBattery.prefab
+++ b/UnityFiles/ShipUpgrades/DoorsHydraulicsBattery.prefab
@@ -1,0 +1,476 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &638249055317919807
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3260138205278579061}
+  - component: {fileID: 7557409928800405657}
+  - component: {fileID: 5438713676967947741}
+  m_Layer: 0
+  m_Name: x
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3260138205278579061
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 638249055317919807}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4811550299418051740}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 484.9, y: 281.5}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7557409928800405657
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 638249055317919807}
+  m_CullTransparentMesh: 1
+--- !u!114 &5438713676967947741
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 638249055317919807}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.9056604, g: 0.9056604, b: 0.9056604, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 6608450dbc8f21443a4f390dc4ab9f46, type: 3}
+    m_FontSize: 18
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 1
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 'X: '
+--- !u!1 &3601297156807338891
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4811550299418051740}
+  - component: {fileID: 5557766142801354880}
+  - component: {fileID: 4329811701920120823}
+  - component: {fileID: 3536698196748246215}
+  m_Layer: 0
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &4811550299418051740
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3601297156807338891}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3260138205278579061}
+  - {fileID: 2804643990210256028}
+  - {fileID: 5604104578495201040}
+  - {fileID: 3254448586145337433}
+  m_Father: {fileID: 6901526314252520495}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!223 &5557766142801354880
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3601297156807338891}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!114 &4329811701920120823
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3601297156807338891}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 1
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 1
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!114 &3536698196748246215
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3601297156807338891}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!1 &5861574402505188862
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6901526314252520495}
+  - component: {fileID: 7148446588576680961}
+  m_Layer: 0
+  m_Name: DoorsHydraulicsBattery
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6901526314252520495
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5861574402505188862}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 45.94936, y: -18.48943, z: -37.32386}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4811550299418051740}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7148446588576680961
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5861574402505188862}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  GlobalObjectIdHash: 951099334
+  AlwaysReplicateAsRoot: 0
+  SynchronizeTransform: 1
+  ActiveSceneSynchronization: 0
+  SceneMigrationSynchronization: 1
+  SpawnWithObservers: 1
+  DontDestroyWithOwner: 1
+  AutoObjectParentSync: 0
+--- !u!1 &7798773581684866590
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2804643990210256028}
+  - component: {fileID: 5733114962108083276}
+  - component: {fileID: 144412984518540408}
+  m_Layer: 0
+  m_Name: y
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2804643990210256028
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7798773581684866590}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4811550299418051740}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 484.9, y: 261.79993}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5733114962108083276
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7798773581684866590}
+  m_CullTransparentMesh: 1
+--- !u!114 &144412984518540408
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7798773581684866590}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.9056604, g: 0.9056604, b: 0.9056604, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 6608450dbc8f21443a4f390dc4ab9f46, type: 3}
+    m_FontSize: 18
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 1
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 'Y: '
+--- !u!1 &7826245556358379149
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5604104578495201040}
+  - component: {fileID: 1337005029496057407}
+  - component: {fileID: 8473704342424134824}
+  m_Layer: 0
+  m_Name: z
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5604104578495201040
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7826245556358379149}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4811550299418051740}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 484.9, y: 241.49994}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1337005029496057407
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7826245556358379149}
+  m_CullTransparentMesh: 1
+--- !u!114 &8473704342424134824
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7826245556358379149}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.9056604, g: 0.9056604, b: 0.9056604, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 6608450dbc8f21443a4f390dc4ab9f46, type: 3}
+    m_FontSize: 18
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 1
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 'Z: '
+--- !u!1 &8153967669838828465
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3254448586145337433}
+  - component: {fileID: 4060026081338105428}
+  - component: {fileID: 4130001601002802232}
+  m_Layer: 0
+  m_Name: time
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3254448586145337433
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8153967669838828465}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4811550299418051740}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 510.2, y: 225.90002}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4060026081338105428
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8153967669838828465}
+  m_CullTransparentMesh: 1
+--- !u!114 &4130001601002802232
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8153967669838828465}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.9056604, g: 0.9056604, b: 0.9056604, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: 6608450dbc8f21443a4f390dc4ab9f46, type: 3}
+    m_FontSize: 18
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 1
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 

--- a/UnityFiles/ShipUpgrades/DoorsHydraulicsBattery.prefab.meta
+++ b/UnityFiles/ShipUpgrades/DoorsHydraulicsBattery.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d5fcae0c063a09c43aa461831bc7dc0c
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: shipupgrades
+  assetBundleVariant: 


### PR DESCRIPTION
- Increases the amount of time in which the doors remain closed
- Default initial price is 300
- Default prices are 200, 300 and 400
- Default initial battery boost is 5 (vanilla's initial value seems to be 30)
- Default incremental battery boost is 5

- The logic behind the upgrade is basically increasing the value of HangarShipDoor.doorPowerDuration to increase the amount of time it keeps closed (HangarShipDoor.doorPower is the ship's current % battery)
- Implementation wise, the resets of the ship's attributes must be done through RPCs so that everyone's have the exact same behaviour with the ship.

This in suggestion to a given [issue](https://github.com/Malcolm-Q/LC-LateGameUpgrades/issues/170)