### PR TITLE
Two features implemented for Contracts system

### DIFF
--- a/MoreShipUpgrades/Misc/PluginConfig.cs
+++ b/MoreShipUpgrades/Misc/PluginConfig.cs
@@ -77,6 +77,7 @@ namespace MoreShipUpgrades.Misc
         public int PLAYER_HEALTH_PRICE { get; set; }
         public int EXTEND_DEADLINE_PRICE { get; set; }
         public int CONTRACT_PRICE { get; set; }
+        public int CONTRACT_SPECIFY_PRICE { get; set; }
         public int WHEELBARROW_PRICE { get; set; }
 
         // attributes
@@ -232,6 +233,7 @@ namespace MoreShipUpgrades.Misc
         public float SCRAP_WHEELBARROW_RARITY { get; set; }
         public bool SCRAP_WHEELBARROW_PLAY_NOISE {  get; set; }
         public float SCAV_VOLUME { get; set; }
+        public bool CONTRACT_FREE_MOONS_ONLY { get; set; }
 
         public PluginConfig(ConfigFile cfg)
         {
@@ -247,7 +249,9 @@ namespace MoreShipUpgrades.Misc
         {
             string topSection = "Contracts";
             CONTRACTS_ENABLED = ConfigEntry(topSection, "Enable the ability to purchase contracts / missions", true, "");
+            CONTRACT_FREE_MOONS_ONLY = ConfigEntry(topSection, "Random contracts on free moons only", true, "If true, \"contract\" command will only generate contracts on free moons.");
             CONTRACT_PRICE = ConfigEntry(topSection, "Price of a random contract", 500, "");
+            CONTRACT_SPECIFY_PRICE = ConfigEntry(topSection, "Price of a specified moon contract", 750, "");
             CONTRACT_BUG_REWARD = ConfigEntry(topSection, "Value of an exterminator contract reward", 500, "");
             CONTRACT_EXOR_REWARD = ConfigEntry(topSection, "Value of an exorcism contract reward", 500, "");
             CONTRACT_DEFUSE_REWARD = ConfigEntry(topSection, "Value of an defusal contract reward", 500, "");

--- a/MoreShipUpgrades/Patches/TerminalPatcher.cs
+++ b/MoreShipUpgrades/Patches/TerminalPatcher.cs
@@ -13,7 +13,7 @@ namespace MoreShipUpgrades.Patches
         private static int endingIndex = -1;
         private const string EXTEND_HELP_COMMAND = ">EXTEND DEADLINE <DAYS>\nExtends the deadline by specified amount. Consumes {0} for each day extended.\n\n";
         private const string INTERNS_HELP_COMMAND = ">INTERNS / INTERN \nRevives the selected player in radar with a new employee. Consumes {0} credits for each revive.\n\n";
-        private const string CONTRACT_HELP_COMMAND = ">CONTRACT \nGives you a random contract for a scrap item with considerable value and lasts til you leave from assigned planet.\nConsumes {0} credits for each contract and will be unable to get another contract til current has expired.\n\n";
+        private const string CONTRACT_HELP_COMMAND = ">CONTRACT [moon]\nGives you a random contract for a scrap item with considerable value and lasts til you leave from assigned planet.\nConsumes {0} credits for each contract and will be unable to get another contract til current has expired.\nIf a moon is specified, it will generate a contract for that moon for the cost of {1} Company credits instead.\n\n";
         private const string INFO_CONTRACT_HELP_COMMAND = ">CONTRACT INFO \nDisplays all information related to each contract and how to complete it.\n\n";
         private const string ATK_HELP_COMMAND = ">ATK / INITATTACK \n Stuns nearby enemies for a set period of time. Only applicable when Discombobulator has been purchased\n\n";
         private const string CD_HELP_COMMAND = ">CD / COOLDOWN \n Shows the current cooldown of the ship stun ability. Only applicable when Discombobulator has been purchased\n\n";
@@ -58,7 +58,7 @@ namespace MoreShipUpgrades.Patches
         private static void HandleHelpContract(ref TerminalNode helpNode)
         {
             bool enabled = UpgradeBus.instance.cfg.CONTRACTS_ENABLED;
-            HandleHelpCommand(ref helpNode, string.Format(CONTRACT_HELP_COMMAND, UpgradeBus.instance.cfg.CONTRACT_PRICE), enabled);
+            HandleHelpCommand(ref helpNode, string.Format(CONTRACT_HELP_COMMAND, UpgradeBus.instance.cfg.CONTRACT_PRICE, UpgradeBus.instance.cfg.CONTRACT_SPECIFY_PRICE), enabled);
             HandleHelpCommand(ref helpNode, INFO_CONTRACT_HELP_COMMAND, enabled);
         }
         private static void HandleHelpInterns(ref TerminalNode helpNode)


### PR DESCRIPTION
- Implemented "contract [moon]" where the player can specify which moon they want to have a contract on. This will use a different price (configurable) and searches if that moon in fact exists to select. After finding it, it will ask the player to confirm the interaction and if so, it will use that moon as for the generated contract.
- Implemented "contract" being able to select any kind of moon present/loaded into the game instead of a set list we had before (this would allow limitation on custom moons) and added a configuration option for where random contract will only select free moons or it will pick any kind of moon. Also added a failsafe incase all of the moons somehow have a cost while having the free moons only configuration on in which it selects the last level it picked.