### PR TITLE
Refactor of implementing info and added world building texts for items and upgrades

### DIFF
--- a/MoreShipUpgrades/Managers/UpgradeBus.cs
+++ b/MoreShipUpgrades/Managers/UpgradeBus.cs
@@ -485,8 +485,7 @@ namespace MoreShipUpgrades.Managers
                 cfg.SHARED_UPGRADES ? true : !cfg.BEEKEEPER_INDIVIDUAL,
                 cfg.BEEKEEPER_ENABLED,
                 cfg.BEEKEEPER_PRICE,
-                ParseUpgradePrices(cfg.BEEKEEPER_UPGRADE_PRICES),
-                AssetBundleHandler.GetInfoFromJSON(beekeeperScript.UPGRADE_NAME));
+                ParseUpgradePrices(cfg.BEEKEEPER_UPGRADE_PRICES));
         }
 
         private void SetupProteinPowderTerminalNode() 
@@ -495,8 +494,7 @@ namespace MoreShipUpgrades.Managers
                                                 cfg.SHARED_UPGRADES ? true : !cfg.PROTEIN_INDIVIDUAL,
                                                 cfg.PROTEIN_ENABLED,
                                                 cfg.PROTEIN_PRICE,
-                                                ParseUpgradePrices(cfg.PROTEIN_UPGRADE_PRICES),
-                                                AssetBundleHandler.GetInfoFromJSON(proteinPowderScript.UPGRADE_NAME));
+                                                ParseUpgradePrices(cfg.PROTEIN_UPGRADE_PRICES));
         }
         private void SetupBiggerLungsTerminalNode()
         {
@@ -504,8 +502,7 @@ namespace MoreShipUpgrades.Managers
                                                 cfg.SHARED_UPGRADES ? true : !cfg.BIGGER_LUNGS_INDIVIDUAL,
                                                 cfg.BIGGER_LUNGS_ENABLED,
                                                 cfg.BIGGER_LUNGS_PRICE,
-                                                ParseUpgradePrices(cfg.BIGGER_LUNGS_UPGRADE_PRICES),
-                                                AssetBundleHandler.GetInfoFromJSON(biggerLungScript.UPGRADE_NAME));
+                                                ParseUpgradePrices(cfg.BIGGER_LUNGS_UPGRADE_PRICES));
         }
         private void SetupRunningShoesTerminalNode()
         {
@@ -513,8 +510,7 @@ namespace MoreShipUpgrades.Managers
                                                 cfg.SHARED_UPGRADES ? true : !cfg.RUNNING_SHOES_INDIVIDUAL,
                                                 cfg.RUNNING_SHOES_ENABLED,
                                                 cfg.RUNNING_SHOES_PRICE,
-                                                ParseUpgradePrices(cfg.RUNNING_SHOES_UPGRADE_PRICES),
-                                                AssetBundleHandler.GetInfoFromJSON(runningShoeScript.UPGRADE_NAME));
+                                                ParseUpgradePrices(cfg.RUNNING_SHOES_UPGRADE_PRICES));
         }
         private void SetupStrongLegsTerminalNode()
         {
@@ -522,8 +518,7 @@ namespace MoreShipUpgrades.Managers
                                                 cfg.SHARED_UPGRADES ? true : !cfg.STRONG_LEGS_INDIVIDUAL,
                                                 cfg.STRONG_LEGS_ENABLED,
                                                 cfg.STRONG_LEGS_PRICE,
-                                                ParseUpgradePrices(cfg.STRONG_LEGS_UPGRADE_PRICES),
-                                                AssetBundleHandler.GetInfoFromJSON(strongLegsScript.UPGRADE_NAME));
+                                                ParseUpgradePrices(cfg.STRONG_LEGS_UPGRADE_PRICES));
         }
         private void SetupMalwareBroadcasterTerminalNode()
         {
@@ -552,8 +547,7 @@ namespace MoreShipUpgrades.Managers
                                                 cfg.SHARED_UPGRADES ? true : !cfg.DISCOMBOBULATOR_INDIVIDUAL,
                                                 cfg.DISCOMBOBULATOR_ENABLED,
                                                 cfg.DISCOMBOBULATOR_PRICE,
-                                                ParseUpgradePrices(cfg.DISCO_UPGRADE_PRICES),
-                                                AssetBundleHandler.GetInfoFromJSON(terminalFlashScript.UPGRADE_NAME));
+                                                ParseUpgradePrices(cfg.DISCO_UPGRADE_PRICES));
         }
         private void SetupHunterTerminalNode()
         {
@@ -593,8 +587,7 @@ namespace MoreShipUpgrades.Managers
                                                 cfg.SHARED_UPGRADES ? true : !cfg.BACK_MUSCLES_INDIVIDUAL,
                                                 cfg.BACK_MUSCLES_ENABLED,
                                                 cfg.BACK_MUSCLES_PRICE,
-                                                ParseUpgradePrices(cfg.BACK_MUSCLES_UPGRADE_PRICES),
-                                                AssetBundleHandler.GetInfoFromJSON(exoskeletonScript.UPGRADE_NAME));
+                                                ParseUpgradePrices(cfg.BACK_MUSCLES_UPGRADE_PRICES));
         }
         private void SetupPagerTerminalNode()
         {
@@ -616,8 +609,7 @@ namespace MoreShipUpgrades.Managers
                                                 cfg.SHARED_UPGRADES ? true : !cfg.PLAYER_HEALTH_INDIVIDUAL,
                                                 cfg.PLAYER_HEALTH_ENABLED,
                                                 cfg.PLAYER_HEALTH_PRICE,
-                                                ParseUpgradePrices(cfg.PLAYER_HEALTH_UPGRADE_PRICES),
-                                                AssetBundleHandler.GetInfoFromJSON(playerHealthScript.UPGRADE_NAME));
+                                                ParseUpgradePrices(cfg.PLAYER_HEALTH_UPGRADE_PRICES));
         }
         /// <summary>
         /// Generic function where it adds a terminal node for an upgrade that can be purchased multiple times
@@ -632,8 +624,7 @@ namespace MoreShipUpgrades.Managers
                                                         bool shareStatus,
                                                         bool enabled,
                                                         int initialPrice,
-                                                        int[] prices,
-                                                        string infoFormat = ""
+                                                        int[] prices
                                                         )
         {
             GameObject multiPerk = AssetBundleHandler.GetPerkGameObject(upgradeName) ;

--- a/MoreShipUpgrades/Managers/UpgradeBus.cs
+++ b/MoreShipUpgrades/Managers/UpgradeBus.cs
@@ -709,6 +709,19 @@ namespace MoreShipUpgrades.Managers
                 for(int i = 0; i < prices.Length; i++)
                     infoString += complexInfoFunctions[upgradeName](i+2, prices[i]);
             }
+            switch(upgradeName) // Need to refactor later for easier upgrade implementation (maybe virtual GetWorldBuildingText() function in BaseUpgrade in which each overrides it)
+            {
+                case beekeeperScript.UPGRADE_NAME: infoString += string.Format(beekeeperScript.WORLD_BUILDING_TEXT, shareStatus ? "your crew" : "you"); break;
+                case biggerLungScript.UPGRADE_NAME: infoString += string.Format(biggerLungScript.WORLD_BUILDING_TEXT, shareStatus ? "your crew's suit oxigen delivery systems" : "your suit's oxygen delivery system"); break;
+                case runningShoeScript.UPGRADE_NAME: infoString += string.Format(runningShoeScript.WORLD_BUILDING_TEXT, shareStatus ? "could give your crew" : "can give you", shareStatus ? "y'all's" : "your"); break;
+                case strongLegsScript.UPGRADE_NAME: infoString += string.Format(strongLegsScript.WORLD_BUILDING_TEXT, shareStatus ? "proprietary pressure-assisted kneebraces to your crew" : "a proprietary pressure-assisted kneebrace"); break;
+                case terminalFlashScript.UPGRADE_NAME: infoString += string.Format(terminalFlashScript.WORLD_BUILDING_TEXT, shareStatus ? "your crew" : "you"); break;
+                case exoskeletonScript.UPGRADE_NAME: infoString += string.Format(exoskeletonScript.WORLD_BUILDING_TEXT, shareStatus ? "departments" : "employees"); break;
+                case proteinPowderScript.UPGRADE_NAME: infoString += proteinPowderScript.WORLD_BUILDING_TEXT; break;
+                case strongerScannerScript.UPGRADE_NAME: infoString += string.Format(strongerScannerScript.WORLD_BUILDING_TEXT, shareStatus ? "a department" : "one"); break;
+                case playerHealthScript.UPGRADE_NAME: infoString += string.Format(playerHealthScript.WORLD_BUILDING_TEXT, shareStatus ? "your crew" : "you"); break;
+                case hunterScript.UPGRADE_NAME: infoString += hunterScript.WORLD_BUILDING_TEXT; break;
+            }
             CustomTerminalNode node = new CustomTerminalNode(upgradeName, initialPrice, infoString, multiPerk, prices, prices.Length);
             terminalNodes.Add(node);
             return node;
@@ -734,6 +747,11 @@ namespace MoreShipUpgrades.Managers
             IndividualUpgrades.Add(upgradeName, shareStatus);
             if (!enabled) return null;
 
+            switch (upgradeName) // Need to refactor later for easier upgrade implementation (maybe virtual GetWorldBuildingText() function in BaseUpgrade in which each overrides it)
+            {
+                case lockSmithScript.UPGRADE_NAME: info += string.Format(lockSmithScript.WORLD_BUILDING_TEXT, shareStatus ? "your crew" : "you", shareStatus ? "for each of your coworkers" : ""); break;
+                case lightningRodScript.UPGRADE_NAME: info += lightningRodScript.WORLD_BUILDING_TEXT; break;
+            }
             CustomTerminalNode node = new CustomTerminalNode(upgradeName, price, info, oneTimeUpgrade);
             terminalNodes.Add(node);
             return node;

