### PR TITLE
Possible fix for people having left over weight when dropping the wheelbarrow

### DIFF
--- a/MoreShipUpgrades/UpgradeComponents/Items/Wheelbarrow/WheelbarrowScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/Items/Wheelbarrow/WheelbarrowScript.cs
@@ -373,7 +373,7 @@ namespace MoreShipUpgrades.UpgradeComponents.Items.Wheelbarrow
             logger.LogDebug(nameof(UpdateWheelbarrowWeightClientRpc));
             logger.LogDebug(GameNetworkManager.Instance.localPlayerController.playerUsername);
             GrabbableObject[] storedItems = GetComponentsInChildren<GrabbableObject>();
-            if (isHeld) playerHeldBy.carryWeight -= Mathf.Clamp(exoskeletonScript.DecreasePossibleWeight(totalWeight - 1f), 0f, 10f);
+            if (isHeld && playerHeldBy == UpgradeBus.instance.GetLocalPlayer()) playerHeldBy.carryWeight -= Mathf.Clamp(exoskeletonScript.DecreasePossibleWeight(totalWeight - 1f), 0f, 10f);
             totalWeight = defaultWeight;
             currentAmountItems = 0;
             for (int i = 0; i < storedItems.Length; i++)
@@ -384,7 +384,7 @@ namespace MoreShipUpgrades.UpgradeComponents.Items.Wheelbarrow
                 totalWeight += (storedItem.itemProperties.weight - 1f) * weightReduceMultiplier;
             }
             logger.LogDebug($"There's currently {(totalWeight - 1f)*100} lbs in the wheelcart");
-            if (isHeld) playerHeldBy.carryWeight += Mathf.Clamp(exoskeletonScript.DecreasePossibleWeight(totalWeight - 1f), 0f, 10f);
+            if (isHeld && playerHeldBy == UpgradeBus.instance.GetLocalPlayer()) playerHeldBy.carryWeight += Mathf.Clamp(exoskeletonScript.DecreasePossibleWeight(totalWeight - 1f), 0f, 10f);
         }
         /// <summary>
         /// Action when the interaction bar is completely filled on the container of the wheelbarrow.


### PR DESCRIPTION
I'm not sure if the RPC is applying multiple times to the same player the calculations leading to constantly increasing your weight to infinity but this seems to be working at LAN level, we'll have to see at online level.