### PR TITLE
Implemented Scan Node Properties handler and fixes

### DIFF
--- a/MoreShipUpgrades/Misc/CommandParser.cs
+++ b/MoreShipUpgrades/Misc/CommandParser.cs
@@ -322,7 +322,7 @@ namespace MoreShipUpgrades.Misc
                     ScanNodeProperties scanNode = enemy.GetComponentInChildren<ScanNodeProperties>();
                     string realName = "";
                     if (scanNode != null) realName = scanNode.headerText; // this should resolve the issue with this command
-                    else realName = "Unkown";
+                    else realName = "Unknown";
                     if (enemyCount.ContainsKey(realName)) { enemyCount[realName]++; }
                     else { enemyCount.Add(realName, 1); }
                 }

--- a/MoreShipUpgrades/Misc/LGUScanNodeProperties.cs
+++ b/MoreShipUpgrades/Misc/LGUScanNodeProperties.cs
@@ -1,0 +1,61 @@
+﻿using UnityEngine;
+
+namespace MoreShipUpgrades.Misc
+{
+    internal class LGUScanNodeProperties
+    {
+        internal enum NodeType
+        {
+            GENERAL = 0,
+            DANGER = 1,
+            SCRAP = 2,
+        }
+        public static void UpdateScrapValue(ref GrabbableObject grabbableObject, int scrapValue = -1)
+        {
+            ScanNodeProperties scanNodeProperties = grabbableObject.GetComponentInChildren<ScanNodeProperties>();
+            ChangeScanNode(scanNodeProperties: ref scanNodeProperties, nodeType: (NodeType)scanNodeProperties.nodeType, header: scanNodeProperties.headerText, subText: $"Value: {scrapValue}", scrapValue: scrapValue);
+        }
+        public static void ChangeScanNode(ref ScanNodeProperties scanNodeProperties, NodeType nodeType, string header = "LGU Scan Node", string subText = "Used for LGU stuff", int creatureScanID = -1, int scrapValue = 0, int minRange = 5, int maxRange = 7)
+        {
+            scanNodeProperties.headerText = header;
+            scanNodeProperties.subText = subText;
+            scanNodeProperties.nodeType = (int)nodeType;
+            scanNodeProperties.creatureScanID = creatureScanID;
+            scanNodeProperties.scrapValue = scrapValue;
+            scanNodeProperties.minRange = minRange;
+            scanNodeProperties.maxRange = maxRange;
+        }
+        static GameObject CreateCanvasScanNode(ref GameObject objectToAddScanNode)
+        {
+            GameObject scanNodeObject = Object.Instantiate(GameObject.CreatePrimitive(PrimitiveType.Cube), objectToAddScanNode.transform.position, Quaternion.Euler(Vector3.zero), objectToAddScanNode.transform);
+            scanNodeObject.name = "ScanNode";
+            scanNodeObject.layer = LayerMask.NameToLayer("ScanNode");
+            Object.Destroy(scanNodeObject.GetComponent<MeshRenderer>());
+            Object.Destroy(scanNodeObject.GetComponent<MeshFilter>());
+            return scanNodeObject;
+        }
+        static void AddScanNode(GameObject objectToAddScanNode, NodeType nodeType, string header = "LGU Scan Node", string subText = "Used for LGU stuff", int creatureScanID = -1, int minRange = 5, int maxRange = 7)
+        {
+            GameObject scanNodeObject = CreateCanvasScanNode(ref objectToAddScanNode);
+            ScanNodeProperties scanNodeProperties = scanNodeObject.AddComponent<ScanNodeProperties>();
+            ChangeScanNode(ref scanNodeProperties, nodeType, header, subText, creatureScanID, minRange, maxRange);
+        }
+        public static void AddGeneralScanNode(GameObject objectToAddScanNode, string header = "LGU Scan Node", string subText = "Used for LGU stuff", int creatureScanID = -1, int minRange = 5, int maxRange = 7)
+        {
+            AddScanNode(objectToAddScanNode: objectToAddScanNode, nodeType: NodeType.GENERAL, header: header, subText: subText, creatureScanID: creatureScanID, minRange: minRange, maxRange: maxRange);
+        }
+
+        public static void AddScrapScanNode(GameObject objectToAddScanNode, string header = "LGU Scan Node", string subText = "Used for LGU stuff", int creatureScanID = -1, int minRange = 5, int maxRange = 7)
+        {
+            AddScanNode(objectToAddScanNode: objectToAddScanNode, nodeType: NodeType.SCRAP, header: header, subText: subText, creatureScanID: creatureScanID, minRange: minRange, maxRange: maxRange);
+        }
+        public static void AddDangerScanNode(GameObject objectToAddScanNode, string header = "LGU Scan Node", string subText = "Used for LGU stuff", int creatureScanID = -1, int minRange = 5, int maxRange = 7)
+        {
+            AddScanNode(objectToAddScanNode: objectToAddScanNode, nodeType: NodeType.DANGER, header: header, subText: subText, creatureScanID: creatureScanID, minRange: minRange, maxRange: maxRange);
+        }
+        public static void RemoveScanNode(GameObject objectToRemoveScanNode)
+        {
+            Object.Destroy(objectToRemoveScanNode.GetComponentInChildren<ScanNodeProperties>());
+        }
+    }
+}

