### PR TITLE
Fixes to Wheelbarrow

### DIFF
--- a/MoreShipUpgrades/Misc/PluginConfig.cs
+++ b/MoreShipUpgrades/Misc/PluginConfig.cs
@@ -495,12 +495,12 @@ namespace MoreShipUpgrades.Misc
             SCRAP_WHEELBARROW_ENABLED = ConfigEntry(topSection, "Enable the Wheelbarrow Scrap Item", true, "Allows you to scavenge a wheelbarrow in which you can store items on");
             SCRAP_WHEELBARROW_RARITY = ConfigEntry(topSection, "Spawn chance of Scrap Wheelbarrow Item", 0.9f, "How likely it is to a scrap wheelbarrow item to spawn when landing on a moon.");
             SCRAP_WHEELBARROW_WEIGHT = ConfigEntry(topSection, "Weight of the Wheelbarrow Scrap Item", 25f, "Weight of the scrap wheelbarrow's without any items in lbs");
-            SCRAP_WHEELBARROW_MAXIMUM_AMOUNT_ITEMS = ConfigEntry(topSection, "Maximum amount of items", 6, "Amount of items allowed before the scrap wheelbarrow is considered full");
-            SCRAP_WHEELBARROW_WEIGHT_REDUCTION_MULTIPLIER = ConfigEntry(topSection, "Weight reduction multiplier", 0.5f, "How much an item's weight will be ignored to the scrap wheelbarrow's total weight");
+            SCRAP_WHEELBARROW_MAXIMUM_AMOUNT_ITEMS = ConfigEntry(topSection, "Maximum amount of items for Scrap Wheelbarrow", 6, "Amount of items allowed before the scrap wheelbarrow is considered full");
+            SCRAP_WHEELBARROW_WEIGHT_REDUCTION_MULTIPLIER = ConfigEntry(topSection, "Weight reduction multiplier for Scrap Wheelbarrow", 0.5f, "How much an item's weight will be ignored to the scrap wheelbarrow's total weight");
             SCRAP_WHEELBARROW_MINIMUM_VALUE = ConfigEntry(topSection, "Minimum scrap value", 50, "Lower boundary of the scrap's possible value");
             SCRAP_WHEELBARROW_MAXIMUM_VALUE = ConfigEntry(topSection, "Maximum scrap value", 100, "Higher boundary of the scrap's possible value");
             SCRAP_WHEELBARROW_RESTRICTION_MODE = ConfigEntry(topSection, "Restrictions on the Wheelbarrow Scrap Item", "ItemCount", "Restriction applied when trying to insert an item on the scrap wheelbarrow.\nSupported values: None, ItemCount, TotalWeight, All");
-            SCRAP_WHEELBARROW_MAXIMUM_WEIGHT_ALLOWED = ConfigEntry(topSection, "Maximum amount of weight", 100f, "How much weight (in lbs) a scrap wheelbarrow can carry in items before it is considered full.");
+            SCRAP_WHEELBARROW_MAXIMUM_WEIGHT_ALLOWED = ConfigEntry(topSection, "Maximum amount of weight for Scrap Wheelbarrow", 100f, "How much weight (in lbs) a scrap wheelbarrow can carry in items before it is considered full.");
             SCRAP_WHEELBARROW_NOISE_RANGE = ConfigEntry(topSection, "Noise range of the Wheelbarrow Scrap Item", 18f, "How far the scrap wheelbarrow sound propagates to nearby enemies when in movement");
             SCRAP_WHEELBARROW_LOOK_SENSITIVITY_DRAWBACK = ConfigEntry(topSection, "Look sensitivity drawback of the Scrap Wheelbarrow Item", 0.8f, "Value multiplied on the player's look sensitivity when moving with the Scrap wheelbarrow Item");
             SCRAP_WHEELBARROW_MOVEMENT_SLOPPY = ConfigEntry(topSection, "Sloppiness of the Scrap Wheelbarrow Item", 2f, "Value multiplied on the player's movement to give the feeling of drifting while carrying the Scrap Wheelbarrow Item");

