### PR TITLE
Implementation of Scrap Insurance

### DIFF
--- a/MoreShipUpgrades/Managers/UpgradeBus.cs
+++ b/MoreShipUpgrades/Managers/UpgradeBus.cs
@@ -121,6 +121,8 @@ namespace MoreShipUpgrades.Managers
         internal bool pager;
         internal pagerScript pageScript;
 
+        public bool insurance;
+
         public Dictionary<string,GameObject> samplePrefabs = new Dictionary<string,GameObject>();
         public GameObject nightVisionPrefab;
         public bool sickBeats;
@@ -179,6 +181,7 @@ namespace MoreShipUpgrades.Managers
         {
             ResetPlayerAttributes();
             EffectsActive = false;
+            insurance = false;
             DestroyTraps = false;
             scannerUpgrade = false;
             nightVision = false;

--- a/MoreShipUpgrades/Misc/AssetBundleHandler.cs
+++ b/MoreShipUpgrades/Misc/AssetBundleHandler.cs
@@ -48,6 +48,7 @@ namespace MoreShipUpgrades.Misc
             { lockSmithScript.UPGRADE_NAME, root+"LockSmith.prefab" },
             { playerHealthScript.UPGRADE_NAME, root+"PlayerHealth.prefab" },
             { ExtendDeadlineScript.UPGRADE_NAME, root+"ExtendDeadline.prefab" },
+            { ScrapInsurance.COMMAND_NAME, root+"ScrapInsurance.prefab" },
 
             { "Advanced Portable Tele", "Assets/ShipUpgrades/TpButtonAdv.asset" },
             { "Portable Tele", "Assets/ShipUpgrades/TpButton.asset" },

--- a/MoreShipUpgrades/Misc/CommandParser.cs
+++ b/MoreShipUpgrades/Misc/CommandParser.cs
@@ -1,5 +1,6 @@
 ﻿using GameNetcodeStuff;
 using MoreShipUpgrades.Managers;
+using MoreShipUpgrades.UpgradeComponents.Commands;
 using MoreShipUpgrades.UpgradeComponents.Items.Contracts.Exorcism;
 using MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades;
 using Newtonsoft.Json;
@@ -531,10 +532,36 @@ namespace MoreShipUpgrades.Misc
                 case "load": outputNode = ExecuteLoadCommands(secondWord, fullText, ref terminal, ref outputNode); return;
                 case "scan": outputNode = ExecuteScanCommands(secondWord, ref outputNode); return;
                 case "transmit": outputNode = ExecuteTransmitMessage(fullText.Substring(firstWord.Length+1), ref outputNode); return;
+                case "scrap": outputNode = ExecuteScrapCommands(secondWord, ref terminal, ref outputNode); return;
                 default: outputNode = ExecuteUpgradeCommand(fullText, ref terminal, ref outputNode); return;
             }
         }