--- a/MoreShipUpgrades/Misc/ScrapValueSyncer.cs
+++ b/MoreShipUpgrades/Misc/ScrapValueSyncer.cs
@@ -1,6 +1,4 @@
-﻿using MoreShipUpgrades.Managers;
-using System.Collections;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace MoreShipUpgrades.Misc
 {
@@ -11,9 +9,7 @@ namespace MoreShipUpgrades.Misc
             GrabbableObject prop = GetComponent<GrabbableObject>();
             prop.scrapValue = scrapValue;
 
-            ScanNodeProperties node = GetComponentInChildren<ScanNodeProperties>();
-            node.scrapValue = scrapValue;
-            node.subText = $"VALUE: ${scrapValue}";
+            LGUScanNodeProperties.UpdateScrapValue(ref prop, scrapValue);
             RoundManager.Instance.totalScrapValueInLevel += scrapValue;
         }
     }

--- a/MoreShipUpgrades/UpgradeComponents/Items/Wheelbarrow/ScrapWheelbarrow.cs
+++ b/MoreShipUpgrades/UpgradeComponents/Items/Wheelbarrow/ScrapWheelbarrow.cs
@@ -6,7 +6,8 @@ namespace MoreShipUpgrades.UpgradeComponents.Items.Wheelbarrow
 {
     internal class ScrapWheelbarrow : WheelbarrowScript
     {
-        private static LGULogger logger = new LGULogger(nameof(ScrapWheelbarrow));
+        static LGULogger logger = new LGULogger(nameof(ScrapWheelbarrow));
+        const string ITEM_NAME = "Shopping Cart";
         public override void Start()
         {
             base.Start();
@@ -27,6 +28,12 @@ namespace MoreShipUpgrades.UpgradeComponents.Items.Wheelbarrow
             Random random = new Random(StartOfRound.Instance.randomMapSeed + 45);
             GetComponent<ScrapValueSyncer>().SetScrapValue(random.Next(UpgradeBus.instance.cfg.SCRAP_WHEELBARROW_MINIMUM_VALUE.Value, UpgradeBus.instance.cfg.SCRAP_WHEELBARROW_MAXIMUM_VALUE.Value));
             logger.LogDebug("Spawned in the scene!");
+        }
+        protected override void SetupScanNodeProperties()
+        {
+            ScanNodeProperties scanNodeProperties = GetComponentInChildren<ScanNodeProperties>();
+            if (scanNodeProperties != null) LGUScanNodeProperties.ChangeScanNode(ref scanNodeProperties, (LGUScanNodeProperties.NodeType)scanNodeProperties.nodeType, header: ITEM_NAME);
+            else LGUScanNodeProperties.AddScrapScanNode(objectToAddScanNode: gameObject, header: ITEM_NAME);
         }
     }
 }

--- a/MoreShipUpgrades/UpgradeComponents/Items/Wheelbarrow/StoreWheelbarrow.cs
+++ b/MoreShipUpgrades/UpgradeComponents/Items/Wheelbarrow/StoreWheelbarrow.cs
@@ -12,6 +12,8 @@ namespace MoreShipUpgrades.UpgradeComponents.Items.Wheelbarrow
     {
         private static LGULogger logger = new LGULogger(nameof(StoreWheelbarrow));
         private GameObject wheel;
+        private const string ITEM_NAME = "Wheelbarrow";
+        private const string ITEM_DESCRIPTION = "Allows carrying multiple items";
 
         public string GetDisplayInfo()
         {
@@ -48,6 +50,13 @@ namespace MoreShipUpgrades.UpgradeComponents.Items.Wheelbarrow
 
             wheel.transform.Rotate(Time.deltaTime, 0f, 0f, Space.Self);
             wheel.transform.rotation.Set(wheel.transform.rotation.x % 360, wheel.transform.rotation.y, wheel.transform.rotation.z, wheel.transform.rotation.w);
+        }
+
+        protected override void SetupScanNodeProperties()
+        {
+            ScanNodeProperties scanNodeProperties = GetComponentInChildren<ScanNodeProperties>();
+            if (scanNodeProperties != null) LGUScanNodeProperties.ChangeScanNode(ref scanNodeProperties, (LGUScanNodeProperties.NodeType)scanNodeProperties.nodeType, header: ITEM_NAME, subText: ITEM_DESCRIPTION);
+            else LGUScanNodeProperties.AddGeneralScanNode(objectToAddScanNode: gameObject, header: ITEM_NAME, subText: ITEM_DESCRIPTION);
         }
     }
 }

