### PR TITLE
Changing medkit's healing method to just add to the attribute instead of using DamagePlayer with negative value

### DIFF
--- a/MoreShipUpgrades/UpgradeComponents/Items/Medkit.cs
+++ b/MoreShipUpgrades/UpgradeComponents/Items/Medkit.cs
@@ -84,7 +84,8 @@ namespace MoreShipUpgrades.UpgradeComponents.Items
             {
                 heal_value -= potentialHealth - maximumHealth;
             }
-            playerHeldBy.DamagePlayer(-heal_value, false, true, CauseOfDeath.Unknown, 0, false, Vector3.zero);
+            playerHeldBy.health += heal_value;
+
             if (uses >= maximumUses)
             {
                 itemUsedUp = true;


### PR DESCRIPTION
This is to prevent cases of mods patching DamagePlayer which introduce damage reduction of rendering the medkit useless.