### PR TITLE
Fixing night vision being enabled for everyone when individual is on and shared all upgrades is off

### DIFF
--- a/MoreShipUpgrades/UpgradeComponents/Items/NightVisionGoggles.cs
+++ b/MoreShipUpgrades/UpgradeComponents/Items/NightVisionGoggles.cs
@@ -21,7 +21,7 @@ namespace MoreShipUpgrades.UpgradeComponents.Items
                 HUDManager.Instance.chatText.text += "<color=#FF0000>Night vision is already active!</color>";
                 return;
             }
-            if (!UpgradeBus.instance.IndividualUpgrades[nightVisionScript.UPGRADE_NAME])
+            if (UpgradeBus.instance.IndividualUpgrades[nightVisionScript.UPGRADE_NAME])
             {
                 LGUStore.instance.EnableNightVisionServerRpc();
             }


### PR DESCRIPTION
Problem here was we were doing "If this upgrade is not shared, share to others" instead of "If this upgrade is shared, share to others"