--- a/MoreShipUpgrades/Misc/Tools.cs
+++ b/MoreShipUpgrades/Misc/Tools.cs
@@ -173,5 +173,19 @@ namespace MoreShipUpgrades.Misc
             return false;
         }
 
+        internal static string GenerateInfoForUpgrade(string infoFormat, int initialPrice, int[] incrementalPrices, Func<int, float> infoFunction)
+        {
+            string info = string.Format(infoFormat, 1, initialPrice, infoFunction(0));
+            for (int i = 0; i < incrementalPrices.Length; i++)
+            {
+                float infoResult = infoFunction(i + 1);
+                if (infoResult % 1 == 0) // It's an Integer
+                    info += string.Format(infoFormat, i + 2, incrementalPrices[i], Mathf.RoundToInt(infoResult));
+                else
+                    info += string.Format(infoFormat, i + 2, incrementalPrices[i], infoResult);
+            }
+            return info;
+        }
+
     }
 }

--- a/MoreShipUpgrades/Plugin.cs
+++ b/MoreShipUpgrades/Plugin.cs
@@ -24,6 +24,7 @@ using MoreShipUpgrades.UpgradeComponents.Items.Contracts.BombDefusal;
 using MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades;
 using MoreShipUpgrades.UpgradeComponents.TierUpgrades;
 using MoreShipUpgrades.UpgradeComponents.Commands;
+using MoreShipUpgrades.UpgradeComponents.Interfaces;
 
 namespace MoreShipUpgrades
 {
@@ -381,11 +382,21 @@ namespace MoreShipUpgrades
             LethalLib.Modules.NetworkPrefabs.RegisterNetworkPrefab(helmet.spawnPrefab);
 
             UpgradeBus.instance.ItemsToSync.Add("Helmet", helmet);
-
-            TerminalNode node = ScriptableObject.CreateInstance<TerminalNode>();
-            node.displayText = string.Format(AssetBundleHandler.GetInfoFromJSON("Helmet"), cfg.HELMET_HITS_BLOCKED);
-            Items.RegisterShopItem(helmet, null, null, node, helmet.creditsWorth);
-
+            SetupStoreItem(helmet);
+        }
+        private TerminalNode SetupInfoNode(Item storeItem)
+        {
+            TerminalNode infoNode = ScriptableObject.CreateInstance<TerminalNode>();
+            GrabbableObject grabbableObject = storeItem.spawnPrefab.GetComponent<GrabbableObject>();
+            if (grabbableObject is IDisplayInfo displayInfo) infoNode.displayText += displayInfo.GetDisplayInfo() + "\n";
+            if (grabbableObject is IItemWorldBuilding worldBuilding) infoNode.displayText += worldBuilding.GetWorldBuildingText() + "\n";
+            infoNode.clearPreviousText = true;
+            return infoNode;
+        }
+        private void SetupStoreItem(Item storeItem)
+        {
+            TerminalNode infoNode = SetupInfoNode(storeItem);
+            Items.RegisterShopItem(shopItem: storeItem, itemInfo: infoNode, price: storeItem.creditsWorth);
         }
         private void SetupRegularTeleporterButton()
         {
@@ -407,12 +418,7 @@ namespace MoreShipUpgrades
 
             UpgradeBus.instance.ItemsToSync.Add("Tele", regularPortableTeleporter);
 
-            TerminalNode PortNode = ScriptableObject.CreateInstance<TerminalNode>();
-            PortNode.displayText = string.Format(AssetBundleHandler.GetInfoFromJSON("Portable Tele"), (int)(cfg.CHANCE_TO_BREAK * 100));
-            PortNode.displayText += RegularPortableTeleporter.WORLD_BUILDING_TEXT;
-            PortNode.clearPreviousText = true;
-
-            Items.RegisterShopItem(regularPortableTeleporter, null, null, PortNode, regularPortableTeleporter.creditsWorth);
+            SetupStoreItem(regularPortableTeleporter);
         }
         private void SetupAdvancedTeleporterButton()
         {
@@ -434,13 +440,7 @@ namespace MoreShipUpgrades
 
             UpgradeBus.instance.ItemsToSync.Add("AdvTele", advancedPortableTeleporter);
 
-            TerminalNode advNode = ScriptableObject.CreateInstance<TerminalNode>();
-            advNode.displayText = string.Format(AssetBundleHandler.GetInfoFromJSON("Advanced Portable Tele"), (int)(cfg.ADV_CHANCE_TO_BREAK * 100));
-            advNode.displayText += AdvancedPortableTeleporter.WORLD_BUILDING_TEXT;
-            advNode.clearPreviousText = true;
-
-            Items.RegisterShopItem(advancedPortableTeleporter, null, null, advNode, advancedPortableTeleporter.creditsWorth);
-
+            SetupStoreItem(advancedPortableTeleporter);
         }
 
         private void SetupNightVision()
@@ -461,15 +461,7 @@ namespace MoreShipUpgrades
 
             UpgradeBus.instance.ItemsToSync.Add("Night", nightVisionItem);
 
-            TerminalNode nightNode = ScriptableObject.CreateInstance<TerminalNode>();
-            string grantStatus = cfg.NIGHT_VISION_INDIVIDUAL || UpgradeBus.instance.cfg.SHARED_UPGRADES ? "one" : "all";
-            string loseOnDeath = cfg.LOSE_NIGHT_VIS_ON_DEATH ? "be" : "not be";
-            nightNode.displayText = string.Format(AssetBundleHandler.GetInfoFromJSON("Night Vision"), grantStatus, loseOnDeath);
-            nightNode.displayText += nightVisionScript.WORLD_BUILDING_TEXT;
-            nightNode.clearPreviousText = true;
-
-            Items.RegisterShopItem(nightVisionItem, null, null, nightNode, nightVisionItem.creditsWorth);
-
+            SetupStoreItem(nightVisionItem);
         }
         private void SetupDivingKit()
         {
@@ -489,11 +481,7 @@ namespace MoreShipUpgrades
 
             UpgradeBus.instance.ItemsToSync.Add("Dive",DiveItem);
 
-            TerminalNode medNode = ScriptableObject.CreateInstance<TerminalNode>();
-            string hands = cfg.DIVEKIT_TWO_HANDED ? "two" : "one";
-            medNode.displayText = $"DIVING KIT - ${cfg.DIVEKIT_PRICE}\n\nBreath underwater.\nWeights {Mathf.RoundToInt((DiveItem.weight -1 )*100)} lbs and is {hands} handed.\n\n";
-            Items.RegisterShopItem(DiveItem, null, null,medNode, DiveItem.creditsWorth);
-
+            SetupStoreItem(DiveItem);
         }
         private void SetupMedkit()
         {
@@ -512,9 +500,7 @@ namespace MoreShipUpgrades
             medScript.use = buttonPressed;
             LethalLib.Modules.NetworkPrefabs.RegisterNetworkPrefab(MedKitItem.spawnPrefab);
 
-            TerminalNode medNode = ScriptableObject.CreateInstance<TerminalNode>();
-            medNode.displayText = string.Format("MEDKIT - ${0}\n\nLeft click to heal yourself for {1} health.\nCan be used {2} times.\n", cfg.MEDKIT_PRICE, cfg.MEDKIT_HEAL_VALUE, cfg.MEDKIT_USES);
-            Items.RegisterShopItem(MedKitItem, null, null,medNode, MedKitItem.creditsWorth);
+            SetupStoreItem(MedKitItem);
 
             Item MedKitMapItem = AssetBundleHandler.GetItemObject("MedkitMapItem");
             if (MedKitMapItem == null) return;
@@ -553,9 +539,7 @@ namespace MoreShipUpgrades
 
             UpgradeBus.instance.ItemsToSync.Add("Peeper", Peeper);
 
-            TerminalNode peepNode = ScriptableObject.CreateInstance<TerminalNode>();
-            peepNode.displayText = "Looks at coil heads, don't lose it\n";
-            LethalLib.Modules.Items.RegisterShopItem(Peeper, null, null, peepNode, Peeper.creditsWorth);
+            SetupStoreItem(Peeper);
         }
         private void SetupWheelbarrows()
         {
@@ -631,9 +615,7 @@ namespace MoreShipUpgrades
 
             UpgradeBus.instance.ItemsToSync.Add("Wheel", wheelbarrow);
 
-            TerminalNode wheelbarrowNode = ScriptableObject.CreateInstance<TerminalNode>();
-            wheelbarrowNode.displayText = $"A portable container which has a maximum capacity of {cfg.WHEELBARROW_MAXIMUM_AMOUNT_ITEMS} and reduces the effective weight of the inserted items by {cfg.WHEELBARROW_WEIGHT_REDUCTION_MULTIPLIER*100} %.\nIt weighs {1f + (cfg.WHEELBARROW_WEIGHT/100f)} lbs";
-            LethalLib.Modules.Items.RegisterShopItem(wheelbarrow, null, null, wheelbarrowNode, wheelbarrow.creditsWorth);
+            SetupStoreItem(wheelbarrow);
         }
         private void SetupPerks()
         {

--- a/MoreShipUpgrades/Plugin.cs
+++ b/MoreShipUpgrades/Plugin.cs
@@ -409,6 +409,8 @@ namespace MoreShipUpgrades
 
             TerminalNode PortNode = ScriptableObject.CreateInstance<TerminalNode>();
             PortNode.displayText = string.Format(AssetBundleHandler.GetInfoFromJSON("Portable Tele"), (int)(cfg.CHANCE_TO_BREAK * 100));
+            PortNode.displayText += RegularPortableTeleporter.WORLD_BUILDING_TEXT;
+            PortNode.clearPreviousText = true;
 
             Items.RegisterShopItem(regularPortableTeleporter, null, null, PortNode, regularPortableTeleporter.creditsWorth);
         }
@@ -434,6 +436,9 @@ namespace MoreShipUpgrades
 
             TerminalNode advNode = ScriptableObject.CreateInstance<TerminalNode>();
             advNode.displayText = string.Format(AssetBundleHandler.GetInfoFromJSON("Advanced Portable Tele"), (int)(cfg.ADV_CHANCE_TO_BREAK * 100));