--- a/MoreShipUpgrades/Plugin.cs
+++ b/MoreShipUpgrades/Plugin.cs
@@ -575,14 +575,16 @@ namespace MoreShipUpgrades
             wheelbarrow.allowDroppingAheadOfPlayer = true;
             wheelbarrow.isConductiveMetal = true;
             wheelbarrow.isScrap = true;
-            wheelbarrow.weight = 1f + (cfg.SCRAP_WHEELBARROW_WEIGHT/100f);
+            wheelbarrow.weight = 0.99f + (cfg.SCRAP_WHEELBARROW_WEIGHT/100f);
             ScrapWheelbarrow barrowScript = wheelbarrow.spawnPrefab.AddComponent<ScrapWheelbarrow>();
             barrowScript.itemProperties = wheelbarrow;
             barrowScript.wheelsClip = shoppingCartSound;
             LethalLib.Modules.NetworkPrefabs.RegisterNetworkPrefab(wheelbarrow.spawnPrefab);
+            LethalLib.Modules.Items.RegisterItem(wheelbarrow);
             Utilities.FixMixerGroups(wheelbarrow.spawnPrefab);
+            int amountToSpawn = cfg.SCRAP_WHEELBARROW_ENABLED ? 1 : 0;
 
-            AnimationCurve curve = new AnimationCurve(new Keyframe(0, 0), new Keyframe(cfg.SCRAP_WHEELBARROW_RARITY, 1), new Keyframe(1, 1));
+            AnimationCurve curve = new AnimationCurve(new Keyframe(0, 0), new Keyframe(cfg.SCRAP_WHEELBARROW_RARITY, amountToSpawn), new Keyframe(1, amountToSpawn));
             SpawnableMapObjectDef mapObjDef = ScriptableObject.CreateInstance<SpawnableMapObjectDef>();
             mapObjDef.spawnableMapObject = new SpawnableMapObject();
             mapObjDef.spawnableMapObject.prefabToSpawn = wheelbarrow.spawnPrefab;
@@ -603,7 +605,7 @@ namespace MoreShipUpgrades
             wheelbarrow.positionOffset = new Vector3(0f, -0.7f, 1.4f);
             wheelbarrow.allowDroppingAheadOfPlayer = true;
             wheelbarrow.isConductiveMetal = true;
-            wheelbarrow.weight = 1f + (cfg.WHEELBARROW_WEIGHT/100f);
+            wheelbarrow.weight = 0.99f + (cfg.WHEELBARROW_WEIGHT/100f);
             StoreWheelbarrow barrowScript = wheelbarrow.spawnPrefab.AddComponent<StoreWheelbarrow>();
             barrowScript.itemProperties = wheelbarrow;
             barrowScript.wheelsClip = wheelbarrowSound;

--- a/MoreShipUpgrades/UpgradeComponents/Items/Wheelbarrow/WheelbarrowScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/Items/Wheelbarrow/WheelbarrowScript.cs
@@ -253,6 +253,14 @@ namespace MoreShipUpgrades.UpgradeComponents.Items.Wheelbarrow
                 playerHeldBy.carryWeight += Mathf.Clamp(exoskeletonScript.DecreasePossibleWeight(itemProperties.weight - 1f), 0, 10f);
                 playerHeldBy.carryWeight -= Mathf.Clamp(exoskeletonScript.DecreasePossibleWeight(totalWeight - 1f), 0, 10f);
             }
+
+            GrabbableObject[] storedItems = GetComponentsInChildren<GrabbableObject>();
+            for (int i = 0; i < storedItems.Length; i++)
+            {
+                if (storedItems[i] is WheelbarrowScript) continue;
+                playerHeldBy.SetItemInElevator(playerHeldBy.isInHangarShipRoom, playerHeldBy.isInElevator, storedItems[i]);
+            }
+
             base.DiscardItem();
         }
         public override void GrabItem()


### PR DESCRIPTION
- Fixed weight having an additional 1 lb compared to configuration.
- Fixed some of scrap wheelbarrow's configuration options to not appear due to duplicate keys
- Possibly fixed enabled scrap wheelbarrow configuration not being used
- Fixed scrap items not appearing as "looted" when dropped in the ship inside a wheelbarrow