### PR TITLE
Implemented "Contract Cancel" command

### DIFF
--- a/MoreShipUpgrades/Misc/CommandParser.cs
+++ b/MoreShipUpgrades/Misc/CommandParser.cs
@@ -388,6 +388,7 @@ namespace MoreShipUpgrades.Misc
             switch(secondWord)
             {
                 case "cancel": return ExecuteContractCancelCommand(ref terminal);
+                case "info": return DisplayTerminalMessage(string.Format(AssetBundleHandler.GetInfoFromJSON("Contract"), UpgradeBus.instance.cfg.CONTRACT_PRICE));
                 default: return TryGetContract(ref terminal);
             }
         }

--- a/MoreShipUpgrades/Patches/TerminalPatcher.cs
+++ b/MoreShipUpgrades/Patches/TerminalPatcher.cs
@@ -14,6 +14,7 @@ namespace MoreShipUpgrades.Patches
         private const string EXTEND_HELP_COMMAND = ">EXTEND DEADLINE <DAYS>\nExtends the deadline by specified amount. Consumes {0} for each day extended.\n\n";
         private const string INTERNS_HELP_COMMAND = ">INTERNS / INTERN \nRevives the selected player in radar with a new employee. Consumes {0} credits for each revive.\n\n";
         private const string CONTRACT_HELP_COMMAND = ">CONTRACT \nGives you a random contract for a scrap item with considerable value and lasts til you leave from assigned planet.\nConsumes {0} credits for each contract and will be unable to get another contract til current has expired.\n\n";
+        private const string INFO_CONTRACT_HELP_COMMAND = ">CONTRACT INFO \nDisplays all information related to each contract and how to complete it.\n\n";
         private const string ATK_HELP_COMMAND = ">ATK / INITATTACK \n Stuns nearby enemies for a set period of time. Only applicable when Discombobulator has been purchased\n\n";
         private const string CD_HELP_COMMAND = ">CD / COOLDOWN \n Shows the current cooldown of the ship stun ability. Only applicable when Discombobulator has been purchased\n\n";
         [HarmonyPostfix]
@@ -56,7 +57,9 @@ namespace MoreShipUpgrades.Patches
         }
         private static void HandleHelpContract(ref TerminalNode helpNode)
         {
-            HandleHelpCommand(ref helpNode, string.Format(CONTRACT_HELP_COMMAND, UpgradeBus.instance.cfg.CONTRACT_PRICE), UpgradeBus.instance.cfg.CONTRACTS_ENABLED);
+            bool enabled = UpgradeBus.instance.cfg.CONTRACTS_ENABLED;
+            HandleHelpCommand(ref helpNode, string.Format(CONTRACT_HELP_COMMAND, UpgradeBus.instance.cfg.CONTRACT_PRICE), enabled);
+            HandleHelpCommand(ref helpNode, INFO_CONTRACT_HELP_COMMAND, enabled);
         }
         private static void HandleHelpInterns(ref TerminalNode helpNode)
         {


### PR DESCRIPTION
- When a contract has been accepted but the crew does not want to do it, they can type "contract cancel" to get rid of it.
- Will make a prompt to confirm to execute this confirm and if the user types anything other than "confirm", the cancel contract command is cancelled.
- After confirming the command, the selected contract will be reset to all clients through RPCs and they can decide to purchase another contract if they wish to.

Due to suggestion in a [issue](https://github.com/Malcolm-Q/LC-LateGameUpgrades/issues/203)