+            advNode.displayText += AdvancedPortableTeleporter.WORLD_BUILDING_TEXT;
+            advNode.clearPreviousText = true;
+
             Items.RegisterShopItem(advancedPortableTeleporter, null, null, advNode, advancedPortableTeleporter.creditsWorth);
 
         }
@@ -460,6 +465,9 @@ namespace MoreShipUpgrades
             string grantStatus = cfg.NIGHT_VISION_INDIVIDUAL || UpgradeBus.instance.cfg.SHARED_UPGRADES ? "one" : "all";
             string loseOnDeath = cfg.LOSE_NIGHT_VIS_ON_DEATH ? "be" : "not be";
             nightNode.displayText = string.Format(AssetBundleHandler.GetInfoFromJSON("Night Vision"), grantStatus, loseOnDeath);
+            nightNode.displayText += nightVisionScript.WORLD_BUILDING_TEXT;
+            nightNode.clearPreviousText = true;
+
             Items.RegisterShopItem(nightVisionItem, null, null, nightNode, nightVisionItem.creditsWorth);
 
         }

--- a/MoreShipUpgrades/UpgradeComponents/Interfaces/IDisplayInfo.cs
+++ b/MoreShipUpgrades/UpgradeComponents/Interfaces/IDisplayInfo.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MoreShipUpgrades.UpgradeComponents.Interfaces
+{
+    internal interface IDisplayInfo
+    {
+        string GetDisplayInfo();
+    }
+}

--- a/MoreShipUpgrades/UpgradeComponents/Interfaces/IItemWorldBuilding.cs
+++ b/MoreShipUpgrades/UpgradeComponents/Interfaces/IItemWorldBuilding.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MoreShipUpgrades.UpgradeComponents.Interfaces
+{
+    internal interface IItemWorldBuilding
+    {
+        string GetWorldBuildingText();
+    }
+}

--- a/MoreShipUpgrades/UpgradeComponents/Interfaces/IOneTimeUpgradeDisplayInfo.cs
+++ b/MoreShipUpgrades/UpgradeComponents/Interfaces/IOneTimeUpgradeDisplayInfo.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MoreShipUpgrades.UpgradeComponents.Interfaces
+{
+    internal interface IOneTimeUpgradeDisplayInfo
+    {
+        string GetDisplayInfo(int price = -1);
+    }
+}

--- a/MoreShipUpgrades/UpgradeComponents/Interfaces/ITierUpgradeDisplayInfo.cs
+++ b/MoreShipUpgrades/UpgradeComponents/Interfaces/ITierUpgradeDisplayInfo.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MoreShipUpgrades.UpgradeComponents.Interfaces
+{
+    internal interface ITierUpgradeDisplayInfo
+    {
+        string GetDisplayInfo(int initialPrice = -1, int maxLevels = -1, int[] incrementalPrices = null);
+    }
+}

--- a/MoreShipUpgrades/UpgradeComponents/Interfaces/IUpgradeWorldBuilding.cs
+++ b/MoreShipUpgrades/UpgradeComponents/Interfaces/IUpgradeWorldBuilding.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MoreShipUpgrades.UpgradeComponents.Interfaces
+{
+    internal interface IUpgradeWorldBuilding
+    {
+        string GetWorldBuildingText(bool shareStatus = false);
+    }
+}

--- a/MoreShipUpgrades/UpgradeComponents/Items/DivingKit.cs
+++ b/MoreShipUpgrades/UpgradeComponents/Items/DivingKit.cs
@@ -1,5 +1,6 @@
 ﻿using GameNetcodeStuff;
 using MoreShipUpgrades.Managers;
+using MoreShipUpgrades.UpgradeComponents.Interfaces;
 using UnityEngine;
 
 namespace MoreShipUpgrades.UpgradeComponents.Items
@@ -7,7 +8,7 @@ namespace MoreShipUpgrades.UpgradeComponents.Items
     /// <summary>
     /// <para>Item which allows players holding the item to breath underwater, however their vision will be blocked by the model as it will be placed on their head.</para>
     /// </summary>
-    internal class DivingKit : GrabbableObject
+    internal class DivingKit : GrabbableObject, IDisplayInfo
     {
         /// <summary>
         /// Local player of Network Manager
@@ -17,6 +18,15 @@ namespace MoreShipUpgrades.UpgradeComponents.Items
         /// Instance which controls the drowning timer of the player
         /// </summary>
         private StartOfRound roundInstance;
+
+        public string GetDisplayInfo()
+        {
+            string hands = UpgradeBus.instance.cfg.DIVEKIT_TWO_HANDED ? "two" : "one";
+            return $"DIVING KIT - ${UpgradeBus.instance.cfg.DIVEKIT_PRICE}\n\n" +
+                $"Breath underwater.\n" +
+                $"Weights {Mathf.RoundToInt((UpgradeBus.instance.cfg.DIVEKIT_WEIGHT - 1) * 100)} lbs and is {hands} handed.";
+        }
+
         public override void Start()
         {
             base.Start();

--- a/MoreShipUpgrades/UpgradeComponents/Items/Helmet.cs
+++ b/MoreShipUpgrades/UpgradeComponents/Items/Helmet.cs
@@ -1,10 +1,12 @@
 ﻿using MoreShipUpgrades.Managers;
+using MoreShipUpgrades.Misc;
+using MoreShipUpgrades.UpgradeComponents.Interfaces;
 using Unity.Netcode;
 using UnityEngine;
 
 namespace MoreShipUpgrades.UpgradeComponents.Items
 {
-    public class Helmet : GrabbableObject
+    public class Helmet : GrabbableObject, IDisplayInfo
     {
         public AudioClip hit;
         private AudioSource audio;
@@ -32,6 +34,11 @@ namespace MoreShipUpgrades.UpgradeComponents.Items
                 else LGUStore.instance.ReqSpawnAndMoveHelmetServerRpc(new NetworkObjectReference(playerHeldBy.GetComponent<NetworkObject>()), playerHeldBy.playerSteamId);
                 playerHeldBy.DespawnHeldObject();
             }
+        }
+
+        public string GetDisplayInfo()
+        {
+            return string.Format(AssetBundleHandler.GetInfoFromJSON("Helmet"), UpgradeBus.instance.cfg.HELMET_HITS_BLOCKED);
         }
     }
 }

--- a/MoreShipUpgrades/UpgradeComponents/Items/Medkit.cs
+++ b/MoreShipUpgrades/UpgradeComponents/Items/Medkit.cs
@@ -1,5 +1,6 @@
 ﻿using MoreShipUpgrades.Managers;
 using MoreShipUpgrades.Misc;
+using MoreShipUpgrades.UpgradeComponents.Interfaces;
 using MoreShipUpgrades.UpgradeComponents.TierUpgrades;
 using UnityEngine;
 using UnityEngine.InputSystem;
@@ -9,7 +10,7 @@ namespace MoreShipUpgrades.UpgradeComponents.Items
     /// <summary>
     /// Logical class which represents an item that can heal the player when activated
     /// </summary>
-    internal class Medkit : GrabbableObject
+    internal class Medkit : GrabbableObject, IDisplayInfo
     {
         /// <summary>
         /// Logger of the class
@@ -112,6 +113,13 @@ namespace MoreShipUpgrades.UpgradeComponents.Items
                 return false;
             }
             return true;
+        }
+
+        public string GetDisplayInfo()
+        {
+            return $"MEDKIT - ${UpgradeBus.instance.cfg.MEDKIT_PRICE}\n\n" +
+                $"Left click to heal yourself for {UpgradeBus.instance.cfg.MEDKIT_HEAL_VALUE} health.\n" +
+                $"Can be used {UpgradeBus.instance.cfg.MEDKIT_USES} times.";
         }
     }
 }

--- a/MoreShipUpgrades/UpgradeComponents/Items/NightVisionGoggles.cs
+++ b/MoreShipUpgrades/UpgradeComponents/Items/NightVisionGoggles.cs
@@ -1,11 +1,29 @@
 ﻿using MoreShipUpgrades.Managers;
+using MoreShipUpgrades.Misc;
+using MoreShipUpgrades.UpgradeComponents.Interfaces;
 using MoreShipUpgrades.UpgradeComponents.TierUpgrades;