+        private static TerminalNode ExecuteScrapInsuranceCommand(ref Terminal terminal, ref TerminalNode outputNode)
+        {
+            if (!UpgradeBus.instance.cfg.SCRAP_INSURANCE_ENABLED) return outputNode;
 
+            if (ScrapInsurance.ScrapInsuranceStatus())
+                return DisplayTerminalMessage($"You already purchased insurance to protect your scrap belongings.\n\n");
+
+            if (!StartOfRound.Instance.inShipPhase)
+                return DisplayTerminalMessage($"You can only acquire insurance while in orbit.\n\n");
+
+            if (terminal.groupCredits < UpgradeBus.instance.cfg.SCRAP_INSURANCE_PRICE)
+                return DisplayTerminalMessage($"Not enough credits to purchase Scrap Insurance.\nPrice: {UpgradeBus.instance.cfg.SCRAP_INSURANCE_PRICE}\nCurrent credits: {terminal.groupCredits}\n\n");
+
+            terminal.groupCredits -= UpgradeBus.instance.cfg.SCRAP_INSURANCE_PRICE;
+            LGUStore.instance.SyncCreditsServerRpc(terminal.groupCredits);
+            ScrapInsurance.TurnOnScrapInsurance();
+            return DisplayTerminalMessage($"Scrap Insurance has been activated.\nIn case of a team wipe in your next trip, your scrap will be preserved.\n\n");
+        }
+        private static TerminalNode ExecuteScrapCommands(string secondWord, ref Terminal terminal, ref TerminalNode outputNode)
+        {
+            switch(secondWord)
+            {
+                case "insurance": return ExecuteScrapInsuranceCommand(ref terminal, ref outputNode);
+                default: return outputNode;
+            }
+        }
         private static TerminalNode LookupDemon(string secondWord, string thirdWord)
         {
             string demon = secondWord.ToUpper();

--- a/MoreShipUpgrades/Misc/PluginConfig.cs
+++ b/MoreShipUpgrades/Misc/PluginConfig.cs
@@ -4,6 +4,7 @@ using Newtonsoft.Json;
 using System.Collections.Generic;
 using MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades;
 using MoreShipUpgrades.UpgradeComponents.TierUpgrades;
+using MoreShipUpgrades.UpgradeComponents.Commands;
 
 
 namespace MoreShipUpgrades.Misc
@@ -35,6 +36,7 @@ namespace MoreShipUpgrades.Misc
         public bool EXTEND_DEADLINE_ENABLED { get; set; }
         public bool WHEELBARROW_ENABLED { get; set; }
         public bool SCRAP_WHEELBARROW_ENABLED { get; set; }
+        public bool SCRAP_INSURANCE_ENABLED {  get; set; }
 
         // individual or shared
         public bool ADVANCED_TELE_INDIVIDUAL { get; set; }
@@ -78,6 +80,7 @@ namespace MoreShipUpgrades.Misc
         public int EXTEND_DEADLINE_PRICE { get; set; }
         public int CONTRACT_PRICE { get; set; }
         public int WHEELBARROW_PRICE { get; set; }
+        public int SCRAP_INSURANCE_PRICE { get; set; }
 
         // attributes
         public float BIGGER_LUNGS_STAMINA_REGEN_INCREASE { get; set; }
@@ -479,6 +482,10 @@ namespace MoreShipUpgrades.Misc
             DIVEKIT_PRICE = ConfigEntry(topSection, "price", 650, "Price for Diving Kit.");
             DIVEKIT_WEIGHT = ConfigEntry(topSection, "Item weight", 1.65f, "-1 and multiply by 100 (1.65 = 65 lbs)");
             DIVEKIT_TWO_HANDED = ConfigEntry(topSection, "Two Handed Item", true, "One or two handed item.");
+
+            topSection = ScrapInsurance.COMMAND_NAME;
+            SCRAP_INSURANCE_ENABLED = ConfigEntry(topSection, "Enable Scrap Insurance Command", true, "One time purchase which allows you to keep all your scrap upon a team wipe on a moon trip");
+            SCRAP_INSURANCE_PRICE = ConfigEntry(topSection, "Price of Scrap Insurance", ScrapInsurance.DEFAULT_PRICE);
 
             topSection = "Wheelbarrow";
             WHEELBARROW_ENABLED = ConfigEntry(topSection, "Enable the Wheelbarrow Item", true, "Allows you to buy a wheelbarrow to carry items outside of your inventory");

--- a/MoreShipUpgrades/Patches/RoundManagerPatcher.cs
+++ b/MoreShipUpgrades/Patches/RoundManagerPatcher.cs
@@ -1,6 +1,11 @@
 ﻿using HarmonyLib;
 using MoreShipUpgrades.Managers;
 using MoreShipUpgrades.Misc;
+using MoreShipUpgrades.UpgradeComponents.Commands;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
 
 namespace MoreShipUpgrades.Patches
 {
@@ -39,6 +44,14 @@ namespace MoreShipUpgrades.Patches
             logger.LogDebug("Changing back the deadline...");
             TimeOfDay.Instance.daysUntilDeadline = previousDaysDeadline;
             savedPrevious = false;
+        }
+
+        [HarmonyPatch(nameof(RoundManager.DespawnPropsAtEndOfRound))]
+        [HarmonyPostfix]
+        public static void DespawnPropsAtEndOfRoundPostfix()
+        {
+            if (!UpgradeBus.instance.cfg.SCRAP_INSURANCE_ENABLED) return;
+            ScrapInsurance.TurnOffScrapInsurance();
         }
     }
 }