--- a/MoreShipUpgrades/UpgradeComponents/Items/Wheelbarrow/WheelbarrowScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/Items/Wheelbarrow/WheelbarrowScript.cs
@@ -12,7 +12,7 @@ using UnityEngine.InputSystem.LowLevel;
 
 namespace MoreShipUpgrades.UpgradeComponents.Items.Wheelbarrow
 {
-    internal class WheelbarrowScript : GrabbableObject
+    abstract class WheelbarrowScript : GrabbableObject
     {
         protected enum Restrictions
         {
@@ -84,9 +84,6 @@ namespace MoreShipUpgrades.UpgradeComponents.Items.Wheelbarrow
         protected bool playSounds;
         private Dictionary<Restrictions, Func<bool>> checkMethods;
 
-        private const string ITEM_NAME = "Wheelbarrow";
-        private const string SCRAP_ITEM_NAME = "Shopping Cart";
-        private const string ITEM_DESCRIPTION = "Allows carrying multiple items";
         private const string NO_ITEMS_TEXT = "No items to deposit...";
         private const string FULL_TEXT = "Too many items in the wheelbarrow";
         private const string TOO_MUCH_WEIGHT_TEXT = "Too much weight in the wheelbarrow...";
@@ -386,19 +383,8 @@ namespace MoreShipUpgrades.UpgradeComponents.Items.Wheelbarrow
         /// <summary>
         /// Prepares the Scan Node associated with the Wheelbarrow for user display
         /// </summary>
-        private void SetupScanNodeProperties()
-        {
-            ScanNodeProperties scanNode = GetComponentInChildren<ScanNodeProperties>();
-            if (scanNode == null)
-            {
-                logger.LogError($"Couldn't find {nameof(ScanNodeProperties)} component in the prefab,");
-                return;
-            }
-            scanNode.creatureScanID = -1;
-            scanNode.headerText = this is StoreWheelbarrow ? ITEM_NAME : SCRAP_ITEM_NAME;
-            scanNode.nodeType = this is StoreWheelbarrow ? 0 : scanNode.nodeType;
-            scanNode.subText = this is StoreWheelbarrow ? ITEM_DESCRIPTION : $"Value: {scrapValue}";
-        }
+        protected abstract void SetupScanNodeProperties();
+
         public void DecrementStoredItems()
         {
             UpdateWheelbarrowWeightServerRpc();

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/BetterScanner.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/BetterScanner.cs
@@ -46,18 +46,13 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
         {
             if (!UpgradeBus.instance.scannerUpgrade) return;
             logger.LogDebug("Inserting a Scan Node on a broken steam valve...");
-            GameObject ScanNodeObject = Instantiate(GameObject.Find("ScanNode"), steamValveHazard.transform.position, Quaternion.Euler(Vector3.zero), steamValveHazard.transform);
-            ScanNodeProperties node = ScanNodeObject.GetComponent<ScanNodeProperties>();
-            node.headerText = "Bursted Steam Valve";
-            node.subText = "Fix it to get rid of the steam";
-            node.nodeType = 0;
-            node.creatureScanID = -1;
+            LGUScanNodeProperties.AddGeneralScanNode(objectToAddScanNode: steamValveHazard.gameObject, header: "Bursted Steam Valve", subText: "Fix it to get rid of the steam", minRange: 3);
         }
 
         public static void RemoveScannerNodeFromValve(ref SteamValveHazard steamValveHazard)
         {
             logger.LogDebug("Removing the Scan Node from a fixed steam valve...");
-            Destroy(steamValveHazard.gameObject.GetComponentInChildren<ScanNodeProperties>());
+            LGUScanNodeProperties.RemoveScanNode(steamValveHazard.gameObject);
         }
         public static string GetBetterScannerInfo(int level, int price)
         {


### PR DESCRIPTION
- Implemented "LGUScanNodeProperties" which manages scan nodes' properties. Used in ScrapValueSyncer and Better Scanner's steam valve marking.
- Fixed "scan enemies" showing "Unkown" instead of "Unknown for enemies without a scan node
- Abstracted Wheelbarrow's SetupScanNodeProperties() to be implemented by each derived class so that the base class doesn't have to know which class is deriving from