+using UnityEngine.Experimental.GlobalIllumination;
 using UnityEngine.InputSystem;
 
 namespace MoreShipUpgrades.UpgradeComponents.Items
 {
-    internal class NightVisionGoggles : GrabbableObject
+    internal class NightVisionGoggles : GrabbableObject, IItemWorldBuilding, IDisplayInfo
     {
+        internal const string WORLD_BUILDING_TEXT = "Very old military surplus phosphor lens modules, retrofitted for compatibility with modern Company-issued helmets" +
+            " and offered to employees of The Company on a subscription plan. The base package comes with cheap batteries, but premium subscriptions offer regular issuances" +
+            " of higher-quality energy solutions, ranging from hobby grade to industrial application power banks. The modules also come with DRM that prevents the user from improvising" +
+            " with other kinds of batteries.";
+        public string GetDisplayInfo()
+        {
+            string grantStatus = UpgradeBus.instance.cfg.NIGHT_VISION_INDIVIDUAL || !UpgradeBus.instance.cfg.SHARED_UPGRADES ? "one" : "all";
+            string loseOnDeath = UpgradeBus.instance.cfg.LOSE_NIGHT_VIS_ON_DEATH ? "be" : "not be";
+            return string.Format(AssetBundleHandler.GetInfoFromJSON("Night Vision"), grantStatus, loseOnDeath);
+        }
+
+        public string GetWorldBuildingText()
+        {
+            return WORLD_BUILDING_TEXT;
+        }
         public override void DiscardItem()
         {
             playerHeldBy.activatingItem = false;

--- a/MoreShipUpgrades/UpgradeComponents/Items/Peeper.cs
+++ b/MoreShipUpgrades/UpgradeComponents/Items/Peeper.cs
@@ -1,9 +1,10 @@
 ﻿using MoreShipUpgrades.Managers;
+using MoreShipUpgrades.UpgradeComponents.Interfaces;
 using UnityEngine;
 
 namespace MoreShipUpgrades.UpgradeComponents.Items
 {
-    public class Peeper : GrabbableObject
+    public class Peeper : GrabbableObject, IDisplayInfo
     {
         /// <summary>
         /// Wether the instance of the class can stop coil-heads from moving or not
@@ -52,6 +53,11 @@ namespace MoreShipUpgrades.UpgradeComponents.Items
                 if (peeper.HasLineOfSightToPosition(springPosition)) return true;
             }
             return false;
+        }
+
+        public string GetDisplayInfo()
+        {
+            return "Looks at coil heads, don't lose it";
         }
     }
 }

--- a/MoreShipUpgrades/UpgradeComponents/Items/PortableTeleporter/AdvancedPortableTeleporter.cs
+++ b/MoreShipUpgrades/UpgradeComponents/Items/PortableTeleporter/AdvancedPortableTeleporter.cs
@@ -1,5 +1,7 @@
 ﻿using GameNetcodeStuff;
 using MoreShipUpgrades.Managers;
+using MoreShipUpgrades.Misc;
+using MoreShipUpgrades.UpgradeComponents.Interfaces;
 using System.Collections;
 using System.Linq;
 using Unity.Netcode;
@@ -8,16 +10,25 @@ using UnityEngine.InputSystem;
 
 namespace MoreShipUpgrades.UpgradeComponents.Items.PortableTeleporter
 {
-    internal class AdvancedPortableTeleporter : BasePortableTeleporter
+    internal class AdvancedPortableTeleporter : BasePortableTeleporter, IDisplayInfo, IItemWorldBuilding
     {
-        internal static string WORLD_BUILDING_TEXT = "\n\nA newer, ostensibly-safer Teleportation Remote made by PortaCorp. PortaCorp was a subsidiary of Shipping Solutions Interplanetary," +
+        internal static string WORLD_BUILDING_TEXT = "A newer, ostensibly-safer Teleportation Remote made by PortaCorp. PortaCorp was a subsidiary of Shipping Solutions Interplanetary," +
             " which was acquired by The Company in 2420, along with their entire stock of PortaCorp Teleportation Remotes. Looking to distance itself from the many safety scandals incurred" +
-            " by earlier adopters of the 'Remote Teleportation' technology, PortaCorp marketed its line of Teleportation Remotes with claims of their comparative ruggedness and reliability.\n\n";
+            " by earlier adopters of the 'Remote Teleportation' technology, PortaCorp marketed its line of Teleportation Remotes with claims of their comparative ruggedness and reliability.";
         public override void Start()
         {
             base.Start();
             breakChance = UpgradeBus.instance.cfg.ADV_CHANCE_TO_BREAK;
             keepItems = UpgradeBus.instance.cfg.ADV_KEEP_ITEMS_ON_TELE;
+        }
+        public string GetDisplayInfo()
+        {
+            return string.Format(AssetBundleHandler.GetInfoFromJSON("Advanced Portable Tele"), (int)(UpgradeBus.instance.cfg.ADV_CHANCE_TO_BREAK * 100));
+        }
+
+        public string GetWorldBuildingText()
+        {
+            return WORLD_BUILDING_TEXT;
         }
     }
 }

--- a/MoreShipUpgrades/UpgradeComponents/Items/PortableTeleporter/AdvancedPortableTeleporter.cs
+++ b/MoreShipUpgrades/UpgradeComponents/Items/PortableTeleporter/AdvancedPortableTeleporter.cs
@@ -10,6 +10,9 @@ namespace MoreShipUpgrades.UpgradeComponents.Items.PortableTeleporter
 {
     internal class AdvancedPortableTeleporter : BasePortableTeleporter
     {
+        internal static string WORLD_BUILDING_TEXT = "\n\nA newer, ostensibly-safer Teleportation Remote made by PortaCorp. PortaCorp was a subsidiary of Shipping Solutions Interplanetary," +
+            " which was acquired by The Company in 2420, along with their entire stock of PortaCorp Teleportation Remotes. Looking to distance itself from the many safety scandals incurred" +
+            " by earlier adopters of the 'Remote Teleportation' technology, PortaCorp marketed its line of Teleportation Remotes with claims of their comparative ruggedness and reliability.\n\n";
         public override void Start()
         {
             base.Start();

--- a/MoreShipUpgrades/UpgradeComponents/Items/PortableTeleporter/BasePortableTeleporter.cs
+++ b/MoreShipUpgrades/UpgradeComponents/Items/PortableTeleporter/BasePortableTeleporter.cs
@@ -105,7 +105,7 @@ namespace MoreShipUpgrades.UpgradeComponents.Items.PortableTeleporter
         {
             if (shipTeleporter != null) return shipTeleporter;
 
-            ShipTeleporter[] tele = FindObjectsOfType<ShipTeleporter>();    
+            ShipTeleporter[] tele = FindObjectsOfType<ShipTeleporter>();
             ShipTeleporter NotInverseTele = null;
             foreach (ShipTeleporter shipTeleporter in tele)
             {

--- a/MoreShipUpgrades/UpgradeComponents/Items/PortableTeleporter/RegularPortableTeleporter.cs
+++ b/MoreShipUpgrades/UpgradeComponents/Items/PortableTeleporter/RegularPortableTeleporter.cs
@@ -10,6 +10,11 @@ namespace MoreShipUpgrades.UpgradeComponents.Items.PortableTeleporter
 {
     internal class RegularPortableTeleporter : BasePortableTeleporter
     {
+        internal static string WORLD_BUILDING_TEXT = "\n\nEarly hand-held teleportation device based on an invention incepted in 2391 with public money," +
+            " which was then sold to a private company for manufacturing. Innovations present in the device allow the user to return to a designated 'home location'" +
+            " with any objects they possess once used. In 2406, a massive stock of liquidated TeleMax Teleportation Remotes was acquired by The Company in aftermarket" +
+            " following a battery-related recall. As a result, the Company is able to offer them to its employees for cheap, but they are prone to swelling and combustion. Handle with care.\n\n";
+
         public override void Start()
         {
             base.Start();

--- a/MoreShipUpgrades/UpgradeComponents/Items/PortableTeleporter/RegularPortableTeleporter.cs
+++ b/MoreShipUpgrades/UpgradeComponents/Items/PortableTeleporter/RegularPortableTeleporter.cs
@@ -1,5 +1,7 @@
 ﻿using GameNetcodeStuff;
 using MoreShipUpgrades.Managers;
+using MoreShipUpgrades.Misc;
+using MoreShipUpgrades.UpgradeComponents.Interfaces;
 using System.Collections;
 using System.Linq;
 using Unity.Netcode;
@@ -8,12 +10,22 @@ using UnityEngine.InputSystem;
 
 namespace MoreShipUpgrades.UpgradeComponents.Items.PortableTeleporter
 {
-    internal class RegularPortableTeleporter : BasePortableTeleporter
+    internal class RegularPortableTeleporter : BasePortableTeleporter, IDisplayInfo, IItemWorldBuilding
     {
-        internal static string WORLD_BUILDING_TEXT = "\n\nEarly hand-held teleportation device based on an invention incepted in 2391 with public money," +
+        internal static string WORLD_BUILDING_TEXT = "Early hand-held teleportation device based on an invention incepted in 2391 with public money," +
             " which was then sold to a private company for manufacturing. Innovations present in the device allow the user to return to a designated 'home location'" +
             " with any objects they possess once used. In 2406, a massive stock of liquidated TeleMax Teleportation Remotes was acquired by The Company in aftermarket" +
-            " following a battery-related recall. As a result, the Company is able to offer them to its employees for cheap, but they are prone to swelling and combustion. Handle with care.\n\n";
+            " following a battery-related recall. As a result, the Company is able to offer them to its employees for cheap, but they are prone to swelling and combustion. Handle with care.";
+
+        public string GetDisplayInfo()
+        {
+            return string.Format(AssetBundleHandler.GetInfoFromJSON("Portable Tele"), (int)(UpgradeBus.instance.cfg.CHANCE_TO_BREAK * 100));
+        }
+
+        public string GetWorldBuildingText()
+        {
+            return WORLD_BUILDING_TEXT;
+        }
 
         public override void Start()
         {

--- a/MoreShipUpgrades/UpgradeComponents/Items/Wheelbarrow/StoreWheelbarrow.cs
+++ b/MoreShipUpgrades/UpgradeComponents/Items/Wheelbarrow/StoreWheelbarrow.cs
@@ -1,5 +1,6 @@
 ﻿using MoreShipUpgrades.Managers;
 using MoreShipUpgrades.Misc;
+using MoreShipUpgrades.UpgradeComponents.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -7,10 +8,18 @@ using UnityEngine;
 
 namespace MoreShipUpgrades.UpgradeComponents.Items.Wheelbarrow
 {
-    internal class StoreWheelbarrow : WheelbarrowScript
+    internal class StoreWheelbarrow : WheelbarrowScript, IDisplayInfo
     {
         private static LGULogger logger = new LGULogger(nameof(StoreWheelbarrow));
         private GameObject wheel;
+
+        public string GetDisplayInfo()
+        {
+            return $"A portable container which has a maximum capacity of {UpgradeBus.instance.cfg.WHEELBARROW_MAXIMUM_AMOUNT_ITEMS}" +
+                $" and reduces the effective weight of the inserted items by {UpgradeBus.instance.cfg.WHEELBARROW_WEIGHT_REDUCTION_MULTIPLIER * 100} %.\n" +
+                $"It weighs {UpgradeBus.instance.cfg.WHEELBARROW_WEIGHT} lbs";
+        }
+
         public override void Start()
         {
             base.Start();

--- a/MoreShipUpgrades/UpgradeComponents/OneTimeUpgrades/BeatScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/OneTimeUpgrades/BeatScript.cs
@@ -1,10 +1,11 @@
 ﻿using GameNetcodeStuff;
 using MoreShipUpgrades.Managers;
 using MoreShipUpgrades.Misc;
+using MoreShipUpgrades.UpgradeComponents.Interfaces;
 
 namespace MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades
 {
-    public class BeatScript : BaseUpgrade
+    public class BeatScript : BaseUpgrade, IOneTimeUpgradeDisplayInfo
     {
         public static string UPGRADE_NAME = "Sick Beats";
         private static LGULogger logger = new LGULogger(UPGRADE_NAME);
@@ -63,6 +64,16 @@ namespace MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades
         {
             if (!UpgradeBus.instance.sickBeats || dmg < 0) return dmg; // < 0 check to not hinder healing
             return (int)(dmg * UpgradeBus.instance.incomingDamageCoefficient);
+        }
+
+        public string GetDisplayInfo(int price = -1)
+        {
+            string txt = $"Sick Beats - ${price}\nPlayers within a {UpgradeBus.instance.cfg.BEATS_RADIUS} unit radius from an active boombox will have the following effects:\n\n";
+            if (UpgradeBus.instance.cfg.BEATS_SPEED) txt += $"Movement speed increased by {UpgradeBus.instance.cfg.BEATS_SPEED_INC}\n";
+            if (UpgradeBus.instance.cfg.BEATS_DMG) txt += $"Damage inflicted increased by {UpgradeBus.instance.cfg.BEATS_DMG_INC}\n";
+            if (UpgradeBus.instance.cfg.BEATS_DEF) txt += $"Incoming Damage multiplied by {UpgradeBus.instance.cfg.BEATS_DEF_CO}\n";
+            if (UpgradeBus.instance.cfg.BEATS_STAMINA) txt += $"Stamina Drain multiplied by {UpgradeBus.instance.cfg.BEATS_STAMINA_CO}\n";
+            return txt;
         }
     }
 }

--- a/MoreShipUpgrades/UpgradeComponents/OneTimeUpgrades/lightningRodScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/OneTimeUpgrades/lightningRodScript.cs
@@ -6,7 +6,11 @@ namespace MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades
 {
     internal class lightningRodScript : BaseUpgrade
     {
-        public static string UPGRADE_NAME = "Lightning Rod";
+        public const string UPGRADE_NAME = "Lightning Rod";
+        internal const string WORLD_BUILDING_TEXT = "\n\nService key for the Ship's terminal which allows your crew to legally use the Ship's 'Static Attraction Field' module." +
+            " Comes with a list of opt-in maintenance procedures that promise to optimize the module's function and field of influence. This Company-issued document " +
+            "is saddled with the uniquely-awkward task of having to ransom a safety feature back to the employee in text while not also admitting to the existence of" +
+            " an occupational hazard that was previously denied in court.\n\n";
         public static lightningRodScript instance;
         private static LGULogger logger;
 

--- a/MoreShipUpgrades/UpgradeComponents/OneTimeUpgrades/lightningRodScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/OneTimeUpgrades/lightningRodScript.cs
@@ -1,10 +1,11 @@
 ﻿using MoreShipUpgrades.Managers;
 using MoreShipUpgrades.Misc;
+using MoreShipUpgrades.UpgradeComponents.Interfaces;
 using UnityEngine;
 
 namespace MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades
 {
-    internal class lightningRodScript : BaseUpgrade
+    internal class lightningRodScript : BaseUpgrade, IUpgradeWorldBuilding, IOneTimeUpgradeDisplayInfo
     {
         public const string UPGRADE_NAME = "Lightning Rod";
         internal const string WORLD_BUILDING_TEXT = "\n\nService key for the Ship's terminal which allows your crew to legally use the Ship's 'Static Attraction Field' module." +
@@ -133,6 +134,16 @@ namespace MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades
             failNode.displayText = ACCESS_DENIED_MESSAGE;
             failNode.clearPreviousText = true;
             __result = failNode;
+        }
+
+        public string GetWorldBuildingText(bool shareStatus = false)
+        {
+            return WORLD_BUILDING_TEXT;
+        }
+
+        public string GetDisplayInfo(int price = -1)
+        {
+            return string.Format(AssetBundleHandler.GetInfoFromJSON(UPGRADE_NAME), price, UpgradeBus.instance.cfg.LIGHTNING_ROD_DIST);
         }
     }
 }

--- a/MoreShipUpgrades/UpgradeComponents/OneTimeUpgrades/lockSmithScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/OneTimeUpgrades/lockSmithScript.cs
@@ -10,7 +10,9 @@ namespace MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades
 {
     public class lockSmithScript : BaseUpgrade
     {
-        public static string UPGRADE_NAME = "Locksmith";
+        public const string UPGRADE_NAME = "Locksmith";
+        internal const string WORLD_BUILDING_TEXT = "\n\nOn-the-job training package that supplies {0} with proprietary knowledge of the 'Ram, Scan, Bump' technique" +
+            " for bypassing The Company's proprietary Low-Tech Manual Security Doors' security system. Comes with an 'all-nines-notched' key, a rubber gasket, and a plastic handle on a metal rod {1}.\n\n";
 
         private GameObject pin1, pin2, pin3, pin4, pin5;
         private List<GameObject> pins;

--- a/MoreShipUpgrades/UpgradeComponents/OneTimeUpgrades/lockSmithScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/OneTimeUpgrades/lockSmithScript.cs
@@ -1,5 +1,6 @@
 ﻿using MoreShipUpgrades.Managers;
 using MoreShipUpgrades.Misc;
+using MoreShipUpgrades.UpgradeComponents.Interfaces;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -8,7 +9,7 @@ using UnityEngine.UI;
 
 namespace MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades
 {
-    public class lockSmithScript : BaseUpgrade
+    public class lockSmithScript : BaseUpgrade, IUpgradeWorldBuilding, IOneTimeUpgradeDisplayInfo
     {
         public const string UPGRADE_NAME = "Locksmith";
         internal const string WORLD_BUILDING_TEXT = "\n\nOn-the-job training package that supplies {0} with proprietary knowledge of the 'Ram, Scan, Bump' technique" +
@@ -134,6 +135,16 @@ namespace MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades
                 pins[lst[i]].GetComponent<Image>().color = Color.white;
             }
             canPick = true;
+        }
+
+        public string GetWorldBuildingText(bool shareStatus = false)
+        {
+            return string.Format(WORLD_BUILDING_TEXT, shareStatus ? "your crew" : "you", shareStatus ? "for each of your coworkers" : "");
+        }
+
+        public string GetDisplayInfo(int price = -1)
+        {
+            return "Allows you to pick door locks by completing a minigame.";
         }
     }
 }

--- a/MoreShipUpgrades/UpgradeComponents/OneTimeUpgrades/pagerScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/OneTimeUpgrades/pagerScript.cs
@@ -1,11 +1,12 @@
 ﻿using MoreShipUpgrades.Managers;
 using MoreShipUpgrades.Misc;
+using MoreShipUpgrades.UpgradeComponents.Interfaces;
 using Unity.Netcode;
 using UnityEngine;
 
 namespace MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades
 {
-    public class pagerScript : BaseUpgrade
+    public class pagerScript : BaseUpgrade, IOneTimeUpgradeDisplayInfo
     {
         public static string UPGRADE_NAME = "Fast Encryption";
         private static LGULogger logger;
@@ -50,6 +51,11 @@ namespace MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades
             logger.LogInfo("Broadcasted messaged received, printing.");
             HUDManager.Instance.chatText.text += $"\n<color=#FF0000>Terminal</color><color=#0000FF>:</color> <color=#FF00FF>{msg}</color>";
             HUDManager.Instance.PingHUDElement(HUDManager.Instance.Chat, 4f, 1f, 0.2f);
+        }
+
+        public string GetDisplayInfo(int price = -1)
+        {
+            return "Unrestrict the transmitter";
         }
     }
 }

--- a/MoreShipUpgrades/UpgradeComponents/OneTimeUpgrades/trapDestroyerScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/OneTimeUpgrades/trapDestroyerScript.cs
@@ -1,11 +1,12 @@
 ﻿using MoreShipUpgrades.Managers;
 using MoreShipUpgrades.Misc;
+using MoreShipUpgrades.UpgradeComponents.Interfaces;
 using Unity.Netcode;
 using UnityEngine;
 
 namespace MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades
 {
-    public class trapDestroyerScript : BaseUpgrade
+    public class trapDestroyerScript : BaseUpgrade, IOneTimeUpgradeDisplayInfo
     {
         public static string UPGRADE_NAME = "Malware Broadcaster";
         void Start()
@@ -54,6 +55,24 @@ namespace MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades
         private void SpawnExplosionClientRpc(Vector3 position)
         {
             if (UpgradeBus.instance.cfg.EXPLODE_TRAP) { Landmine.SpawnExplosion(position + Vector3.up, true, 5.7f, 6.4f); }
+        }
+
+        public string GetDisplayInfo(int price = -1)
+        {
+            string desc;
+            if (UpgradeBus.instance.cfg.DESTROY_TRAP)
+            {
+                if (UpgradeBus.instance.cfg.EXPLODE_TRAP)
+                {
+                    desc = "Broadcasted codes now explode map hazards.";
+                }
+                else
+                {
+                    desc = "Broadcasted codes now destroy map hazards.";
+                }
+            }
+            else { desc = $"Broadcasted codes now disable map hazards for {UpgradeBus.instance.cfg.DISARM_TIME} seconds."; }
+            return desc;
         }
     }
 }

--- a/MoreShipUpgrades/UpgradeComponents/OneTimeUpgrades/walkieScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/OneTimeUpgrades/walkieScript.cs
@@ -1,5 +1,6 @@
 ﻿using MoreShipUpgrades.Managers;
 using MoreShipUpgrades.Misc;
+using MoreShipUpgrades.UpgradeComponents.Interfaces;
 using System;
 using System.Security.Cryptography;
 using UnityEngine;
@@ -7,7 +8,7 @@ using UnityEngine.UI;
 
 namespace MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades
 {
-    public class walkieScript : BaseUpgrade
+    public class walkieScript : BaseUpgrade, IOneTimeUpgradeDisplayInfo
     {
         public static string UPGRADE_NAME = "Walkie GPS";
 
@@ -87,6 +88,11 @@ namespace MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades
         {
             UpgradeBus.instance.walkieUIActive = false;
             canvas.SetActive(false);
+        }
+
+        public string GetDisplayInfo(int price = -1)
+        {
+            return "Displays your location and time when holding a walkie talkie.\nEspecially useful for fog.";
         }
     }
 }

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/DoorsHydraulicsBattery.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/DoorsHydraulicsBattery.cs
@@ -1,13 +1,15 @@
 ﻿using GameNetcodeStuff;
 using MoreShipUpgrades.Managers;
 using MoreShipUpgrades.Misc;
+using MoreShipUpgrades.UpgradeComponents.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.Text;
+using UnityEngine;
 
 namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
 {
-    internal class DoorsHydraulicsBattery : BaseUpgrade
+    internal class DoorsHydraulicsBattery : BaseUpgrade, ITierUpgradeDisplayInfo
     {
         private static LGULogger logger;
         public const string UPGRADE_NAME = "Shutter Batteries";
@@ -97,5 +99,11 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
             active = false;
         }
 
+        public string GetDisplayInfo(int initialPrice = -1, int maxLevels = -1, int[] incrementalPrices = null)
+        {
+            Func<int, float> infoFunction = level => UpgradeBus.instance.cfg.DOOR_HYDRAULICS_BATTERY_INITIAL + (level) * UpgradeBus.instance.cfg.DOOR_HYDRAULICS_BATTERY_INCREMENTAL;
+            string infoFormat = "LVL {0} - ${1} - Increases the door's hydraulic capacity to remain closed by {2} units\n"; // to put in the infoStrings after
+            return Tools.GenerateInfoForUpgrade(infoFormat, initialPrice, incrementalPrices, infoFunction);
+        }
     }
 }

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/beekeeperScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/beekeeperScript.cs
@@ -7,11 +7,14 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
     internal class beekeeperScript : BaseUpgrade
     {
         private static LGULogger logger = new LGULogger(UPGRADE_NAME);
-        public static string UPGRADE_NAME = "Beekeeper";
+        internal const string UPGRADE_NAME = "Beekeeper";
         public static string PRICES_DEFAULT = "225,280,340";
+        internal static string WORLD_BUILDING_TEXT = "\n\nOn-the-job training package that teaches {0} proper Circuit Bee Nest handling techniques." +
+            " Also comes with a weekly issuance of alkaline pills to partially inoculate {0} against Circuit Bee Venom.\n\n";
 
         void Start()
         {
+            WORLD_BUILDING_TEXT = 
             upgradeName = UPGRADE_NAME;
             DontDestroyOnLoad(gameObject);
             Register();

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/beekeeperScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/beekeeperScript.cs
@@ -1,10 +1,11 @@
 ﻿using MoreShipUpgrades.Managers;
 using MoreShipUpgrades.Misc;
+using MoreShipUpgrades.UpgradeComponents.Interfaces;
 using UnityEngine;
 
 namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
 {
-    internal class beekeeperScript : BaseUpgrade
+    internal class beekeeperScript : BaseUpgrade, IUpgradeWorldBuilding, ITierUpgradeDisplayInfo
     {
         private static LGULogger logger = new LGULogger(UPGRADE_NAME);
         internal const string UPGRADE_NAME = "Beekeeper";
@@ -56,6 +57,18 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
         {
             if (!UpgradeBus.instance.increaseHivePrice) return originalValue;
             return (int)(originalValue * UpgradeBus.instance.cfg.BEEKEEPER_HIVE_VALUE_INCREASE);
+        }
+
+        public string GetWorldBuildingText(bool shareStatus = false)
+        {
+            return string.Format(WORLD_BUILDING_TEXT, shareStatus ? "your crew" : "you");
+        }
+
+        public string GetDisplayInfo(int initialPrice = -1, int maxLevels = -1, int[] incrementalPrices = null)
+        {
+            System.Func<int, float> infoFunction = level => 100 * (UpgradeBus.instance.cfg.BEEKEEPER_DAMAGE_MULTIPLIER - (level * UpgradeBus.instance.cfg.BEEKEEPER_DAMAGE_MULTIPLIER_INCREMENT));
+            string infoFormat = AssetBundleHandler.GetInfoFromJSON(UPGRADE_NAME);
+            return Tools.GenerateInfoForUpgrade(infoFormat, initialPrice, incrementalPrices, infoFunction);
         }
     }
 }

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/biggerLungScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/biggerLungScript.cs
@@ -8,10 +8,13 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
     internal class biggerLungScript : BaseUpgrade
     {
         private static LGULogger logger;
-        public static string UPGRADE_NAME = "Bigger Lungs";
+        public const string UPGRADE_NAME = "Bigger Lungs";
         public static string PRICES_DEFAULT = "350,450,550";
         private int currentLevel = 0; // For "Load LGU" issues
         private static bool active = false;
+        internal const string WORLD_BUILDING_TEXT = "\n\nService package for {0}." +
+            " Opting into every maintenance procedure will arrange for your suit's pipes to be cleaned and repaired, filters re-issued," +
+            " and DRM removed from the integrated air conditioning system.\n\n";
 
         void Start()
         {

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/biggerLungScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/biggerLungScript.cs
@@ -1,11 +1,12 @@
 ﻿using GameNetcodeStuff;
 using MoreShipUpgrades.Managers;
 using MoreShipUpgrades.Misc;
+using MoreShipUpgrades.UpgradeComponents.Interfaces;
 using UnityEngine;
 
 namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
 {
-    internal class biggerLungScript : BaseUpgrade
+    internal class biggerLungScript : BaseUpgrade, IUpgradeWorldBuilding, ITierUpgradeDisplayInfo
     {
         private static LGULogger logger;
         public const string UPGRADE_NAME = "Bigger Lungs";
@@ -94,6 +95,18 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
         {
             if (!UpgradeBus.instance.biggerLungs || UpgradeBus.instance.lungLevel < 1) return jumpCost;
             return jumpCost * UpgradeBus.instance.cfg.BIGGER_LUNGS_JUMP_STAMINA_COST_DECREASE;
+        }
+
+        public string GetWorldBuildingText(bool shareStatus = false)
+        {
+            return string.Format(WORLD_BUILDING_TEXT, shareStatus ? "your crew's suit oxigen delivery systems" : "your suit's oxygen delivery system");
+        }
+
+        public string GetDisplayInfo(int initialPrice = -1, int maxLevels = -1, int[] incrementalPrices = null)
+        {
+            System.Func<int, float> infoFunction = level => UpgradeBus.instance.cfg.SPRINT_TIME_INCREASE_UNLOCK + (level * UpgradeBus.instance.cfg.SPRINT_TIME_INCREMENT);
+            string infoFormat = AssetBundleHandler.GetInfoFromJSON(UPGRADE_NAME);
+            return Tools.GenerateInfoForUpgrade(infoFormat, initialPrice, incrementalPrices, infoFunction);
         }
     }
 }

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/exoskeletonScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/exoskeletonScript.cs
@@ -7,8 +7,12 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
 {
     internal class exoskeletonScript : BaseUpgrade
     {
-        public static string UPGRADE_NAME = "Back Muscles";
+        public const string UPGRADE_NAME = "Back Muscles";
         public static string PRICES_DEFAULT = "600,700,800";
+        internal const string WORLD_BUILDING_TEXT = "\n\nCompany-issued hydraulic girdles which are only awarded to high-performing {0} who can afford to opt in." +
+            " Highly valued by all employees of The Company for their combination of miraculous health-preserving benefits and artificial, intentionally-implemented scarcity." +
+            " Sardonically called the 'Back Muscles Upgrade' by some. Comes with a user manual, which mostly contains minimalistic ads for girdle maintenance contractors." +
+            " Most of the phone numbers don't work anymore.\n\n";
 
         void Start()
         {

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/exoskeletonScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/exoskeletonScript.cs
@@ -1,11 +1,13 @@
 ﻿using GameNetcodeStuff;
 using MoreShipUpgrades.Managers;
 using MoreShipUpgrades.Misc;
+using MoreShipUpgrades.UpgradeComponents.Interfaces;
+using System;
 using UnityEngine;
 
 namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
 {
-    internal class exoskeletonScript : BaseUpgrade
+    internal class exoskeletonScript : BaseUpgrade, IUpgradeWorldBuilding, ITierUpgradeDisplayInfo
     {
         public const string UPGRADE_NAME = "Back Muscles";
         public static string PRICES_DEFAULT = "600,700,800";
@@ -65,6 +67,18 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
             }
             player.carryWeight = UpgradeBus.instance.alteredWeight;
             if (player.carryWeight < 1f) { player.carryWeight = 1f; }
+        }
+
+        public string GetWorldBuildingText(bool shareStatus = false)
+        {
+            return string.Format(WORLD_BUILDING_TEXT, shareStatus ? "departments" : "employees");
+        }
+
+        public string GetDisplayInfo(int initialPrice = -1, int maxLevels = -1, int[] incrementalPrices = null)
+        {
+            Func<int, float> infoFunction = level => (UpgradeBus.instance.cfg.CARRY_WEIGHT_REDUCTION - (level * UpgradeBus.instance.cfg.CARRY_WEIGHT_INCREMENT)) * 100;
+            string infoFormat = AssetBundleHandler.GetInfoFromJSON(UPGRADE_NAME);
+            return Tools.GenerateInfoForUpgrade(infoFormat, initialPrice, incrementalPrices, infoFunction);
         }
     }
 

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/hunterScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/hunterScript.cs
@@ -8,7 +8,10 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
 {
     internal class hunterScript : BaseUpgrade
     {
-        public static string UPGRADE_NAME = "Hunter";
+        public const string UPGRADE_NAME = "Hunter";
+        internal const string WORLD_BUILDING_TEXT = "\n\nOn-the-job training program that teaches your crew how to properly collect lab-ready samples of blood," +
+            " skin, and organ tissue from entities found within the facility. These samples are valuable to The Company. Used to be a part of the standard onboarding procedure," +
+            " but was made opt-in only in 2005 to cut onboarding costs.\n\n";
         private static LGULogger logger = new LGULogger(UPGRADE_NAME);
         static Dictionary<string, string> monsterNames = new Dictionary<string, string>()
             {

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/hunterScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/hunterScript.cs
@@ -1,12 +1,15 @@
 ﻿using MoreShipUpgrades.Managers;
 using MoreShipUpgrades.Misc;
+using MoreShipUpgrades.UpgradeComponents.Interfaces;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using UnityEngine;
 
 namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
 {
-    internal class hunterScript : BaseUpgrade
+    internal class hunterScript : BaseUpgrade, IUpgradeWorldBuilding, ITierUpgradeDisplayInfo
     {
         public const string UPGRADE_NAME = "Hunter";
         internal const string WORLD_BUILDING_TEXT = "\n\nOn-the-job training program that teaches your crew how to properly collect lab-ready samples of blood," +
@@ -95,6 +98,19 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
             result = result.Substring(0, result.Length - 2);
             result += "\n";
             return string.Format(AssetBundleHandler.GetInfoFromJSON(UPGRADE_NAME), level, price, result);
+        }
+
+        public string GetWorldBuildingText(bool shareStatus = false)
+        {
+            return WORLD_BUILDING_TEXT;
+        }
+
+        public string GetDisplayInfo(int initialPrice = -1, int maxLevels = -1, int[] incrementalPrices = null)
+        {
+            string info = GetHunterInfo(1, initialPrice);
+            for (int i = 0; i < maxLevels; i++)
+                info += GetHunterInfo(i + 2, incrementalPrices[i]);
+            return info;
         }
     }
 }

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/nightVisionScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/nightVisionScript.cs
@@ -1,6 +1,7 @@
 ﻿using GameNetcodeStuff;
 using MoreShipUpgrades.Managers;
 using MoreShipUpgrades.Misc;
+using MoreShipUpgrades.UpgradeComponents.Interfaces;
 using Newtonsoft.Json;
 using System;
 using System.Collections;
@@ -11,7 +12,7 @@ using UnityEngine.InputSystem;
 
 namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
 {
-    internal class nightVisionScript : BaseUpgrade
+    internal class nightVisionScript : BaseUpgrade, ITierUpgradeDisplayInfo
     {
         private float nightBattery;
         private Transform batteryBar;
@@ -204,6 +205,14 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
                         return string.Format(AssetBundleHandler.GetInfoFromJSON(UPGRADE_NAME), level, price, drainTime, regenTime);
                     }
             }
+        }
+
+        public string GetDisplayInfo(int initialPrice = -1, int maxLevels = -1, int[] incrementalPrices = null)
+        {
+            string info = GetNightVisionInfo(1, initialPrice);
+            for (int i = 0; i < maxLevels; i++)
+                info += GetNightVisionInfo(i + 2, incrementalPrices[i]);
+            return info;
         }
     }
 }

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/nightVisionScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/nightVisionScript.cs
@@ -21,6 +21,10 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
 
         public static string UPGRADE_NAME = "NV Headset Batteries";
         public static string PRICES_DEFAULT = "300,400,500";
+        internal static string WORLD_BUILDING_TEXT = "\n\nVery old military surplus phosphor lens modules, retrofitted for compatibility with modern Company-issued helmets" +
+            " and offered to employees of The Company on a subscription plan. The base package comes with cheap batteries, but premium subscriptions offer regular issuances" +
+            " of higher-quality energy solutions, ranging from hobby grade to industrial application power banks. The modules also come with DRM that prevents the user from improvising" +
+            " with other kinds of batteries.\n\n";
 
         private static LGULogger logger = new LGULogger(UPGRADE_NAME);
         void Start()

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/playerHealthScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/playerHealthScript.cs
@@ -9,7 +9,11 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
 {
     internal class playerHealthScript : BaseUpgrade
     {
-        public static string UPGRADE_NAME = "Stimpack";
+        public const string UPGRADE_NAME = "Stimpack";
+        internal const string WORLD_BUILDING_TEXT = "\n\nAn experimental Company-offered 'health treatment' program advertised only on old, peeling Ship posters," +
+            " which are themselves only present in about 40% of all Company-issued Ships. Some Ships even have multiple. Nothing is known from the outside about how it works," +
+            " and in order to be eligible for the program, {0} must sign an NDA.\n\n";
+
         private static bool active;
         private int previousLevel;
         private static LGULogger logger;

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/playerHealthScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/playerHealthScript.cs
@@ -1,13 +1,14 @@
 ﻿using GameNetcodeStuff;
 using MoreShipUpgrades.Managers;
 using MoreShipUpgrades.Misc;
+using MoreShipUpgrades.UpgradeComponents.Interfaces;
 using System;
 using System.Numerics;
 using UnityEngine;
 
 namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
 {
-    internal class playerHealthScript : BaseUpgrade
+    internal class playerHealthScript : BaseUpgrade, IUpgradeWorldBuilding, ITierUpgradeDisplayInfo
     {
         public const string UPGRADE_NAME = "Stimpack";
         internal const string WORLD_BUILDING_TEXT = "\n\nAn experimental Company-offered 'health treatment' program advertised only on old, peeling Ship posters," +
@@ -128,6 +129,18 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
             player.health -= healthRemoval;
             logger.LogDebug($"Upgrade reset on {player.playerUsername}");
             active = false;
+        }
+
+        public string GetWorldBuildingText(bool shareStatus = false)
+        {
+            return string.Format(WORLD_BUILDING_TEXT, shareStatus ? "your crew" : "you");
+        }
+
+        public string GetDisplayInfo(int initialPrice = -1, int maxLevels = -1, int[] incrementalPrices = null)
+        {
+            Func<int, float> infoFunction = level => UpgradeBus.instance.cfg.PLAYER_HEALTH_ADDITIONAL_HEALTH_UNLOCK + (level) * UpgradeBus.instance.cfg.PLAYER_HEALTH_ADDITIONAL_HEALTH_INCREMENT;
+            string infoFormat = AssetBundleHandler.GetInfoFromJSON(UPGRADE_NAME);
+            return Tools.GenerateInfoForUpgrade(infoFormat, initialPrice, incrementalPrices, infoFunction);
         }
     }
 }

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/proteinPowderScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/proteinPowderScript.cs
@@ -10,7 +10,9 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
 {
     internal class proteinPowderScript : BaseUpgrade
     {
-        public static string UPGRADE_NAME = "Protein Powder";
+        public const string UPGRADE_NAME = "Protein Powder";
+        internal const string WORLD_BUILDING_TEXT = "\n\nMultivitamins, creatine, and military surplus stimulants blended together and repackaged," +
+            " then offered on subscription. Known to be habit-forming. The label includes a Company Surgeon General's warning about increased aggression.\n\n";
 
         private static int CRIT_DAMAGE_VALUE = 100;
 

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/proteinPowderScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/proteinPowderScript.cs
@@ -1,6 +1,7 @@
 ﻿using GameNetcodeStuff;
 using MoreShipUpgrades.Managers;
 using MoreShipUpgrades.Misc;
+using MoreShipUpgrades.UpgradeComponents.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.Numerics;
@@ -8,7 +9,7 @@ using UnityEngine;
 
 namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
 {
-    internal class proteinPowderScript : BaseUpgrade
+    internal class proteinPowderScript : BaseUpgrade, IUpgradeWorldBuilding, ITierUpgradeDisplayInfo
     {
         public const string UPGRADE_NAME = "Protein Powder";
         internal const string WORLD_BUILDING_TEXT = "\n\nMultivitamins, creatine, and military surplus stimulants blended together and repackaged," +
@@ -85,6 +86,18 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
             if (currentLevel != maximumLevel) return false;
 
             return UnityEngine.Random.value < UpgradeBus.instance.cfg.PROTEIN_CRIT_CHANCE;
+        }
+
+        public string GetWorldBuildingText(bool shareStatus = false)
+        {
+            return WORLD_BUILDING_TEXT;
+        }
+
+        public string GetDisplayInfo(int initialPrice = -1, int maxLevels = -1, int[] incrementalPrices = null)
+        {
+            Func<int, float> infoFunction = level => UpgradeBus.instance.cfg.PROTEIN_UNLOCK_FORCE + 1 + (UpgradeBus.instance.cfg.PROTEIN_INCREMENT * level);
+            string infoFormat = AssetBundleHandler.GetInfoFromJSON(UPGRADE_NAME);
+            return Tools.GenerateInfoForUpgrade(infoFormat, initialPrice, incrementalPrices, infoFunction);
         }
     }
 }

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/runningShoeScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/runningShoeScript.cs
@@ -7,11 +7,13 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
 {
     internal class runningShoeScript : BaseUpgrade
     {
-        public static string UPGRADE_NAME = "Running Shoes";
+        public const string UPGRADE_NAME = "Running Shoes";
         private static LGULogger logger;
         public static string PRICES_DEFAULT = "500,750,1000";
         private int currentLevel = 0; // For "Load LGU" issues
         private static bool active = false;
+        internal const string WORLD_BUILDING_TEXT = "\n\nA new pair of boots {0} a whole new lease on life. In this instance," +
+            " it might also result in fewer wet sock incidents and consequent trenchfoot. After all, who knows how many people have walked in {1} shoes?\n\n";
         void Start()
         {
             upgradeName = UPGRADE_NAME;

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/runningShoeScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/runningShoeScript.cs
@@ -1,11 +1,13 @@
 ﻿using GameNetcodeStuff;
 using MoreShipUpgrades.Managers;
 using MoreShipUpgrades.Misc;
+using MoreShipUpgrades.UpgradeComponents.Interfaces;
+using System;
 using UnityEngine;
 
 namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
 {
-    internal class runningShoeScript : BaseUpgrade
+    internal class runningShoeScript : BaseUpgrade, IUpgradeWorldBuilding, ITierUpgradeDisplayInfo 
     {
         public const string UPGRADE_NAME = "Running Shoes";
         private static LGULogger logger;
@@ -87,6 +89,18 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
         {
             if (!(UpgradeBus.instance.runningShoes && UpgradeBus.instance.runningLevel == UpgradeBus.instance.cfg.RUNNING_SHOES_UPGRADE_PRICES.Split(',').Length)) return defaultValue;
             return Mathf.Clamp(defaultValue - UpgradeBus.instance.cfg.NOISE_REDUCTION, 0f, defaultValue);
+        }
+
+        public string GetWorldBuildingText(bool shareStatus = false)
+        {
+            return string.Format(WORLD_BUILDING_TEXT, shareStatus ? "could give your crew" : "can give you", shareStatus ? "y'all's" : "your");
+        }
+
+        public string GetDisplayInfo(int initialPrice = -1, int maxLevels = -1, int[] incrementalPrices = null)
+        {
+            Func<int, float> infoFunction = level => UpgradeBus.instance.cfg.MOVEMENT_SPEED_UNLOCK + (level * UpgradeBus.instance.cfg.MOVEMENT_INCREMENT);
+            string infoFormat = AssetBundleHandler.GetInfoFromJSON(UPGRADE_NAME);
+            return Tools.GenerateInfoForUpgrade(infoFormat, initialPrice, incrementalPrices, infoFunction);
         }
     }
 }

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/strongLegsScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/strongLegsScript.cs
@@ -1,10 +1,12 @@
 ﻿using GameNetcodeStuff;
 using MoreShipUpgrades.Managers;
 using MoreShipUpgrades.Misc;
+using MoreShipUpgrades.UpgradeComponents.Interfaces;
+using UnityEngine;
 
 namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
 {
-    internal class strongLegsScript : BaseUpgrade
+    internal class strongLegsScript : BaseUpgrade, IUpgradeWorldBuilding, ITierUpgradeDisplayInfo
     {
         internal const string UPGRADE_NAME = "Strong Legs";
         private static LGULogger logger;
@@ -87,6 +89,18 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
         {
             if (!(UpgradeBus.instance.strongLegs && UpgradeBus.instance.legLevel == UpgradeBus.instance.cfg.STRONG_LEGS_UPGRADE_PRICES.Split(',').Length)) return defaultValue;
             return (int)(defaultValue * (1.0f - UpgradeBus.instance.cfg.STRONG_LEGS_REDUCE_FALL_DAMAGE_MULTIPLIER));
+        }
+
+        public string GetWorldBuildingText(bool shareStatus = false)
+        {
+            return string.Format(WORLD_BUILDING_TEXT, shareStatus ? "proprietary pressure-assisted kneebraces to your crew" : "a proprietary pressure-assisted kneebrace");
+        }
+
+        public string GetDisplayInfo(int initialPrice = -1, int maxLevels = -1, int[] incrementalPrices = null)
+        {
+            System.Func<int, float> infoFunction = level => UpgradeBus.instance.cfg.JUMP_FORCE_UNLOCK + (level * UpgradeBus.instance.cfg.JUMP_FORCE_INCREMENT);
+            string infoFormat = AssetBundleHandler.GetInfoFromJSON(UPGRADE_NAME);
+            return Tools.GenerateInfoForUpgrade(infoFormat, initialPrice, incrementalPrices, infoFunction);
         }
     }
 }

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/strongLegsScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/strongLegsScript.cs
@@ -6,11 +6,14 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
 {
     internal class strongLegsScript : BaseUpgrade
     {
-        public static string UPGRADE_NAME = "Strong Legs";
+        internal const string UPGRADE_NAME = "Strong Legs";
         private static LGULogger logger;
         public static string PRICES_DEFAULT = "150,190,250";
         private int currentLevel = 0; // For "Load LGU" issues
         private static bool active = false;
+        internal const string WORLD_BUILDING_TEXT = "\n\nOne-time issuance of {0}." +
+            " Comes with a vague list of opt-in maintenance procedures offered by The Company, which includes such gems as 'actuation optimization'," +
+            " 'weight & balance personalization', and similar nigh-meaningless corpo-tech jargon. All of it is expensive.\n\n";
 
         void Start()
         {

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/strongerScannerScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/strongerScannerScript.cs
@@ -6,7 +6,13 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
 {
     internal class strongerScannerScript : BaseUpgrade
     {
-        public static string UPGRADE_NAME = "Better Scanner";
+        public const string UPGRADE_NAME = "Better Scanner";
+        internal const string WORLD_BUILDING_TEXT = "\n\nA serialized Company-Issue Magazine subscription, called 'Stuff Finders'." +
+            " Uniquely, {0} must subscribe to each issue of 'Stuff Finders' individually. Each separate subscription promises and delivers a weekly issuance" +
+            " of a magazine with the exact same information in it as last time, organized in a different order and with slightly different printing qualities each time." +
+            " There are only three 'unique' issues, and each issue only has one or two pieces of actual useful information in it. The rest of the magazine is just ads" +
+            " for The Company's other offerings. There is an extra fee for cancelling a subscription of 'Stuff Finders' before terminating your employment." +
+            " The useful information always comes in the form of an unlabelled service key or Ship terminal hyperlink.\n\n";
         private static LGULogger logger;
         void Awake()
         {

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/strongerScannerScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/strongerScannerScript.cs
@@ -1,10 +1,11 @@
 ﻿using MoreShipUpgrades.Managers;
 using MoreShipUpgrades.Misc;
+using MoreShipUpgrades.UpgradeComponents.Interfaces;
 using UnityEngine;
 
 namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
 {
-    internal class strongerScannerScript : BaseUpgrade
+    internal class strongerScannerScript : BaseUpgrade, IUpgradeWorldBuilding, ITierUpgradeDisplayInfo
     {
         public const string UPGRADE_NAME = "Better Scanner";
         internal const string WORLD_BUILDING_TEXT = "\n\nA serialized Company-Issue Magazine subscription, called 'Stuff Finders'." +
@@ -79,6 +80,19 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
                     }
             }
             return "";
+        }
+
+        public string GetWorldBuildingText(bool shareStatus = false)
+        {
+            return string.Format(WORLD_BUILDING_TEXT, shareStatus ? "a department" : "one");
+        }
+
+        public string GetDisplayInfo(int initialPrice = -1, int maxLevels = -1, int[] incrementalPrices = null)
+        {
+            string info = GetBetterScannerInfo(1, initialPrice);
+            for (int i = 0; i < maxLevels; i++)
+                info += GetBetterScannerInfo(i + 2, incrementalPrices[i]);
+            return info;
         }
     }
 }

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/terminalFlashScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/terminalFlashScript.cs
@@ -1,12 +1,13 @@
 ﻿using MoreShipUpgrades.Managers;
 using MoreShipUpgrades.Misc;
+using MoreShipUpgrades.UpgradeComponents.Interfaces;
 using System.Collections;
 using Unity.Netcode;
 using UnityEngine;
 
 namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
 {
-    public class terminalFlashScript : BaseUpgrade
+    public class terminalFlashScript : BaseUpgrade, IUpgradeWorldBuilding, ITierUpgradeDisplayInfo
     {
         public const string UPGRADE_NAME = "Discombobulator";
         public static string PRICES_DEFAULT = "330,460,620";
@@ -94,5 +95,16 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
             terminal.terminalAudio.maxDistance = 17f;
         }
 
+        public string GetWorldBuildingText(bool shareStatus = false)
+        {
+            return string.Format(WORLD_BUILDING_TEXT, shareStatus ? "your crew" : "you");
+        }
+
+        public string GetDisplayInfo(int initialPrice = -1, int maxLevels = -1, int[] incrementalPrices = null)
+        {
+            System.Func<int, float> infoFunction = level => UpgradeBus.instance.cfg.DISCOMBOBULATOR_STUN_DURATION + (level * UpgradeBus.instance.cfg.DISCOMBOBULATOR_INCREMENT);
+            string infoFormat = AssetBundleHandler.GetInfoFromJSON(UPGRADE_NAME);
+            return Tools.GenerateInfoForUpgrade(infoFormat, initialPrice, incrementalPrices, infoFunction);
+        }
     }
 }

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/terminalFlashScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/terminalFlashScript.cs
@@ -8,9 +8,12 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
 {
     public class terminalFlashScript : BaseUpgrade
     {
-        public static string UPGRADE_NAME = "Discombobulator";
+        public const string UPGRADE_NAME = "Discombobulator";
         public static string PRICES_DEFAULT = "330,460,620";
         private static LGULogger logger = new LGULogger(nameof(terminalFlashScript));
+        internal const string WORLD_BUILDING_TEXT = "\n\nService key for the Ship's terminal which allows {0} to legally use the Ship's 'Discombobulator' module." +
+            " Comes with a list of opt-in maintenance procedures that promise to optimze the discharge and refractory of the system." +
+            " Said document contains no mention of whatever it might be that it was included in the Ship's design to discombobulate.\n\n";
         void Start()
         {
             upgradeName = UPGRADE_NAME;


### PR DESCRIPTION
Added:
- Interfaces for World Building classes which force them to implement the "GetWorldBuildingText()" function which is then added to the associated info node.
- Interface for information of the item/upgrade's usability which force them to implement the "GetDisplayInfo()" function which is then added to the associated info node.

This way, we get rid of the responsibility from the UpgradeBus and give it to each upgrade, making the UpgradeBus lighter in its logical duties.