--- a/MoreShipUpgrades/Patches/RoundManagerTranspilerPatcher.cs
+++ b/MoreShipUpgrades/Patches/RoundManagerTranspilerPatcher.cs
@@ -1,0 +1,35 @@
+﻿using HarmonyLib;
+using MoreShipUpgrades.UpgradeComponents.Commands;
+using System;
+using System.Collections.Generic;
+using System.Reflection.Emit;
+using System.Reflection;
+using System.Text;
+using MoreShipUpgrades.Misc;
+
+namespace MoreShipUpgrades.Patches
+{
+    [HarmonyPatch(typeof(RoundManager))]
+    internal class RoundManagerTranspilerPatcher
+    {
+        private static LGULogger logger = new LGULogger(nameof(RoundManagerPatcher));
+        [HarmonyPatch(nameof(RoundManager.DespawnPropsAtEndOfRound))]
+        [HarmonyTranspiler]
+        public static IEnumerable<CodeInstruction> DespawnPropsAtEndOfRoundTranspiler(IEnumerable<CodeInstruction> instructions)
+        {
+            FieldInfo allPlayersDead = typeof(StartOfRound).GetField(nameof(StartOfRound.allPlayersDead));
+            MethodInfo scrapInsuranceStatus = typeof(ScrapInsurance).GetMethod(nameof(ScrapInsurance.GetScrapInsuranceStatus));
+
+            List<CodeInstruction> codes = new List<CodeInstruction>(instructions);
+            for (int i = 0; i < codes.Count; i++)
+            {
+                if (!(codes[i].opcode == OpCodes.Ldfld && codes[i].operand == (object)allPlayersDead)) continue;
+                codes.Insert(i + 1, new CodeInstruction(OpCodes.And));
+                codes.Insert(i + 1, new CodeInstruction(OpCodes.Not));
+                codes.Insert(i + 1, new CodeInstruction(OpCodes.Call, scrapInsuranceStatus));
+                break;
+            }
+            return codes;
+        }
+    }
+}

--- a/MoreShipUpgrades/Patches/TerminalPatcher.cs
+++ b/MoreShipUpgrades/Patches/TerminalPatcher.cs
@@ -14,8 +14,9 @@ namespace MoreShipUpgrades.Patches
         private const string EXTEND_HELP_COMMAND = ">EXTEND DEADLINE <DAYS>\nExtends the deadline by specified amount. Consumes {0} for each day extended.\n\n";
         private const string INTERNS_HELP_COMMAND = ">INTERNS / INTERN \nRevives the selected player in radar with a new employee. Consumes {0} credits for each revive.\n\n";
         private const string CONTRACT_HELP_COMMAND = ">CONTRACT \nGives you a random contract for a scrap item with considerable value and lasts til you leave from assigned planet.\nConsumes {0} credits for each contract and will be unable to get another contract til current has expired.\n\n";
-        private const string ATK_HELP_COMMAND = ">ATK / INITATTACK \n Stuns nearby enemies for a set period of time. Only applicable when Discombobulator has been purchased\n\n";
-        private const string CD_HELP_COMMAND = ">CD / COOLDOWN \n Shows the current cooldown of the ship stun ability. Only applicable when Discombobulator has been purchased\n\n";
+        private const string ATK_HELP_COMMAND = ">ATK / INITATTACK \nStuns nearby enemies for a set period of time. Only applicable when Discombobulator has been purchased\n\n";
+        private const string CD_HELP_COMMAND = ">CD / COOLDOWN \nShows the current cooldown of the ship stun ability. Only applicable when Discombobulator has been purchased\n\n";
+        private const string SCRAP_INSURANCE_COMMAND = "> SCRAP INSURANCE \nActivates an insurance policy on scrap stored in the ship incase of a team wipe occurs.\nCan only be bought while in orbit and will only apply in the next moon land after purchase.\nConsumes {0} credits for each activation of insurance.\n\n";
         [HarmonyPostfix]
         [HarmonyPatch("Start")]
         private static void StartPostfix(ref Terminal __instance)
@@ -29,6 +30,7 @@ namespace MoreShipUpgrades.Patches
             HandleHelpInterns(ref helpNode);
             HandleHelpContract(ref helpNode);
             HandleHelpDiscombobulator(ref helpNode);
+            HandleHelpScrapInsurance(ref helpNode);
             endingIndex = helpNode.displayText.Length;
         }
         private static void HandleHelpCommand(ref TerminalNode helpNode, string helpText, bool enabled = true)
@@ -47,6 +49,10 @@ namespace MoreShipUpgrades.Patches
                 helpNode.displayText = text;
                 return;
             }
+        }
+        private static void HandleHelpScrapInsurance(ref TerminalNode helpNode)
+        {
+            HandleHelpCommand(ref helpNode, string.Format(SCRAP_INSURANCE_COMMAND, UpgradeBus.instance.cfg.SCRAP_INSURANCE_PRICE), UpgradeBus.instance.cfg.SCRAP_INSURANCE_ENABLED);
         }
         private static void HandleHelpDiscombobulator(ref TerminalNode helpNode)
         {

--- a/MoreShipUpgrades/Plugin.cs
+++ b/MoreShipUpgrades/Plugin.cs
@@ -636,6 +636,7 @@ namespace MoreShipUpgrades
             SetupContract();
             SetupSickBeats();
             SetupExtendDeadline();
+            SetupScrapInsurance();
         }
 
         private void SetupSickBeats()
@@ -723,6 +724,10 @@ namespace MoreShipUpgrades
         private void SetupExtendDeadline()
         {
             SetupGenericPerk<ExtendDeadlineScript>(ExtendDeadlineScript.UPGRADE_NAME);
+        }
+        private void SetupScrapInsurance()
+        {
+            SetupGenericPerk<ScrapInsurance>(ScrapInsurance.COMMAND_NAME);
         }
         /// <summary>
         /// Generic function where it adds a script (specificed through the type) into an GameObject asset 

--- a/MoreShipUpgrades/UpgradeComponents/Commands/ScrapInsurance.cs
+++ b/MoreShipUpgrades/UpgradeComponents/Commands/ScrapInsurance.cs
@@ -1,0 +1,48 @@
+﻿using MoreShipUpgrades.Managers;
+using MoreShipUpgrades.Misc;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Unity.Netcode;
+
+namespace MoreShipUpgrades.UpgradeComponents.Commands
+{
+    internal class ScrapInsurance : NetworkBehaviour
+    {
+        public static string COMMAND_NAME = "Scrap Insurance";
+        public static int DEFAULT_PRICE = 400;
+        void Start()
+        {
+            DontDestroyOnLoad(gameObject);
+            UpgradeBus.instance.insurance = false;
+        }
+        public static bool GetScrapInsuranceStatus()
+        {
+            LGULogger logger = new LGULogger(COMMAND_NAME);
+            logger.LogDebug("Grabbing status of insurance...");
+            return UpgradeBus.instance.insurance;
+        }
+        public static bool ScrapInsuranceStatus()
+        {
+            return UpgradeBus.instance.insurance;
+        }
+        public static void TurnOnScrapInsurance()
+        {
+            LGULogger logger = new LGULogger(COMMAND_NAME);
+            logger.LogDebug("Turning on...");
+            ToggleInsurance(true);
+        }
+
+        public static void TurnOffScrapInsurance()
+        {
+            LGULogger logger = new LGULogger(COMMAND_NAME);
+            logger.LogDebug("Turning off...");
+            ToggleInsurance(false);
+        }
+
+        static void ToggleInsurance(bool enabled)
+        {
+            UpgradeBus.instance.insurance = enabled;
+        }
+    }
+}


### PR DESCRIPTION
- Allows you to keep scrap after a team wipe when bought
- Default price is 400 credits (configurable)
- Implementation wise, two transpilers which stop the hud from displaying "All scrap lost" and the logic which deletes all scrap items in the ship if all players are dead and a postifx after the attempted deletion to turn off scrap insurance.
- I really wanted to use ScrapInsurance as Singleton but for some reason it doesn't load so Start never starts. I have no idea what's happerning. :c

As suggested in a [issue](https://github.com/Malcolm-Q/LC-LateGameUpgrades/issues/151)