### PR TITLE
Changed level and active attribute storage from each variable to dictionaries

### DIFF
--- a/MoreShipUpgrades/Managers/LGUStore.cs
+++ b/MoreShipUpgrades/Managers/LGUStore.cs
@@ -422,15 +422,11 @@ namespace MoreShipUpgrades.Managers
             foreach (CustomTerminalNode customNode in UpgradeBus.instance.terminalNodes)
             {
                 bool activeUpgrade = UpgradeBus.instance.activeUpgrades.GetValueOrDefault(customNode.Name, false);
+                if (!activeUpgrade) continue;
                 int upgradeLevel = UpgradeBus.instance.upgradeLevels.GetValueOrDefault(customNode.Name, 0);
-
-
-                if (activeUpgrade)
-                {
-                    customNode.Unlocked = true;
-                    customNode.CurrentUpgrade = upgradeLevel + 1;
-                    UpgradeBus.instance.UpgradeObjects[customNode.Name].GetComponent<BaseUpgrade>().Load();
-                }
+                customNode.Unlocked = true;
+                customNode.CurrentUpgrade = upgradeLevel + 1;
+                UpgradeBus.instance.UpgradeObjects[customNode.Name].GetComponent<BaseUpgrade>().Load();
 
             }
         }

--- a/MoreShipUpgrades/Managers/LGUStore.cs
+++ b/MoreShipUpgrades/Managers/LGUStore.cs
@@ -26,58 +26,6 @@ namespace MoreShipUpgrades.Managers
         private ulong playerID = 0;
         private static LGULogger logger = new LGULogger(nameof(LGUStore));
         private string saveDataKey = "LGU_SAVE_DATA";
-
-        private static Dictionary<string, Func<SaveInfo, bool>> conditions = new Dictionary<string, Func<SaveInfo, bool>>
-        {
-            {MalwareBroadcaster.UPGRADE_NAME, saveInfo => saveInfo.DestroyTraps },
-            {Discombobulator.UPGRADE_NAME, SaveInfo => SaveInfo.terminalFlash },
-            {BiggerLungs.UPGRADE_NAME, SaveInfo => SaveInfo.biggerLungs },
-            {RunningShoes.UPGRADE_NAME, SaveInfo => SaveInfo.runningShoes },
-            {NightVision.UPGRADE_NAME, SaveInfo => SaveInfo.nightVision },
-            {StrongLegs.UPGRADE_NAME, SaveInfo => SaveInfo.strongLegs },
-            {BetterScanner.UPGRADE_NAME, SaveInfo => SaveInfo.scannerUpgrade },
-            {Beekeeper.UPGRADE_NAME, SaveInfo => SaveInfo.beekeeper },
-            {BackMuscles.UPGRADE_NAME, SaveInfo => SaveInfo.exoskeleton },
-            {LockSmith.UPGRADE_NAME, SaveInfo => SaveInfo.lockSmith },
-            {WalkieGPS.UPGRADE_NAME, SaveInfo => SaveInfo.walkies },
-            {ProteinPowder.UPGRADE_NAME, SaveInfo => SaveInfo.proteinPowder },
-            {FastEncryption.UPGRADE_NAME, SaveInfo => SaveInfo.pager },
-            {Hunter.UPGRADE_NAME, SaveInfo => SaveInfo.hunter },
-            {LightningRod.UPGRADE_NAME, SaveInfo => SaveInfo.lightningRod },
-            {Stimpack.UPGRADE_NAME, SaveInfo => SaveInfo.playerHealth },
-            {DoorsHydraulicsBattery.UPGRADE_NAME, SaveInfo => SaveInfo.doorsHydraulicsBattery },
-            {SickBeats.UPGRADE_NAME, SaveInfo => SaveInfo.sickBeats },
-            { MarketInfluence.UPGRADE_NAME, SaveInfo => SaveInfo.marketInfluence },
-            {BargainConnections.UPGRADE_NAME, SaveInfo => SaveInfo.bargainConnections },
-            {LethalDeals.UPGRADE_NAME, SaveInfo => SaveInfo.lethalDeals },
-            {QuantumDisruptor.UPGRADE_NAME, SaveInfo => SaveInfo.quantumDisruptor },
-        };
-
-        private static Dictionary<string, Func<SaveInfo, int>> levelConditions = new Dictionary<string, Func<SaveInfo, int>>
-        {
-            { MalwareBroadcaster.UPGRADE_NAME, saveInfo => 0 },
-            { Discombobulator.UPGRADE_NAME, saveInfo => saveInfo.discoLevel },
-            { BiggerLungs.UPGRADE_NAME, saveInfo => saveInfo.lungLevel },
-            { RunningShoes.UPGRADE_NAME, saveInfo => saveInfo.runningLevel },
-            { NightVision.UPGRADE_NAME, saveInfo => saveInfo.nightVisionLevel },
-            { StrongLegs.UPGRADE_NAME, saveInfo => saveInfo.legLevel },
-            { BetterScanner.UPGRADE_NAME, saveInfo => saveInfo.scanLevel },
-            { Beekeeper.UPGRADE_NAME, saveInfo => saveInfo.beeLevel },
-            { BackMuscles.UPGRADE_NAME, saveInfo => saveInfo.backLevel },
-            { LockSmith.UPGRADE_NAME, saveInfo => 0 },
-            { WalkieGPS.UPGRADE_NAME, saveInfo => 0 },
-            { ProteinPowder.UPGRADE_NAME, SaveInfo => SaveInfo.proteinLevel },
-            { FastEncryption.UPGRADE_NAME, SaveInfo => 0 },
-            { Hunter.UPGRADE_NAME, SaveInfo => SaveInfo.huntLevel },
-            { LightningRod.UPGRADE_NAME, saveInfo => 0},
-            { Stimpack.UPGRADE_NAME, saveInfo => saveInfo.playerHealthLevel },
-            { DoorsHydraulicsBattery.UPGRADE_NAME, saveInfo => saveInfo.doorsHydraulicsBatteryLevel},
-            { SickBeats.UPGRADE_NAME, saveInfo => 0 },
-            { MarketInfluence.UPGRADE_NAME, SaveInfo => SaveInfo.marketInfluenceLevel },
-            { BargainConnections.UPGRADE_NAME, saveInfo => saveInfo.bargainConnectionsLevel },
-            { LethalDeals.UPGRADE_NAME, saveInfo => 0 },
-            { QuantumDisruptor.UPGRADE_NAME, saveInfo => saveInfo.quantumDisruptorLevel },
-        };
         private bool retrievedCfg;
         private bool receivedSave;
 
@@ -99,6 +47,7 @@ namespace MoreShipUpgrades.Managers
                 if (json != null)
                 {
                     logger.LogInfo($"Loading save file for slot {saveNum}.");
+                    File.WriteAllText(filePath, json);
                     lguSave = JsonConvert.DeserializeObject<LGUSave>(json);
                     UpdateUpgradeBus();
                 }
@@ -307,20 +256,6 @@ namespace MoreShipUpgrades.Managers
         }
 
         [ServerRpc(RequireOwnership = false)]
-        public void DeleteUpgradesServerRpc()
-        {
-            logger.LogInfo($"Deleting Upgrades...");
-            int i = 0;
-            BaseUpgrade[] upgradeObjects = GameObject.FindObjectsOfType<BaseUpgrade>();
-            foreach (BaseUpgrade upgrade in upgradeObjects)
-            {
-                i++;
-                GameNetworkManager.Destroy(upgrade.gameObject);
-            }
-            logger.LogInfo($"Deleted {i} Upgrade Objects.");
-        }
-
-        [ServerRpc(RequireOwnership = false)]
         public void SyncCreditsServerRpc(int credits)
         {
             logger.LogInfo($"Request to sync credits to ${credits} received, calling ClientRpc...");
@@ -341,7 +276,80 @@ namespace MoreShipUpgrades.Managers
         {
             lguSave.playerSaves.Add(id,JsonConvert.DeserializeObject<SaveInfo>(json));
         }
+        /// <summary>
+        /// Method to get old data from json and store in the new dictionaries
+        /// </summary>
+        /// <param name="saveInfo">Save that might contain old data</param>
+        void CheckForOldData(SaveInfo saveInfo)
+        {
+            if (saveInfo.exoskeleton)
+            {
+                UpgradeBus.instance.activeUpgrades[BackMuscles.UPGRADE_NAME] = saveInfo.exoskeleton;
+                UpgradeBus.instance.upgradeLevels[BackMuscles.UPGRADE_NAME] = saveInfo.backLevel;
+            }
+            if (saveInfo.beekeeper)
+            {
+                UpgradeBus.instance.activeUpgrades[Beekeeper.UPGRADE_NAME] = saveInfo.beekeeper;
+                UpgradeBus.instance.upgradeLevels[Beekeeper.UPGRADE_NAME] = saveInfo.beeLevel;
+            }
+            if (saveInfo.biggerLungs)
+            {
+                UpgradeBus.instance.activeUpgrades[BiggerLungs.UPGRADE_NAME] = saveInfo.biggerLungs;
+                UpgradeBus.instance.upgradeLevels[BiggerLungs.UPGRADE_NAME] = saveInfo.lungLevel;
+            }
+            if (saveInfo.doorsHydraulicsBattery)
+            {
+                UpgradeBus.instance.activeUpgrades[DoorsHydraulicsBattery.UPGRADE_NAME] = saveInfo.doorsHydraulicsBattery;
+                UpgradeBus.instance.upgradeLevels[DoorsHydraulicsBattery.UPGRADE_NAME] = saveInfo.doorsHydraulicsBatteryLevel;
+            }
+            if (saveInfo.hunter)
+            {
+                UpgradeBus.instance.activeUpgrades[Hunter.UPGRADE_NAME] = saveInfo.hunter;
+                UpgradeBus.instance.upgradeLevels[Hunter.UPGRADE_NAME] = saveInfo.huntLevel;
+            }
+            if (saveInfo.nightVision)
+            {
+                UpgradeBus.instance.activeUpgrades[NightVision.UPGRADE_NAME] = saveInfo.nightVision;
+                UpgradeBus.instance.upgradeLevels[NightVision.UPGRADE_NAME] = saveInfo.nightVisionLevel;
+            }
+            if (saveInfo.playerHealth)
+            {
+                UpgradeBus.instance.activeUpgrades[Stimpack.UPGRADE_NAME] = saveInfo.playerHealth;
+                UpgradeBus.instance.upgradeLevels[Stimpack.UPGRADE_NAME] = saveInfo.playerHealthLevel;
+            }
+            if (saveInfo.proteinPowder) 
+            {
+                UpgradeBus.instance.activeUpgrades[ProteinPowder.UPGRADE_NAME] = saveInfo.proteinPowder;
+                UpgradeBus.instance.upgradeLevels[ProteinPowder.UPGRADE_NAME] = saveInfo.proteinLevel;
+            }
+            if (saveInfo.runningShoes)
+            {
+                UpgradeBus.instance.activeUpgrades[RunningShoes.UPGRADE_NAME] = saveInfo.runningShoes;
+                UpgradeBus.instance.upgradeLevels[RunningShoes.UPGRADE_NAME] = saveInfo.runningLevel;
+            }
+            if (saveInfo.scannerUpgrade)
+            {
+                UpgradeBus.instance.activeUpgrades[BetterScanner.UPGRADE_NAME] = saveInfo.scannerUpgrade;
+                UpgradeBus.instance.upgradeLevels[BetterScanner.UPGRADE_NAME] = saveInfo.scanLevel;
+            }
+            if (saveInfo.strongLegs)
+            {
+                UpgradeBus.instance.activeUpgrades[StrongLegs.UPGRADE_NAME] = saveInfo.strongLegs;
+                UpgradeBus.instance.upgradeLevels[StrongLegs.UPGRADE_NAME] = saveInfo.legLevel;
+            }
+            if (saveInfo.terminalFlash)
+            {
+                UpgradeBus.instance.activeUpgrades[StrongLegs.UPGRADE_NAME] = saveInfo.terminalFlash;
+                UpgradeBus.instance.upgradeLevels[StrongLegs.UPGRADE_NAME] = saveInfo.discoLevel;
+            }
+            if (saveInfo.walkies) UpgradeBus.instance.activeUpgrades[WalkieGPS.UPGRADE_NAME] = saveInfo.walkies;
+            if (saveInfo.lockSmith) UpgradeBus.instance.activeUpgrades[LockSmith.UPGRADE_NAME] = saveInfo.lockSmith;
+            if (saveInfo.sickBeats) UpgradeBus.instance.activeUpgrades[SickBeats.UPGRADE_NAME] = saveInfo.sickBeats;
+            if (saveInfo.pager) UpgradeBus.instance.activeUpgrades[FastEncryption.UPGRADE_NAME] = saveInfo.pager;
+            if (saveInfo.DestroyTraps) UpgradeBus.instance.activeUpgrades[MalwareBroadcaster.UPGRADE_NAME] = saveInfo.DestroyTraps;
+            if (saveInfo.lightningRod) UpgradeBus.instance.activeUpgrades[LightningRod.UPGRADE_NAME] = saveInfo.lightningRod;
 
+        }
         public void UpdateUpgradeBus(bool UseLocalSteamID = true, bool checkID = true)
         {
             if(UseLocalSteamID)
@@ -363,42 +371,14 @@ namespace MoreShipUpgrades.Managers
                 logger.LogInfo($"Successfully loaded save data for ID: {playerID}");
             }
             bool oldHelmet = UpgradeBus.instance.wearingHelmet;
-            UpgradeBus.instance.DestroyTraps = saveInfo.DestroyTraps;
-            UpgradeBus.instance.scannerUpgrade = saveInfo.scannerUpgrade;
-            UpgradeBus.instance.nightVision = saveInfo.nightVision;
-            UpgradeBus.instance.exoskeleton = saveInfo.exoskeleton;
-            UpgradeBus.instance.TPButtonPressed = saveInfo.TPButtonPressed;
-            UpgradeBus.instance.beekeeper = saveInfo.beekeeper;
-            UpgradeBus.instance.terminalFlash = saveInfo.terminalFlash;
-            UpgradeBus.instance.strongLegs = saveInfo.strongLegs;
-            UpgradeBus.instance.runningShoes = saveInfo.runningShoes;
-            UpgradeBus.instance.biggerLungs = saveInfo.biggerLungs;
-            UpgradeBus.instance.lockSmith = saveInfo.lockSmith;
-            UpgradeBus.instance.proteinPowder = saveInfo.proteinPowder;
-            UpgradeBus.instance.lightningRod = saveInfo.lightningRod;
-            UpgradeBus.instance.pager = saveInfo.pager;
-            UpgradeBus.instance.hunter = saveInfo.hunter;
-            UpgradeBus.instance.playerHealth = saveInfo.playerHealth;
-            UpgradeBus.instance.wearingHelmet = saveInfo.wearingHelmet;
-            UpgradeBus.instance.sickBeats = saveInfo.sickBeats;
-            UpgradeBus.instance.doorsHydraulicsBattery = saveInfo.doorsHydraulicsBattery;
+            UpgradeBus.instance.activeUpgrades = saveInfo.activeUpgrades;
+            UpgradeBus.instance.upgradeLevels = saveInfo.upgradeLevels;
 
-            UpgradeBus.instance.beeLevel = saveInfo.beeLevel;
-            UpgradeBus.instance.huntLevel = saveInfo.huntLevel;
-            UpgradeBus.instance.proteinLevel = saveInfo.proteinLevel;
-            UpgradeBus.instance.lungLevel = saveInfo.lungLevel;
-            UpgradeBus.instance.walkies = saveInfo.walkies;
-            UpgradeBus.instance.backLevel = saveInfo.backLevel;
-            UpgradeBus.instance.runningLevel = saveInfo.runningLevel;
-            UpgradeBus.instance.discoLevel = saveInfo.discoLevel;
-            UpgradeBus.instance.legLevel = saveInfo.legLevel;
-            UpgradeBus.instance.scanLevel = saveInfo.scanLevel;
-            UpgradeBus.instance.nightVisionLevel = saveInfo.nightVisionLevel;
-            UpgradeBus.instance.playerHealthLevel = saveInfo.playerHealthLevel;
-            UpgradeBus.instance.doorsHydraulicsBatteryLevel = saveInfo.doorsHydraulicsBatteryLevel;
+            CheckForOldData(saveInfo);
 
             UpgradeBus.instance.contractLevel = saveInfo.contractLevel;
             UpgradeBus.instance.contractType = saveInfo.contractType;
+            UpgradeBus.instance.wearingHelmet = saveInfo.wearingHelmet;
 
             UpgradeBus.instance.SaleData = saveInfo.SaleData;
 
@@ -441,14 +421,17 @@ namespace MoreShipUpgrades.Managers
             logger.LogInfo("Applying loaded upgrades...");
             foreach (CustomTerminalNode customNode in UpgradeBus.instance.terminalNodes)
             {
-                if (conditions.TryGetValue(customNode.Name, out var condition) && condition(saveInfo))
+                bool activeUpgrade = UpgradeBus.instance.activeUpgrades.GetValueOrDefault(customNode.Name, false);
+                int upgradeLevel = UpgradeBus.instance.upgradeLevels.GetValueOrDefault(customNode.Name, 0);
+
+
+                if (activeUpgrade)
                 {
-                    logger.LogInfo($"Activated {customNode.Name}!");
                     customNode.Unlocked = true;
-                    levelConditions.TryGetValue(customNode.Name, out var level);
-                    customNode.CurrentUpgrade = level.Invoke(saveInfo);
+                    customNode.CurrentUpgrade = upgradeLevel + 1;
                     UpgradeBus.instance.UpgradeObjects[customNode.Name].GetComponent<BaseUpgrade>().Load();
                 }
+
             }
         }
 
@@ -607,49 +590,52 @@ namespace MoreShipUpgrades.Managers
     [Serializable]
     public class SaveInfo
     {
-        public bool DestroyTraps = UpgradeBus.instance.DestroyTraps;
-        public bool scannerUpgrade = UpgradeBus.instance.scannerUpgrade;
-        public bool nightVision = UpgradeBus.instance.nightVision;
-        public bool exoskeleton = UpgradeBus.instance.exoskeleton;
-        public bool TPButtonPressed = UpgradeBus.instance.TPButtonPressed;
-        public bool beekeeper = UpgradeBus.instance.beekeeper;
-        public bool terminalFlash = UpgradeBus.instance.terminalFlash;
-        public bool strongLegs = UpgradeBus.instance.strongLegs;
-        public bool proteinPowder = UpgradeBus.instance.proteinPowder;
-        public bool runningShoes = UpgradeBus.instance.runningShoes;
-        public bool biggerLungs = UpgradeBus.instance.biggerLungs;
-        public bool lockSmith = UpgradeBus.instance.lockSmith;
-        public bool walkies = UpgradeBus.instance.walkies;
-        public bool lightningRod = UpgradeBus.instance.lightningRod;
-        public bool pager = UpgradeBus.instance.pager;
-        public bool hunter = UpgradeBus.instance.hunter;
-        public bool playerHealth = UpgradeBus.instance.playerHealth;
-        public bool wearingHelmet = UpgradeBus.instance.wearingHelmet;
-        public bool sickBeats = UpgradeBus.instance.sickBeats;
-        public bool doorsHydraulicsBattery = UpgradeBus.instance.doorsHydraulicsBattery;
-        public bool marketInfluence = UpgradeBus.instance.marketInfluence;
-        public bool bargainConnections = UpgradeBus.instance.bargainConnections;
-        public bool lethalDeals = UpgradeBus.instance.lethalDeals;
-        public bool quantumDisruptor = UpgradeBus.instance.quantumDisruptor;
+        public Dictionary<string, bool> activeUpgrades = UpgradeBus.instance.activeUpgrades;
+        public Dictionary<string, int> upgradeLevels = UpgradeBus.instance.upgradeLevels;
+        public bool DestroyTraps;
+        public bool scannerUpgrade;
+        public bool nightVision;
+        public bool exoskeleton;
+        public bool beekeeper;
+        public bool terminalFlash;
+        public bool strongLegs;
+        public bool proteinPowder;
+        public bool runningShoes;
+        public bool biggerLungs;
+        public bool lockSmith;
+        public bool walkies;
+        public bool lightningRod;
+        public bool pager;
+        public bool hunter;
+        public bool playerHealth;
+        public bool sickBeats;
+        public bool doorsHydraulicsBattery;
+        public bool marketInfluence;
+        public bool bargainConnections;
+        public bool lethalDeals;
+        public bool quantumDisruptor;
 
-        public int beeLevel = UpgradeBus.instance.beeLevel;
-        public int huntLevel = UpgradeBus.instance.huntLevel;
-        public int proteinLevel = UpgradeBus.instance.proteinLevel;
-        public int lungLevel = UpgradeBus.instance.lungLevel;
-        public int backLevel = UpgradeBus.instance.backLevel;
-        public int runningLevel = UpgradeBus.instance.runningLevel;
-        public int scanLevel = UpgradeBus.instance.scanLevel;
-        public int discoLevel = UpgradeBus.instance.discoLevel;
-        public int legLevel = UpgradeBus.instance.legLevel;
-        public int nightVisionLevel = UpgradeBus.instance.nightVisionLevel;
-        public int playerHealthLevel = UpgradeBus.instance.playerHealthLevel;
-        public int doorsHydraulicsBatteryLevel = UpgradeBus.instance.doorsHydraulicsBatteryLevel;
-        public int marketInfluenceLevel = UpgradeBus.instance.marketInfluenceLevel;
-        public int bargainConnectionsLevel = UpgradeBus.instance.bargainConnectionsLevel;
-        public int quantumDisruptorLevel = UpgradeBus.instance.quantumDisruptorLevel;
+        public int beeLevel;
+        public int huntLevel;
+        public int proteinLevel;
+        public int lungLevel;
+        public int backLevel;
+        public int runningLevel;
+        public int scanLevel;
+        public int discoLevel;
+        public int legLevel;
+        public int nightVisionLevel;
+        public int playerHealthLevel;
+        public int doorsHydraulicsBatteryLevel;
+        public int marketInfluenceLevel;
+        public int bargainConnectionsLevel;
+        public int quantumDisruptorLevel;
+
+        public bool TPButtonPressed = UpgradeBus.instance.TPButtonPressed;
         public string contractType = UpgradeBus.instance.contractType;
         public string contractLevel = UpgradeBus.instance.contractLevel;
         public Dictionary<string, float> SaleData = UpgradeBus.instance.SaleData;
+        public bool wearingHelmet = UpgradeBus.instance.wearingHelmet;
     }
 
     [Serializable]

--- a/MoreShipUpgrades/Managers/LGUStore.cs
+++ b/MoreShipUpgrades/Managers/LGUStore.cs
@@ -47,7 +47,6 @@ namespace MoreShipUpgrades.Managers
                 if (json != null)
                 {
                     logger.LogInfo($"Loading save file for slot {saveNum}.");
-                    File.WriteAllText(filePath, json);
                     lguSave = JsonConvert.DeserializeObject<LGUSave>(json);
                     UpdateUpgradeBus();
                 }

--- a/MoreShipUpgrades/Managers/UpgradeBus.cs
+++ b/MoreShipUpgrades/Managers/UpgradeBus.cs
@@ -1,4 +1,5 @@
 ﻿using GameNetcodeStuff;
+using HarmonyLib;
 using LethalLib.Modules;
 using MoreShipUpgrades.Misc;
 using MoreShipUpgrades.Misc.TerminalNodes;
@@ -23,47 +24,15 @@ namespace MoreShipUpgrades.Managers
         public GameObject introScreen;
         private static LGULogger logger = new LGULogger(nameof(UpgradeBus));
 
-        public bool DestroyTraps = false;
-        public bool scannerUpgrade = false;
-        public bool wearingHelmet = false;
-        public bool nightVision = false;
+        internal Dictionary<string, bool> activeUpgrades = new Dictionary<string, bool>();
+        internal Dictionary<string, int> upgradeLevels = new Dictionary<string, int>();
+
+        internal bool TPButtonPressed;
+
+        public GameObject nightVisionPrefab;
         public bool nightVisionActive = false;
         public float nightVisRange;
         public float nightVisIntensity;
-        public bool exoskeleton = false;
-        public bool TPButtonPressed = false;
-        public bool beekeeper = false;
-        public bool terminalFlash = false;
-        public bool strongLegs = false;
-        public bool runningShoes = false;
-        public bool lockSmith = false;
-        public bool biggerLungs = false;
-        public bool proteinPowder = false;
-        public bool lightningRod = false;
-        public bool hunter = false;
-        public bool playerHealth = false;
-        public bool doorsHydraulicsBattery = false;
-        public bool marketInfluence = false;
-        public bool bargainConnections = false;
-        public bool lethalDeals = false;
-        internal bool quantumDisruptor = false;
-
-        public int lungLevel = 0;
-        public int helmetHits = 0;
-        public int huntLevel = 0;
-        public int proteinLevel = 0;
-        public int beeLevel = 0;
-        public int backLevel = 0;
-        public int runningLevel = 0;
-        public int discoLevel = 0;
-        public int legLevel = 0;
-        public int scanLevel = 0;
-        public int nightVisionLevel = 0;
-        public int playerHealthLevel = 0;
-        public int doorsHydraulicsBatteryLevel = 0;
-        public int marketInfluenceLevel = 0;
-        public int bargainConnectionsLevel = 0;
-        internal int quantumDisruptorLevel = 0;
 
         public float flashCooldown = 0f;
         public float alteredWeight = 1f;
@@ -101,23 +70,25 @@ namespace MoreShipUpgrades.Managers
         public string[] internNames, internInterests;
 
         public List<Peeper> coilHeadItems = new List<Peeper>();
-        internal bool walkies;
+
         internal bool walkieUIActive;
         internal string version;
 
         public AssetBundle UpgradeAssets;
-        internal bool pager;
 
         public Dictionary<string,GameObject> samplePrefabs = new Dictionary<string,GameObject>();
-        public GameObject nightVisionPrefab;
-        public bool sickBeats;
+
         public float staminaDrainCoefficient = 1f;
         public float incomingDamageCoefficient = 1f;
         public int damageBoost;
         public GameObject BoomboxIcon;
         public bool EffectsActive;
+
         public GameObject helmetModel;
         public Helmet helmetScript;
+        public bool wearingHelmet = false;
+        public int helmetHits = 0;
+
         public Dictionary<string, AudioClip> SFX = new Dictionary<string, AudioClip>();
         public bool helmetDesync;
         public List<string> bombOrder = new List<string>();
@@ -171,45 +142,12 @@ namespace MoreShipUpgrades.Managers
         {
             ResetPlayerAttributes();
             if(IsHost || IsServer) ResetShipAttributesClientRpc();
-            EffectsActive = false;
-            DestroyTraps = false;
-            scannerUpgrade = false;
-            nightVision = false;
-            walkies = false;
-            nightVisionActive = false;
-            exoskeleton = false;
-            TPButtonPressed = false;
-            beekeeper = false;
-            terminalFlash = false;
-            strongLegs = false;
-            runningShoes = false;
-            lockSmith = false;
-            biggerLungs = false;
-            lightningRod = false;
-            pager = false;
-            hunter = false;
-            playerHealth = false;
-            sickBeats = false;
-            marketInfluence = false;
-            bargainConnections = false;
-            lethalDeals = false;
 
+            EffectsActive = false;
+            nightVisionActive = false;
             contractType = "None";
             contractLevel = "None";
 
-            huntLevel = 0;
-            proteinLevel = 0;
-            lungLevel = 0;
-            backLevel = 0;
-            scanLevel = 0;
-            beeLevel = 0;
-            runningLevel = 0;
-            discoLevel = 0;
-            legLevel = 0;
-            nightVisionLevel = 0;
-            playerHealthLevel = 0;
-            marketInfluenceLevel = 0;
-            bargainConnectionsLevel = 0;
             flashCooldown = 0f;
             alteredWeight = 1f;
             if (wipeObjRefs) {
@@ -225,6 +163,11 @@ namespace MoreShipUpgrades.Managers
                 if(node.Name == NightVision.UPGRADE_NAME) { node.Unlocked = true; }
             }
 
+            foreach (string key in activeUpgrades.Keys.ToList())
+                activeUpgrades[key] = false;
+
+            foreach (string key in upgradeLevels.Keys.ToList())
+                upgradeLevels[key] = 0;
         }
         private void ResetPlayerAttributes()
         {
@@ -232,21 +175,14 @@ namespace MoreShipUpgrades.Managers
             if (player == null) return; // Disconnecting the game
 
             logger.LogDebug($"Resetting {player.playerUsername}'s attributes");
-            if (cfg.RUNNING_SHOES_ENABLED.Value && runningShoes) UpgradeObjects[RunningShoes.UPGRADE_NAME].GetComponent<GameAttributeTierUpgrade>().UnloadUpgradeAttribute(ref runningShoes, ref runningLevel);
-            if (cfg.BIGGER_LUNGS_ENABLED.Value && biggerLungs) UpgradeObjects[BiggerLungs.UPGRADE_NAME].GetComponent<GameAttributeTierUpgrade>().UnloadUpgradeAttribute(ref biggerLungs, ref lungLevel);
-            if (cfg.STRONG_LEGS_ENABLED.Value && strongLegs) UpgradeObjects[StrongLegs.UPGRADE_NAME].GetComponent<GameAttributeTierUpgrade>().UnloadUpgradeAttribute(ref strongLegs, ref legLevel);
-            if (cfg.PLAYER_HEALTH_ENABLED.Value && playerHealth) UpgradeObjects[Stimpack.UPGRADE_NAME].GetComponent<GameAttributeTierUpgrade>().UnloadUpgradeAttribute(ref playerHealth, ref playerHealthLevel);
+            UpgradeObjects.Values.Where(upgrade => upgrade.GetComponent<GameAttributeTierUpgrade>() is IPlayerSync).Do(upgrade => upgrade.GetComponent<GameAttributeTierUpgrade>().UnloadUpgradeAttribute());
         }
 
         [ClientRpc]
         private void ResetShipAttributesClientRpc()
         {
-            HangarShipDoor shipDoors = GetShipDoors();
-            if (shipDoors == null) return; // Very edge case
-
             logger.LogDebug($"Resetting the ship's attributes");
-            if (cfg.DOOR_HYDRAULICS_BATTERY_ENABLED.Value && doorsHydraulicsBattery) UpgradeObjects[Stimpack.UPGRADE_NAME].GetComponent<GameAttributeTierUpgrade>().UnloadUpgradeAttribute(ref doorsHydraulicsBattery, ref doorsHydraulicsBatteryLevel);
-            if (cfg.QUANTUM_DISRUPTOR_ENABLED.Value && quantumDisruptor) UpgradeObjects[QuantumDisruptor.UPGRADE_NAME].GetComponent<GameAttributeTierUpgrade>().UnloadUpgradeAttribute(ref quantumDisruptor, ref quantumDisruptorLevel);
+            UpgradeObjects.Values.Where(upgrade => upgrade.GetComponent<GameAttributeTierUpgrade>() is IServerSync).Do(upgrade => upgrade.GetComponent<GameAttributeTierUpgrade>().UnloadUpgradeAttribute());
         }
 
         internal void GenerateSales(int seed = -1) // TODO: Save sales

--- a/MoreShipUpgrades/Misc/CommandParser.cs
+++ b/MoreShipUpgrades/Misc/CommandParser.cs
@@ -40,7 +40,7 @@ namespace MoreShipUpgrades.Misc
         }
         private static TerminalNode ExecuteDiscombobulatorAttack(ref Terminal terminal)
         {
-            if (!UpgradeBus.instance.terminalFlash) return DisplayTerminalMessage("You don't have access to this command yet. Purchase the 'Discombobulator'.\n\n");
+            if (!BaseUpgrade.GetActiveUpgrade(Discombobulator.UPGRADE_NAME)) return DisplayTerminalMessage("You don't have access to this command yet. Purchase the 'Discombobulator'.\n\n");
 
             if (UpgradeBus.instance.flashCooldown > 0f) return DisplayTerminalMessage($"You can discombobulate again in {Mathf.Round(UpgradeBus.instance.flashCooldown)} seconds.\nType 'cooldown' or 'cd' to check discombobulation cooldown.\n\n");
 
@@ -52,14 +52,14 @@ namespace MoreShipUpgrades.Misc
 
             if (UpgradeBus.instance.cfg.DISCOMBOBULATOR_NOTIFY_CHAT.Value)
             {
-                terminal.StartCoroutine(CountDownChat(UpgradeBus.instance.cfg.DISCOMBOBULATOR_STUN_DURATION.Value + (UpgradeBus.instance.cfg.DISCOMBOBULATOR_INCREMENT.Value * UpgradeBus.instance.discoLevel)));
+                terminal.StartCoroutine(CountDownChat(UpgradeBus.instance.cfg.DISCOMBOBULATOR_STUN_DURATION.Value + (UpgradeBus.instance.cfg.DISCOMBOBULATOR_INCREMENT.Value * BaseUpgrade.GetUpgradeLevel(Discombobulator.UPGRADE_NAME))));
             }
             return DisplayTerminalMessage($"Discombobulator hit {array.Length} enemies.\n\n");
         }
 
         private static TerminalNode ExecuteDiscombobulatorCooldown()
         {
-            if (!UpgradeBus.instance.terminalFlash) return DisplayTerminalMessage("You don't have access to this command yet. Purchase the 'Discombobulator'.\n\n");
+            if (!BaseUpgrade.GetActiveUpgrade(Discombobulator.UPGRADE_NAME)) return DisplayTerminalMessage("You don't have access to this command yet. Purchase the 'Discombobulator'.\n\n");
 
             if (UpgradeBus.instance.flashCooldown > 0f) return DisplayTerminalMessage($"You can discombobulate again in {Mathf.Round(UpgradeBus.instance.flashCooldown)} seconds.\n\n");
 
@@ -213,7 +213,7 @@ namespace MoreShipUpgrades.Misc
 
         private static TerminalNode ExecuteScanHivesCommand()
         {
-            if (UpgradeBus.instance.scanLevel < 1) return DisplayTerminalMessage("\nUpgrade Better Scanner to level 2 to use this command\nEnter `info better scanner` to check upgrades.\n\n");
+            if (BaseUpgrade.GetUpgradeLevel(BetterScanner.UPGRADE_NAME) < 1) return DisplayTerminalMessage("\nUpgrade Better Scanner to level 2 to use this command\nEnter `info better scanner` to check upgrades.\n\n");
 
             GrabbableObject[] scrapItems = UnityEngine.Object.FindObjectsOfType<GrabbableObject>().ToArray();
             GrabbableObject[] filteredHives = scrapItems.Where(scrap => scrap.itemProperties.itemName == "Hive").ToArray();
@@ -230,7 +230,7 @@ namespace MoreShipUpgrades.Misc
 
         private static TerminalNode ExecuteScanScrapCommand()
         {
-            if (UpgradeBus.instance.scanLevel < 1) return DisplayTerminalMessage("\nUpgrade Better Scanner to level 2 to use this command\nEnter `info better scanner` to check upgrades.\n\n");
+            if (BaseUpgrade.GetUpgradeLevel(BetterScanner.UPGRADE_NAME) < 1) return DisplayTerminalMessage("\nUpgrade Better Scanner to level 2 to use this command\nEnter `info better scanner` to check upgrades.\n\n");
 
             GrabbableObject[] scrapItems = UnityEngine.Object.FindObjectsOfType<GrabbableObject>().ToArray();
             GrabbableObject[] filteredScrap = scrapItems.Where(scrap => scrap.isInFactory && scrap.itemProperties.isScrap).ToArray();
@@ -247,7 +247,7 @@ namespace MoreShipUpgrades.Misc
 
         private static TerminalNode ExecuteScanPlayerCommand()
         {
-            if (UpgradeBus.instance.scanLevel < 1) return DisplayTerminalMessage("\nUpgrade Better Scanner to level 2 to use this command\nEnter `info better scanner` to check upgrades.\n\n");
+            if (BaseUpgrade.GetUpgradeLevel(BetterScanner.UPGRADE_NAME) < 1) return DisplayTerminalMessage("\nUpgrade Better Scanner to level 2 to use this command\nEnter `info better scanner` to check upgrades.\n\n");
 
             PlayerControllerB[] players = UnityEngine.Object.FindObjectsOfType<PlayerControllerB>().ToArray();
             PlayerControllerB[] filteredPlayers = players.Where(player => player.playerSteamId != 0).ToArray();
@@ -270,7 +270,7 @@ namespace MoreShipUpgrades.Misc
 
         private static TerminalNode ExecuteScanEnemiesCommand()
         {
-            if (UpgradeBus.instance.scanLevel < 1) return DisplayTerminalMessage("\nUpgrade Better Scanner to level 2 to use this command\nEnter `info better scanner` to check upgrades.\n\n");
+            if (BaseUpgrade.GetUpgradeLevel(BetterScanner.UPGRADE_NAME) < 1) return DisplayTerminalMessage("\nUpgrade Better Scanner to level 2 to use this command\nEnter `info better scanner` to check upgrades.\n\n");
 
             EnemyAI[] enemies = UnityEngine.Object.FindObjectsOfType<EnemyAI>().Where(enem => !enem.isEnemyDead).ToArray();
             string displayText = null;
@@ -314,7 +314,7 @@ namespace MoreShipUpgrades.Misc
 
         private static TerminalNode ExecuteScanDoorsCommand()
         {
-            if (UpgradeBus.instance.scanLevel < 1) return DisplayTerminalMessage("\nUpgrade Better Scanner to level 2 to use this command\nEnter `info better scanner` to check upgrades.\n\n");
+            if (BaseUpgrade.GetUpgradeLevel(BetterScanner.UPGRADE_NAME) < 1) return DisplayTerminalMessage("\nUpgrade Better Scanner to level 2 to use this command\nEnter `info better scanner` to check upgrades.\n\n");
 
             List<GameObject> fireEscape = UnityEngine.Object.FindObjectsOfType<GameObject>().Where(obj => obj.name == "SpawnEntranceBTrigger").ToList();
             List<EntranceTeleport> mainDoors = UnityEngine.Object.FindObjectsOfType<EntranceTeleport>().ToList();

--- a/MoreShipUpgrades/Misc/Upgrades/BaseUpgrade.cs
+++ b/MoreShipUpgrades/Misc/Upgrades/BaseUpgrade.cs
@@ -1,4 +1,6 @@
-﻿using MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades;
+﻿using MoreShipUpgrades.Managers;
+using MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades;
+using System.Collections.Generic;
 using Unity.Netcode;
 
 namespace MoreShipUpgrades.Misc.Upgrades
@@ -22,20 +24,48 @@ namespace MoreShipUpgrades.Misc.Upgrades
         public const string PRICES_SECTION = "Price of each additional upgrade";
         public const string PRICES_DESCRIPTION = "Value must be seperated by commas EX: '123,321,222'";
         #endregion
-        #region Abstract Methods
-        internal abstract void Start();
+        #region Virtual Methods
+        internal virtual void Start()
+        {
+            DontDestroyOnLoad(gameObject);
+            Register();
+        }
         /// <summary>
         /// Function called when the upgrade is being purchased for the first time
         /// </summary>
-        public abstract void Load();
+        public virtual void Load()
+        {
+            string loadColour = "#FF0000";
+            string loadMessage = $"\n<color={loadColour}>{upgradeName} is active!</color>";
+            HUDManager.Instance.chatText.text += loadMessage;
+            UpgradeBus.instance.activeUpgrades[upgradeName] = true;
+        }
         /// <summary>
         /// Function responsible to insert this upgrade's gameObject into the UpgradeBus' list of gameObjects for handling
         /// </summary>
-        public abstract void Register();
+        public virtual void Register()
+        {
+            if (!UpgradeBus.instance.UpgradeObjects.ContainsKey(upgradeName)) { UpgradeBus.instance.UpgradeObjects.Add(upgradeName, gameObject); }
+        }
         /// <summary>
         /// Function called when the upgrade is being unloaded or the save is being reset
         /// </summary>
-        public abstract void Unwind();
+        public virtual void Unwind()
+        {
+            string unloadColour = "#FF0000";
+            string unloadMessage = $"\n<color={unloadColour}>{upgradeName} has been disabled!</color>";
+            HUDManager.Instance.chatText.text += unloadMessage;
+            UpgradeBus.instance.activeUpgrades[upgradeName] = false;
+        }
         #endregion
+        internal static bool GetActiveUpgrade(string upgradeName)
+        {
+            return UpgradeBus.instance.activeUpgrades.GetValueOrDefault(upgradeName, false);
+        }
+
+        internal static int GetUpgradeLevel(string upgradeName)
+        {
+            return UpgradeBus.instance.upgradeLevels.GetValueOrDefault(upgradeName, 0);
+        }
     }
 }

--- a/MoreShipUpgrades/Misc/Upgrades/GameAttributeTierUpgrade.cs
+++ b/MoreShipUpgrades/Misc/Upgrades/GameAttributeTierUpgrade.cs
@@ -95,12 +95,12 @@ namespace MoreShipUpgrades.Misc.Upgrades
         /// </summary>
         /// <param name="upgradeActive">Represents the state of the upgrade being applied on the player</param>
         /// <param name="upgradeLevel">Current level of the upgrade when loading the upgrade</param>
-        protected void LoadUpgradeAttribute(ref bool upgradeActive, int upgradeLevel = 0)
+        protected void LoadUpgradeAttribute()
         {
             if (!activeUpgrade) AddInitialValue();
-            upgradeActive = true;
             activeUpgrade = true;
 
+            int upgradeLevel = GetUpgradeLevel(upgradeName);
             AddPossibleIncrementalValues(upgradeLevel);
             currentUpgradeLevel = upgradeLevel;
         }
@@ -178,14 +178,14 @@ namespace MoreShipUpgrades.Misc.Upgrades
         /// </summary>
         /// <param name="upgradeActive">Current status of the upgrade</param>
         /// <param name="upgradeLevel">Current level of the upgrade</param>
-        internal void UnloadUpgradeAttribute(ref bool upgradeActive, ref int upgradeLevel)
+        internal void UnloadUpgradeAttribute()
         {
+            bool upgradeActive = GetActiveUpgrade(upgradeName);
+            int upgradeLevel = GetUpgradeLevel(upgradeName);
             if (upgradeActive) RemoveInitialValue();
             RemovePossibleIncrementalValues(upgradeLevel);
-            upgradeActive = false;
-            upgradeLevel = 0;
-            activeUpgrade = upgradeActive;
-            currentUpgradeLevel = upgradeLevel;
+            activeUpgrade = false;
+            currentUpgradeLevel = 0;
         }
         /// <summary>
         /// Removes the initial value introduced into the selected attribute
@@ -234,8 +234,19 @@ namespace MoreShipUpgrades.Misc.Upgrades
         #region Overriden Methods
         public override void Increment()
         {
+            base.Increment();
             AddIncrementalValue();
             currentUpgradeLevel++;
+        }
+        public override void Load()
+        {
+            LoadUpgradeAttribute();
+            base.Load();
+        }
+        public override void Unwind()
+        {
+            UnloadUpgradeAttribute();
+            base.Unwind();
         }
         #endregion
     }

--- a/MoreShipUpgrades/Misc/Upgrades/OneTimeUpgrade.cs
+++ b/MoreShipUpgrades/Misc/Upgrades/OneTimeUpgrade.cs
@@ -9,32 +9,6 @@ namespace MoreShipUpgrades.Misc.Upgrades
     /// </summary>
     abstract class OneTimeUpgrade : BaseUpgrade, IOneTimeUpgradeDisplayInfo
     {
-        #region Overriden Methods
-        internal override void Start()
-        {
-            DontDestroyOnLoad(gameObject);
-            Register();
-        }
-        public override void Load()
-        {
-            string loadColour = "#FF0000";
-            string loadMessage = $"\n<color={loadColour}>{upgradeName} is active!</color>";
-            HUDManager.Instance.chatText.text += loadMessage;
-        }
-
-        public override void Register()
-        {
-            UnityEngine.Debug.Log($"{upgradeName}");
-            if (!UpgradeBus.instance.UpgradeObjects.ContainsKey(upgradeName)) { UpgradeBus.instance.UpgradeObjects.Add(upgradeName, gameObject); }
-        }
-
-        public override void Unwind()
-        {
-            string unloadColour = "#FF0000";
-            string unloadMessage = $"\n<color={unloadColour}>{upgradeName} has been disabled!</color>";
-            HUDManager.Instance.chatText.text += unloadMessage;
-        }
-        #endregion
         #region Interface Methods
         public abstract string GetDisplayInfo(int price = -1);
         #endregion

--- a/MoreShipUpgrades/Misc/Upgrades/TierUpgrade.cs
+++ b/MoreShipUpgrades/Misc/Upgrades/TierUpgrade.cs
@@ -1,5 +1,6 @@
 ﻿using MoreShipUpgrades.Managers;
 using MoreShipUpgrades.UpgradeComponents.Interfaces;
+using System.Collections.Generic;
 
 namespace MoreShipUpgrades.Misc.Upgrades
 {
@@ -9,38 +10,21 @@ namespace MoreShipUpgrades.Misc.Upgrades
     abstract class TierUpgrade : BaseUpgrade, ITierUpgradeDisplayInfo
     {
         #region Overriden Methods
-        internal override void Start()
-        {
-            DontDestroyOnLoad(gameObject);
-            Register();
-        }
-        /// <summary>
-        /// Handles the upgrade being purchased past the unlock phase
-        /// </summary>
-        public override void Load()
-        {
-            string loadColour = "#FF0000";
-            string loadMessage = $"\n<color={loadColour}>{upgradeName} is active!</color>";
-            HUDManager.Instance.chatText.text += loadMessage;
-        }
-
-        public override void Register()
-        {
-            if (!UpgradeBus.instance.UpgradeObjects.ContainsKey(upgradeName)) { UpgradeBus.instance.UpgradeObjects.Add(upgradeName, gameObject); }
-        }
 
         public override void Unwind()
         {
-            string unloadColour = "#FF0000";
-            string unloadMessage = $"\n<color={unloadColour}>{upgradeName} has been disabled!</color>";
-            HUDManager.Instance.chatText.text += unloadMessage;
+            base.Unwind();
+            UpgradeBus.instance.upgradeLevels[upgradeName] = 0;
         }
         #endregion
         #region Interface Methods
         public abstract string GetDisplayInfo(int initialPrice = -1, int maxLevels = -1, int[] incrementalPrices = null);
         #endregion
         #region Abstract Methods
-        public abstract void Increment();
+        public virtual void Increment()
+        {
+            UpgradeBus.instance.upgradeLevels[upgradeName]++;
+        }
         #endregion
     }
 }

--- a/MoreShipUpgrades/Patches/Enemies/EnemyAIPatcher.cs
+++ b/MoreShipUpgrades/Patches/Enemies/EnemyAIPatcher.cs
@@ -1,6 +1,7 @@
 ﻿using HarmonyLib;
 using MoreShipUpgrades.Managers;
 using MoreShipUpgrades.Misc;
+using MoreShipUpgrades.Misc.Upgrades;
 using MoreShipUpgrades.UpgradeComponents.TierUpgrades;
 using System.Linq;
 using Unity.Netcode;
@@ -21,11 +22,11 @@ namespace MoreShipUpgrades.Patches.Enemies
             currentEnemy = __instance.NetworkObject.NetworkObjectId;
             string name = __instance.enemyType.enemyName;
 
-            if (!(UpgradeBus.instance.activeUpgrades[Hunter.UPGRADE_NAME] && Hunter.tiers[UpgradeBus.instance.upgradeLevels[Hunter.UPGRADE_NAME]].Contains(name.ToLower())))
+            if (!(BaseUpgrade.GetActiveUpgrade(Hunter.UPGRADE_NAME) && Hunter.tiers[BaseUpgrade.GetActiveLevel(Hunter.UPGRADE_NAME)].Contains(name.ToLower())))
             {
                 logger.LogDebug($"No sample was found to spawn for {name.ToLower()}");
                 logger.LogDebug("Enemies in the Hunter list");
-                foreach (string monsterName in Hunter.tiers[UpgradeBus.instance.upgradeLevels[Hunter.UPGRADE_NAME]])
+                foreach (string monsterName in Hunter.tiers[BaseUpgrade.GetActiveLevel(Hunter.UPGRADE_NAME)])
                     logger.LogDebug($"{monsterName}");
                 return;
             }

--- a/MoreShipUpgrades/Patches/Enemies/EnemyAIPatcher.cs
+++ b/MoreShipUpgrades/Patches/Enemies/EnemyAIPatcher.cs
@@ -21,11 +21,11 @@ namespace MoreShipUpgrades.Patches.Enemies
             currentEnemy = __instance.NetworkObject.NetworkObjectId;
             string name = __instance.enemyType.enemyName;
 
-            if (!(UpgradeBus.instance.hunter && Hunter.tiers[UpgradeBus.instance.huntLevel].Contains(name.ToLower())))
+            if (!(UpgradeBus.instance.activeUpgrades[Hunter.UPGRADE_NAME] && Hunter.tiers[UpgradeBus.instance.upgradeLevels[Hunter.UPGRADE_NAME]].Contains(name.ToLower())))
             {
                 logger.LogDebug($"No sample was found to spawn for {name.ToLower()}");
                 logger.LogDebug("Enemies in the Hunter list");
-                foreach (string monsterName in Hunter.tiers[UpgradeBus.instance.huntLevel])
+                foreach (string monsterName in Hunter.tiers[UpgradeBus.instance.upgradeLevels[Hunter.UPGRADE_NAME]])
                     logger.LogDebug($"{monsterName}");
                 return;
             }

--- a/MoreShipUpgrades/Patches/Enemies/EnemyAIPatcher.cs
+++ b/MoreShipUpgrades/Patches/Enemies/EnemyAIPatcher.cs
@@ -22,11 +22,11 @@ namespace MoreShipUpgrades.Patches.Enemies
             currentEnemy = __instance.NetworkObject.NetworkObjectId;
             string name = __instance.enemyType.enemyName;
 
-            if (!(BaseUpgrade.GetActiveUpgrade(Hunter.UPGRADE_NAME) && Hunter.tiers[BaseUpgrade.GetActiveLevel(Hunter.UPGRADE_NAME)].Contains(name.ToLower())))
+            if (!(BaseUpgrade.GetActiveUpgrade(Hunter.UPGRADE_NAME) && Hunter.tiers[BaseUpgrade.GetUpgradeLevel(Hunter.UPGRADE_NAME)].Contains(name.ToLower())))
             {
                 logger.LogDebug($"No sample was found to spawn for {name.ToLower()}");
                 logger.LogDebug("Enemies in the Hunter list");
-                foreach (string monsterName in Hunter.tiers[BaseUpgrade.GetActiveLevel(Hunter.UPGRADE_NAME)])
+                foreach (string monsterName in Hunter.tiers[BaseUpgrade.GetUpgradeLevel(Hunter.UPGRADE_NAME)])
                     logger.LogDebug($"{monsterName}");
                 return;
             }

--- a/MoreShipUpgrades/Patches/HUD/HUDManagerPatcher.cs
+++ b/MoreShipUpgrades/Patches/HUD/HUDManagerPatcher.cs
@@ -29,7 +29,7 @@ namespace MoreShipUpgrades.Patches.HUD
             bool cannotSeeEnemiesThroughWalls = node.nodeType == 1 && !UpgradeBus.instance.cfg.BETTER_SCANNER_ENEMIES.Value;
             if (throughWall)
             {
-                if (BaseUpgrade.GetActiveLevel(BetterScanner.UPGRADE_NAME) < 2 || BaseUpgrade.GetActiveLevel(BetterScanner.UPGRADE_NAME) == 2 && cannotSeeEnemiesThroughWalls)
+                if (BaseUpgrade.GetUpgradeLevel(BetterScanner.UPGRADE_NAME) < 2 || BaseUpgrade.GetUpgradeLevel(BetterScanner.UPGRADE_NAME) == 2 && cannotSeeEnemiesThroughWalls)
                 {
                     __result = false;
                     return;

--- a/MoreShipUpgrades/Patches/HUD/HUDManagerPatcher.cs
+++ b/MoreShipUpgrades/Patches/HUD/HUDManagerPatcher.cs
@@ -5,6 +5,7 @@ using MoreShipUpgrades.Misc;
 using MoreShipUpgrades.UpgradeComponents.Commands;
 using MoreShipUpgrades.UpgradeComponents.Items.Wheelbarrow;
 using MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades;
+using MoreShipUpgrades.UpgradeComponents.TierUpgrades;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
@@ -21,13 +22,13 @@ namespace MoreShipUpgrades.Patches.HUD
         private static void alterReqs(ScanNodeProperties node, ref bool __result, PlayerControllerB playerScript)
         {
             if (node != null && node.GetComponentInParent<WheelbarrowScript>() != null && node.headerText != "Shopping Cart" && node.headerText != "Wheelbarrow") { __result = false; return; }
-            if (!UpgradeBus.instance.scannerUpgrade) { return; }
+            if (!UpgradeBus.instance.activeUpgrades[BetterScanner.UPGRADE_NAME]) { return; }
             if (node == null) { __result = false; return; }
             bool throughWall = Physics.Linecast(playerScript.gameplayCamera.transform.position, node.transform.position, 256, QueryTriggerInteraction.Ignore);
             bool cannotSeeEnemiesThroughWalls = node.nodeType == 1 && !UpgradeBus.instance.cfg.BETTER_SCANNER_ENEMIES.Value;
             if (throughWall)
             {
-                if (UpgradeBus.instance.scanLevel < 2 || UpgradeBus.instance.scanLevel == 2 && cannotSeeEnemiesThroughWalls)
+                if (UpgradeBus.instance.upgradeLevels[BetterScanner.UPGRADE_NAME] < 2 || UpgradeBus.instance.upgradeLevels[BetterScanner.UPGRADE_NAME] == 2 && cannotSeeEnemiesThroughWalls)
                 {
                     __result = false;
                     return;

--- a/MoreShipUpgrades/Patches/HUD/HUDManagerPatcher.cs
+++ b/MoreShipUpgrades/Patches/HUD/HUDManagerPatcher.cs
@@ -2,6 +2,7 @@
 using HarmonyLib;
 using MoreShipUpgrades.Managers;
 using MoreShipUpgrades.Misc;
+using MoreShipUpgrades.Misc.Upgrades;
 using MoreShipUpgrades.UpgradeComponents.Commands;
 using MoreShipUpgrades.UpgradeComponents.Items.Wheelbarrow;
 using MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades;
@@ -22,13 +23,13 @@ namespace MoreShipUpgrades.Patches.HUD
         private static void alterReqs(ScanNodeProperties node, ref bool __result, PlayerControllerB playerScript)
         {
             if (node != null && node.GetComponentInParent<WheelbarrowScript>() != null && node.headerText != "Shopping Cart" && node.headerText != "Wheelbarrow") { __result = false; return; }
-            if (!UpgradeBus.instance.activeUpgrades[BetterScanner.UPGRADE_NAME]) { return; }
+            if (!BaseUpgrade.GetActiveUpgrade(BetterScanner.UPGRADE_NAME)) { return; }
             if (node == null) { __result = false; return; }
             bool throughWall = Physics.Linecast(playerScript.gameplayCamera.transform.position, node.transform.position, 256, QueryTriggerInteraction.Ignore);
             bool cannotSeeEnemiesThroughWalls = node.nodeType == 1 && !UpgradeBus.instance.cfg.BETTER_SCANNER_ENEMIES.Value;
             if (throughWall)
             {
-                if (UpgradeBus.instance.upgradeLevels[BetterScanner.UPGRADE_NAME] < 2 || UpgradeBus.instance.upgradeLevels[BetterScanner.UPGRADE_NAME] == 2 && cannotSeeEnemiesThroughWalls)
+                if (BaseUpgrade.GetActiveLevel(BetterScanner.UPGRADE_NAME) < 2 || BaseUpgrade.GetActiveLevel(BetterScanner.UPGRADE_NAME) == 2 && cannotSeeEnemiesThroughWalls)
                 {
                     __result = false;
                     return;

--- a/MoreShipUpgrades/Patches/Interactables/InteractTriggerPatcher.cs
+++ b/MoreShipUpgrades/Patches/Interactables/InteractTriggerPatcher.cs
@@ -15,7 +15,7 @@ namespace MoreShipUpgrades.Patches.Interactables
         [HarmonyPatch(nameof(InteractTrigger.OnTriggerEnter))]
         private static bool pickDoor(InteractTrigger __instance, Collider other)
         {
-            if (!UpgradeBus.instance.lockSmith) { return true; }
+            if (!UpgradeBus.instance.activeUpgrades[LockSmith.UPGRADE_NAME]) { return true; }
             PlayerControllerB player = other.gameObject.GetComponent<PlayerControllerB>();
             if (player == null) { return true; }
             if (!player.IsOwner) { return true; }

--- a/MoreShipUpgrades/Patches/Interactables/InteractTriggerPatcher.cs
+++ b/MoreShipUpgrades/Patches/Interactables/InteractTriggerPatcher.cs
@@ -2,6 +2,7 @@
 using HarmonyLib;
 using MoreShipUpgrades.Managers;
 using MoreShipUpgrades.Misc;
+using MoreShipUpgrades.Misc.Upgrades;
 using MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades;
 using UnityEngine;
 
@@ -15,7 +16,7 @@ namespace MoreShipUpgrades.Patches.Interactables
         [HarmonyPatch(nameof(InteractTrigger.OnTriggerEnter))]
         private static bool pickDoor(InteractTrigger __instance, Collider other)
         {
-            if (!UpgradeBus.instance.activeUpgrades[LockSmith.UPGRADE_NAME]) { return true; }
+            if (!BaseUpgrade.GetActiveUpgrade(LockSmith.UPGRADE_NAME)) { return true; }
             PlayerControllerB player = other.gameObject.GetComponent<PlayerControllerB>();
             if (player == null) { return true; }
             if (!player.IsOwner) { return true; }

--- a/MoreShipUpgrades/Patches/Items/WalkiePatcher.cs
+++ b/MoreShipUpgrades/Patches/Items/WalkiePatcher.cs
@@ -11,7 +11,7 @@ namespace MoreShipUpgrades.Patches.Items
         [HarmonyPatch(nameof(WalkieTalkie.PocketItem))]
         private static void DisableHUD(WalkieTalkie __instance)
         {
-            if (!UpgradeBus.instance.walkies || !__instance.playerHeldBy.IsOwner) { return; }
+            if (!UpgradeBus.instance.activeUpgrades[WalkieGPS.UPGRADE_NAME] || !__instance.playerHeldBy.IsOwner) { return; }
             WalkieGPS.instance.WalkieDeactivate();
         }
 
@@ -19,7 +19,7 @@ namespace MoreShipUpgrades.Patches.Items
         [HarmonyPatch(nameof(WalkieTalkie.DiscardItem))]
         private static void DisableHUDDiscard(WalkieTalkie __instance)
         {
-            if (!UpgradeBus.instance.walkies || !__instance.playerHeldBy.IsOwner) { return; }
+            if (!UpgradeBus.instance.activeUpgrades[WalkieGPS.UPGRADE_NAME] || !__instance.playerHeldBy.IsOwner) { return; }
             WalkieGPS.instance.WalkieDeactivate();
         }
 
@@ -28,7 +28,7 @@ namespace MoreShipUpgrades.Patches.Items
         [HarmonyPatch(nameof(WalkieTalkie.EquipItem))]
         private static void EnableHUD(WalkieTalkie __instance)
         {
-            if (!UpgradeBus.instance.walkies || !__instance.playerHeldBy.IsOwner) { return; }
+            if (!UpgradeBus.instance.activeUpgrades[WalkieGPS.UPGRADE_NAME] || !__instance.playerHeldBy.IsOwner) { return; }
             WalkieGPS.instance.WalkieActive();
         }
     }

--- a/MoreShipUpgrades/Patches/Items/WalkiePatcher.cs
+++ b/MoreShipUpgrades/Patches/Items/WalkiePatcher.cs
@@ -1,5 +1,6 @@
 ﻿using HarmonyLib;
 using MoreShipUpgrades.Managers;
+using MoreShipUpgrades.Misc.Upgrades;
 using MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades;
 
 namespace MoreShipUpgrades.Patches.Items
@@ -11,7 +12,7 @@ namespace MoreShipUpgrades.Patches.Items
         [HarmonyPatch(nameof(WalkieTalkie.PocketItem))]
         private static void DisableHUD(WalkieTalkie __instance)
         {
-            if (!UpgradeBus.instance.activeUpgrades[WalkieGPS.UPGRADE_NAME] || !__instance.playerHeldBy.IsOwner) { return; }
+            if (!BaseUpgrade.GetActiveUpgrade(WalkieGPS.UPGRADE_NAME) || !__instance.playerHeldBy.IsOwner) { return; }
             WalkieGPS.instance.WalkieDeactivate();
         }
 
@@ -19,7 +20,7 @@ namespace MoreShipUpgrades.Patches.Items
         [HarmonyPatch(nameof(WalkieTalkie.DiscardItem))]
         private static void DisableHUDDiscard(WalkieTalkie __instance)
         {
-            if (!UpgradeBus.instance.activeUpgrades[WalkieGPS.UPGRADE_NAME] || !__instance.playerHeldBy.IsOwner) { return; }
+            if (!BaseUpgrade.GetActiveUpgrade(WalkieGPS.UPGRADE_NAME) || !__instance.playerHeldBy.IsOwner) { return; }
             WalkieGPS.instance.WalkieDeactivate();
         }
 
@@ -28,7 +29,7 @@ namespace MoreShipUpgrades.Patches.Items
         [HarmonyPatch(nameof(WalkieTalkie.EquipItem))]
         private static void EnableHUD(WalkieTalkie __instance)
         {
-            if (!UpgradeBus.instance.activeUpgrades[WalkieGPS.UPGRADE_NAME] || !__instance.playerHeldBy.IsOwner) { return; }
+            if (!BaseUpgrade.GetActiveUpgrade(WalkieGPS.UPGRADE_NAME) || !__instance.playerHeldBy.IsOwner) { return; }
             WalkieGPS.instance.WalkieActive();
         }
     }

--- a/MoreShipUpgrades/Patches/PlayerController/PlayerControllerBPatcher.cs
+++ b/MoreShipUpgrades/Patches/PlayerController/PlayerControllerBPatcher.cs
@@ -12,6 +12,7 @@ using UnityEngine;
 using MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades;
 using MoreShipUpgrades.UpgradeComponents.TierUpgrades;
 using MoreShipUpgrades.UpgradeComponents.TierUpgrades.AttributeUpgrades;
+using MoreShipUpgrades.Misc.Upgrades;
 
 namespace MoreShipUpgrades.Patches.PlayerController
 {
@@ -29,7 +30,7 @@ namespace MoreShipUpgrades.Patches.PlayerController
             if (__instance.isPlayerDead) return;
             if (!__instance.AllowPlayerDeath()) return;
 
-            if (!UpgradeBus.instance.nightVision) return;
+            if (!UpgradeBus.instance.activeUpgrades[NightVision.UPGRADE_NAME]) return;
 
             UpgradeBus.instance.UpgradeObjects[NightVision.UPGRADE_NAME].GetComponent<NightVision>().DisableOnClient();
             if (!UpgradeBus.instance.cfg.NIGHT_VISION_DROP_ON_DEATH.Value) return;
@@ -220,7 +221,7 @@ namespace MoreShipUpgrades.Patches.PlayerController
         [HarmonyPatch(nameof(PlayerControllerB.Update))]
         static void CheckForBoomboxes(PlayerControllerB __instance)
         {
-            if (!UpgradeBus.instance.sickBeats || __instance != GameNetworkManager.Instance.localPlayerController) return;
+            if (!BaseUpgrade.GetActiveUpgrade(SickBeats.UPGRADE_NAME) || __instance != GameNetworkManager.Instance.localPlayerController) return;
             UpgradeBus.instance.boomBoxes.RemoveAll(b => b == null);
             bool result = false;
             if (__instance.isPlayerDead)

--- a/MoreShipUpgrades/Patches/PlayerController/PlayerControllerBPatcher.cs
+++ b/MoreShipUpgrades/Patches/PlayerController/PlayerControllerBPatcher.cs
@@ -30,7 +30,7 @@ namespace MoreShipUpgrades.Patches.PlayerController
             if (__instance.isPlayerDead) return;
             if (!__instance.AllowPlayerDeath()) return;
 
-            if (!UpgradeBus.instance.activeUpgrades[NightVision.UPGRADE_NAME]) return;
+            if (!BaseUpgrade.GetActiveUpgrade(NightVision.UPGRADE_NAME)) return;
 
             UpgradeBus.instance.UpgradeObjects[NightVision.UPGRADE_NAME].GetComponent<NightVision>().DisableOnClient();
             if (!UpgradeBus.instance.cfg.NIGHT_VISION_DROP_ON_DEATH.Value) return;

--- a/MoreShipUpgrades/Patches/RoundComponents/StartOfRoundPatcher.cs
+++ b/MoreShipUpgrades/Patches/RoundComponents/StartOfRoundPatcher.cs
@@ -2,11 +2,10 @@
 using HarmonyLib;
 using MoreShipUpgrades.Managers;
 using MoreShipUpgrades.Misc;
+using MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades;
 using MoreShipUpgrades.UpgradeComponents.TierUpgrades.AttributeUpgrades;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
-using System.Reflection.Emit;
 using Unity.Netcode;
 using UnityEngine;
 
@@ -52,7 +51,7 @@ namespace MoreShipUpgrades.Patches.RoundComponents
         [HarmonyPatch(nameof(StartOfRound.PowerSurgeShip))]
         private static bool PowerSurgeShip()
         {
-            if (UpgradeBus.instance.lightningRod) return false;
+            if (UpgradeBus.instance.activeUpgrades[LightningRod.UPGRADE_NAME]) return false;
             return true;
         }
 

--- a/MoreShipUpgrades/Patches/RoundComponents/StartOfRoundPatcher.cs
+++ b/MoreShipUpgrades/Patches/RoundComponents/StartOfRoundPatcher.cs
@@ -2,6 +2,7 @@
 using HarmonyLib;
 using MoreShipUpgrades.Managers;
 using MoreShipUpgrades.Misc;
+using MoreShipUpgrades.Misc.Upgrades;
 using MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades;
 using MoreShipUpgrades.UpgradeComponents.TierUpgrades.AttributeUpgrades;
 using System.Collections.Generic;
@@ -51,7 +52,7 @@ namespace MoreShipUpgrades.Patches.RoundComponents
         [HarmonyPatch(nameof(StartOfRound.PowerSurgeShip))]
         private static bool PowerSurgeShip()
         {
-            if (UpgradeBus.instance.activeUpgrades[LightningRod.UPGRADE_NAME]) return false;
+            if (BaseUpgrade.GetActiveUpgrade(LightningRod.UPGRADE_NAME)) return false;
             return true;
         }
 

--- a/MoreShipUpgrades/Patches/TerminalComponents/TerminalAccessibleObjectPatcher.cs
+++ b/MoreShipUpgrades/Patches/TerminalComponents/TerminalAccessibleObjectPatcher.cs
@@ -13,7 +13,7 @@ namespace MoreShipUpgrades.Patches.TerminalComponents
         [HarmonyPatch(nameof(TerminalAccessibleObject.CallFunctionFromTerminal))]
         private static bool DestroyObject(ref TerminalAccessibleObject __instance, ref float ___codeAccessCooldownTimer, ref bool ___inCooldown)
         {
-            if (!UpgradeBus.instance.DestroyTraps || __instance.gameObject.layer != LayerMask.NameToLayer("MapHazards")) { return true; }
+            if (!UpgradeBus.instance.activeUpgrades[MalwareBroadcaster.UPGRADE_NAME] || __instance.gameObject.layer != LayerMask.NameToLayer("MapHazards")) { return true; }
             if (UpgradeBus.instance.cfg.DESTROY_TRAP.Value)
             {
                 MalwareBroadcaster.instance.ReqDestroyObjectServerRpc(new NetworkObjectReference(__instance.gameObject.transform.parent.gameObject.GetComponent<NetworkObject>()));

--- a/MoreShipUpgrades/Patches/TerminalComponents/TerminalAccessibleObjectPatcher.cs
+++ b/MoreShipUpgrades/Patches/TerminalComponents/TerminalAccessibleObjectPatcher.cs
@@ -1,5 +1,6 @@
 ﻿using HarmonyLib;
 using MoreShipUpgrades.Managers;
+using MoreShipUpgrades.Misc.Upgrades;
 using MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades;
 using Unity.Netcode;
 using UnityEngine;
@@ -13,7 +14,7 @@ namespace MoreShipUpgrades.Patches.TerminalComponents
         [HarmonyPatch(nameof(TerminalAccessibleObject.CallFunctionFromTerminal))]
         private static bool DestroyObject(ref TerminalAccessibleObject __instance, ref float ___codeAccessCooldownTimer, ref bool ___inCooldown)
         {
-            if (!UpgradeBus.instance.activeUpgrades[MalwareBroadcaster.UPGRADE_NAME] || __instance.gameObject.layer != LayerMask.NameToLayer("MapHazards")) { return true; }
+            if (!BaseUpgrade.GetActiveUpgrade(MalwareBroadcaster.UPGRADE_NAME) || __instance.gameObject.layer != LayerMask.NameToLayer("MapHazards")) { return true; }
             if (UpgradeBus.instance.cfg.DESTROY_TRAP.Value)
             {
                 MalwareBroadcaster.instance.ReqDestroyObjectServerRpc(new NetworkObjectReference(__instance.gameObject.transform.parent.gameObject.GetComponent<NetworkObject>()));

--- a/MoreShipUpgrades/Patches/Weather/StormyWeatherPatcher.cs
+++ b/MoreShipUpgrades/Patches/Weather/StormyWeatherPatcher.cs
@@ -1,6 +1,7 @@
 ﻿using HarmonyLib;
 using MoreShipUpgrades.Managers;
 using MoreShipUpgrades.Misc;
+using MoreShipUpgrades.Misc.Upgrades;
 using MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades;
 using UnityEngine;
 
@@ -25,7 +26,7 @@ namespace MoreShipUpgrades.Patches.Weather
         [HarmonyPatch(nameof(StormyWeather.Update))]
         static void InterceptSelectedObject(StormyWeather __instance, GrabbableObject ___targetingMetalObject)
         {
-            if (!UpgradeBus.instance.activeUpgrades[LightningRod.UPGRADE_NAME] || !LGUStore.instance.IsHost || !LGUStore.instance.IsServer) { return; }
+            if (!BaseUpgrade.GetActiveUpgrade(LightningRod.UPGRADE_NAME) || !LGUStore.instance.IsHost || !LGUStore.instance.IsServer) { return; }
             if (___targetingMetalObject == null)
             {
                 if (LightningRod.instance != null) // Lightning rod could be disabled so we wouldn't have an instance

--- a/MoreShipUpgrades/Patches/Weather/StormyWeatherPatcher.cs
+++ b/MoreShipUpgrades/Patches/Weather/StormyWeatherPatcher.cs
@@ -25,7 +25,7 @@ namespace MoreShipUpgrades.Patches.Weather
         [HarmonyPatch(nameof(StormyWeather.Update))]
         static void InterceptSelectedObject(StormyWeather __instance, GrabbableObject ___targetingMetalObject)
         {
-            if (!UpgradeBus.instance.lightningRod || !LGUStore.instance.IsHost || !LGUStore.instance.IsServer) { return; }
+            if (!UpgradeBus.instance.activeUpgrades[LightningRod.UPGRADE_NAME] || !LGUStore.instance.IsHost || !LGUStore.instance.IsServer) { return; }
             if (___targetingMetalObject == null)
             {
                 if (LightningRod.instance != null) // Lightning rod could be disabled so we wouldn't have an instance

--- a/MoreShipUpgrades/UpgradeComponents/Interfaces/IPlayerSync.cs
+++ b/MoreShipUpgrades/UpgradeComponents/Interfaces/IPlayerSync.cs
@@ -1,0 +1,6 @@
+﻿namespace MoreShipUpgrades.UpgradeComponents.Interfaces
+{
+    internal interface IPlayerSync
+    {
+    }
+}

--- a/MoreShipUpgrades/UpgradeComponents/Interfaces/IServerSync.cs
+++ b/MoreShipUpgrades/UpgradeComponents/Interfaces/IServerSync.cs
@@ -1,0 +1,6 @@
+﻿namespace MoreShipUpgrades.UpgradeComponents.Interfaces
+{
+    internal interface IServerSync
+    {
+    }
+}

--- a/MoreShipUpgrades/UpgradeComponents/Items/NightVisionGoggles.cs
+++ b/MoreShipUpgrades/UpgradeComponents/Items/NightVisionGoggles.cs
@@ -1,5 +1,6 @@
 ﻿using MoreShipUpgrades.Managers;
 using MoreShipUpgrades.Misc;
+using MoreShipUpgrades.Misc.Upgrades;
 using MoreShipUpgrades.UpgradeComponents.Interfaces;
 using MoreShipUpgrades.UpgradeComponents.TierUpgrades;
 using UnityEngine.Experimental.GlobalIllumination;
@@ -34,7 +35,7 @@ namespace MoreShipUpgrades.UpgradeComponents.Items
         {
             base.ItemActivate(used, buttonDown);
             if (!buttonDown) return;
-            if (UpgradeBus.instance.activeUpgrades[NightVision.UPGRADE_NAME])
+            if (BaseUpgrade.GetActiveUpgrade(NightVision.UPGRADE_NAME))
             {
                 HUDManager.Instance.chatText.text += "<color=#FF0000>Night vision is already active!</color>";
                 return;

--- a/MoreShipUpgrades/UpgradeComponents/Items/NightVisionGoggles.cs
+++ b/MoreShipUpgrades/UpgradeComponents/Items/NightVisionGoggles.cs
@@ -34,7 +34,7 @@ namespace MoreShipUpgrades.UpgradeComponents.Items
         {
             base.ItemActivate(used, buttonDown);
             if (!buttonDown) return;
-            if (UpgradeBus.instance.nightVision)
+            if (UpgradeBus.instance.activeUpgrades[NightVision.UPGRADE_NAME])
             {
                 HUDManager.Instance.chatText.text += "<color=#FF0000>Night vision is already active!</color>";
                 return;

--- a/MoreShipUpgrades/UpgradeComponents/OneTimeUpgrades/FastEncryption.cs
+++ b/MoreShipUpgrades/UpgradeComponents/OneTimeUpgrades/FastEncryption.cs
@@ -18,29 +18,20 @@ namespace MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades
             logger = new LGULogger(upgradeName);
             base.Start();
         }
-
         public override void Load()
         {
             base.Load();
-
-            UpgradeBus.instance.pager = true;
             instance = this;
         }
 
-        public override void Unwind()
-        {
-            base.Unwind();
-            UpgradeBus.instance.pager = false;
-        }
         public static int GetLimitOfCharactersTransmit(int defaultLimit, string message)
         {
-            logger.LogDebug("Being called");
-            if (!UpgradeBus.instance.pager) return defaultLimit;
+            if (!GetActiveUpgrade(UPGRADE_NAME)) return defaultLimit;
             return message.Length;
         }
         public static float GetMultiplierOnSignalTextTimer(float defaultMultiplier)
         {
-            if (!UpgradeBus.instance.pager) return defaultMultiplier;
+            if (!GetActiveUpgrade(UPGRADE_NAME)) return defaultMultiplier;
             return defaultMultiplier* TRANSMIT_MULTIPLIER;
         }
 

--- a/MoreShipUpgrades/UpgradeComponents/OneTimeUpgrades/LethalDeals.cs
+++ b/MoreShipUpgrades/UpgradeComponents/OneTimeUpgrades/LethalDeals.cs
@@ -15,22 +15,9 @@ namespace MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades
             upgradeName = UPGRADE_NAME;
             base.Start();
         }
-
-        public override void Load()
-        {
-            base.Load();
-
-            UpgradeBus.instance.lethalDeals = true;
-        }
-
-        public override void Unwind()
-        {
-            base.Unwind();
-            UpgradeBus.instance.lethalDeals = false;
-        }
         public static int GetLethalDealsGuaranteedItems(int amount)
         {
-            if (!UpgradeBus.instance.lethalDeals) return amount;
+            if (!GetActiveUpgrade(UPGRADE_NAME)) return amount;
             return GUARANTEED_ITEMS_AMOUNT;
         }
         public override string GetDisplayInfo(int price = -1)

--- a/MoreShipUpgrades/UpgradeComponents/OneTimeUpgrades/LightningRod.cs
+++ b/MoreShipUpgrades/UpgradeComponents/OneTimeUpgrades/LightningRod.cs
@@ -49,17 +49,6 @@ namespace MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades
             upgradeName = UPGRADE_NAME;
             base.Start();
         }
-        public override void Load()
-        {
-            base.Load();
-            UpgradeBus.instance.lightningRod = true;
-        }
-
-        public override void Unwind()
-        {
-            base.Unwind();
-            UpgradeBus.instance.lightningRod = false;
-        }
 
         public static void TryInterceptLightning(ref StormyWeather __instance, ref GrabbableObject ___targetingMetalObject)
         {

--- a/MoreShipUpgrades/UpgradeComponents/OneTimeUpgrades/LockSmith.cs
+++ b/MoreShipUpgrades/UpgradeComponents/OneTimeUpgrades/LockSmith.cs
@@ -45,24 +45,6 @@ namespace MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades
             pins = new List<GameObject> { pin1, pin2, pin3, pin4, pin5 };
         }
 
-        public override void Load()
-        {
-            base.Load();
-
-            UpgradeBus.instance.lockSmith = true;
-        }
-
-        public override void Register()
-        {
-            base.Register();
-        }
-        public override void Unwind()
-        {
-            base.Unwind();
-
-            UpgradeBus.instance.lockSmith = false;
-        }
-
         void Update()
         {
             if (!Keyboard.current[Key.Escape].wasPressedThisFrame) return;

--- a/MoreShipUpgrades/UpgradeComponents/OneTimeUpgrades/MalwareBroadcaster.cs
+++ b/MoreShipUpgrades/UpgradeComponents/OneTimeUpgrades/MalwareBroadcaster.cs
@@ -20,15 +20,7 @@ namespace MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades
         public override void Load()
         {
             base.Load();
-
-            UpgradeBus.instance.DestroyTraps = true;
             instance = this;
-        }
-
-        public override void Unwind()
-        {
-            base.Unwind();
-            UpgradeBus.instance.DestroyTraps = false;
         }
 
         [ServerRpc(RequireOwnership = false)]

--- a/MoreShipUpgrades/UpgradeComponents/OneTimeUpgrades/SickBeats.cs
+++ b/MoreShipUpgrades/UpgradeComponents/OneTimeUpgrades/SickBeats.cs
@@ -18,18 +18,6 @@ namespace MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades
             UpgradeBus.instance.BoomboxIcon = transform.GetChild(0).GetChild(0).gameObject;
         }
 
-        public override void Load()
-        {
-            base.Load();
-            UpgradeBus.instance.sickBeats = true;
-        }
-
-        public override void Unwind()
-        {
-            base.Unwind();
-            UpgradeBus.instance.sickBeats = false;
-        }
-
         public static void HandlePlayerEffects(PlayerControllerB player)
         {
             UpgradeBus.instance.BoomboxIcon.SetActive(UpgradeBus.instance.EffectsActive);
@@ -57,7 +45,7 @@ namespace MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades
 
         public static int CalculateDefense(int dmg)
         {
-            if (!UpgradeBus.instance.sickBeats || dmg < 0) return dmg; // < 0 check to not hinder healing
+            if (!GetActiveUpgrade(UPGRADE_NAME) || dmg < 0) return dmg; // < 0 check to not hinder healing
             return (int)(dmg * UpgradeBus.instance.incomingDamageCoefficient);
         }
 

--- a/MoreShipUpgrades/UpgradeComponents/OneTimeUpgrades/WalkieGPS.cs
+++ b/MoreShipUpgrades/UpgradeComponents/OneTimeUpgrades/WalkieGPS.cs
@@ -29,16 +29,7 @@ namespace MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades
         public override void Load()
         {
             base.Load();
-
-            UpgradeBus.instance.walkies = true;
             instance = this;
-        }
-
-        public override void Unwind()
-        {
-            base.Unwind();
-
-            UpgradeBus.instance.walkies = false;
         }
 
         public void Update()

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/AttributeUpgrades/BiggerLungs.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/AttributeUpgrades/BiggerLungs.cs
@@ -2,10 +2,11 @@
 using MoreShipUpgrades.Misc;
 using MoreShipUpgrades.Misc.Upgrades;
 using MoreShipUpgrades.UpgradeComponents.Interfaces;
+using System.Collections.Generic;
 
 namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades.AttributeUpgrades
 {
-    class BiggerLungs : GameAttributeTierUpgrade, IUpgradeWorldBuilding
+    class BiggerLungs : GameAttributeTierUpgrade, IUpgradeWorldBuilding, IPlayerSync
     {
         public const string UPGRADE_NAME = "Bigger Lungs";
         public static string PRICES_DEFAULT = "350,450,550";
@@ -22,33 +23,15 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades.AttributeUpgrades
             initialValue = UpgradeBus.instance.cfg.SPRINT_TIME_INCREASE_UNLOCK.Value;
             incrementalValue = UpgradeBus.instance.cfg.SPRINT_TIME_INCREMENT.Value;
         }
-
-        public override void Increment()
-        {
-            base.Increment();
-            UpgradeBus.instance.lungLevel++;
-        }
-
-        public override void Load()
-        {
-            LoadUpgradeAttribute(ref UpgradeBus.instance.biggerLungs, UpgradeBus.instance.lungLevel);
-            base.Load();
-        }
-
-        public override void Unwind()
-        {
-            UnloadUpgradeAttribute(ref UpgradeBus.instance.biggerLungs, ref UpgradeBus.instance.lungLevel);
-            base.Unwind();
-        }
         public static float ApplyPossibleIncreasedStaminaRegen(float regenValue)
         {
-            if (!UpgradeBus.instance.biggerLungs || UpgradeBus.instance.lungLevel < 0) return regenValue * UpgradeBus.instance.staminaDrainCoefficient;
+            if (!GetActiveUpgrade(UPGRADE_NAME) || GetUpgradeLevel(UPGRADE_NAME) < 0) return regenValue * UpgradeBus.instance.staminaDrainCoefficient;
             return regenValue * UpgradeBus.instance.cfg.BIGGER_LUNGS_STAMINA_REGEN_INCREASE.Value * UpgradeBus.instance.staminaDrainCoefficient;
         }
 
         public static float ApplyPossibleReducedJumpStaminaCost(float jumpCost)
         {
-            if (!UpgradeBus.instance.biggerLungs || UpgradeBus.instance.lungLevel < 1) return jumpCost;
+            if (!GetActiveUpgrade(UPGRADE_NAME) || GetUpgradeLevel(UPGRADE_NAME) < 1) return jumpCost;
             return jumpCost * UpgradeBus.instance.cfg.BIGGER_LUNGS_JUMP_STAMINA_COST_DECREASE.Value;
         }
         public string GetWorldBuildingText(bool shareStatus = false)

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/AttributeUpgrades/DoorsHydraulicsBattery.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/AttributeUpgrades/DoorsHydraulicsBattery.cs
@@ -6,7 +6,7 @@ using System;
 
 namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades.AttributeUpgrades
 {
-    internal class DoorsHydraulicsBattery : GameAttributeTierUpgrade
+    internal class DoorsHydraulicsBattery : GameAttributeTierUpgrade, IServerSync
     {
         public const string UPGRADE_NAME = "Shutter Batteries";
         public const string PRICES_DEFAULT = "200,300,400";
@@ -33,24 +33,6 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades.AttributeUpgrades
             changingAttribute = GameAttribute.SHIP_DOOR_BATTERY;
             initialValue = UpgradeBus.instance.cfg.DOOR_HYDRAULICS_BATTERY_INITIAL.Value;
             incrementalValue = UpgradeBus.instance.cfg.DOOR_HYDRAULICS_BATTERY_INCREMENTAL.Value;
-        }
-        public override void Load()
-        {
-            LoadUpgradeAttribute(ref UpgradeBus.instance.doorsHydraulicsBattery, UpgradeBus.instance.doorsHydraulicsBatteryLevel);
-            base.Load();
-        }
-
-
-        public override void Increment()
-        {
-            base.Increment();
-            UpgradeBus.instance.doorsHydraulicsBatteryLevel++;
-        }
-
-        public override void Unwind()
-        {
-            UnloadUpgradeAttribute(ref UpgradeBus.instance.doorsHydraulicsBattery, ref UpgradeBus.instance.doorsHydraulicsBatteryLevel);
-            base.Unwind();
         }
         public override string GetDisplayInfo(int initialPrice = -1, int maxLevels = -1, int[] incrementalPrices = null)
         {

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/AttributeUpgrades/QuantumDisruptor.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/AttributeUpgrades/QuantumDisruptor.cs
@@ -1,13 +1,14 @@
 ﻿using MoreShipUpgrades.Managers;
 using MoreShipUpgrades.Misc;
 using MoreShipUpgrades.Misc.Upgrades;
+using MoreShipUpgrades.UpgradeComponents.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades.AttributeUpgrades
 {
-    internal class QuantumDisruptor : GameAttributeTierUpgrade
+    internal class QuantumDisruptor : GameAttributeTierUpgrade, IServerSync
     {
         internal const string UPGRADE_NAME = "Quantum Disruptor";
         internal const string PRICES_DEFAULT = "1200,1500,1800";
@@ -19,22 +20,6 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades.AttributeUpgrades
             changingAttribute = GameAttribute.TIME_GLOBAL_TIME_MULTIPLIER;
             initialValue = UpgradeBus.instance.cfg.QUANTUM_DISRUPTOR_INITIAL_MULTIPLIER.Value;
             incrementalValue = UpgradeBus.instance.cfg.QUANTUM_DISRUPTOR_INCREMENTAL_MULTIPLIER.Value;
-        }
-        public override void Increment()
-        {
-            base.Increment();
-            UpgradeBus.instance.quantumDisruptorLevel++;
-        }
-        public override void Unwind()
-        {
-            UnloadUpgradeAttribute(ref UpgradeBus.instance.quantumDisruptor, ref UpgradeBus.instance.quantumDisruptorLevel);
-            base.Unwind();
-        }
-
-        public override void Load()
-        {
-            LoadUpgradeAttribute(ref UpgradeBus.instance.quantumDisruptor, UpgradeBus.instance.quantumDisruptorLevel);
-            base.Load();
         }
         public override string GetDisplayInfo(int initialPrice = -1, int maxLevels = -1, int[] incrementalPrices = null)
         {

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/AttributeUpgrades/RunningShoes.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/AttributeUpgrades/RunningShoes.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 
 namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades.AttributeUpgrades
 {
-    internal class RunningShoes : GameAttributeTierUpgrade, IUpgradeWorldBuilding
+    internal class RunningShoes : GameAttributeTierUpgrade, IUpgradeWorldBuilding, IPlayerSync
     {
         public const string UPGRADE_NAME = "Running Shoes";
         public static string PRICES_DEFAULT = "500,750,1000";
@@ -23,27 +23,9 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades.AttributeUpgrades
             initialValue = UpgradeBus.instance.cfg.MOVEMENT_SPEED_UNLOCK.Value;
             incrementalValue = UpgradeBus.instance.cfg.MOVEMENT_INCREMENT.Value;
         }
-
-        public override void Increment()
-        {
-            base.Increment();
-            UpgradeBus.instance.runningLevel++;
-        }
-
-        public override void Unwind()
-        {
-            UnloadUpgradeAttribute(ref UpgradeBus.instance.runningShoes, ref UpgradeBus.instance.runningLevel);
-            base.Unwind();
-        }
-
-        public override void Load()
-        {
-            LoadUpgradeAttribute(ref UpgradeBus.instance.runningShoes, UpgradeBus.instance.runningLevel);
-            base.Load();
-        }
         public static float ApplyPossibleReducedNoiseRange(float defaultValue)
         {
-            if (!(UpgradeBus.instance.runningShoes && UpgradeBus.instance.runningLevel == UpgradeBus.instance.cfg.RUNNING_SHOES_UPGRADE_PRICES.Value.Split(',').Length)) return defaultValue;
+            if (!(GetActiveUpgrade(UPGRADE_NAME) && GetUpgradeLevel(UPGRADE_NAME) == UpgradeBus.instance.cfg.RUNNING_SHOES_UPGRADE_PRICES.Value.Split(',').Length)) return defaultValue;
             return Mathf.Clamp(defaultValue - UpgradeBus.instance.cfg.NOISE_REDUCTION.Value, 0f, defaultValue);
         }
 

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/AttributeUpgrades/Stimpack.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/AttributeUpgrades/Stimpack.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 
 namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades.AttributeUpgrades
 {
-    internal class Stimpack : GameAttributeTierUpgrade, IUpgradeWorldBuilding
+    internal class Stimpack : GameAttributeTierUpgrade, IUpgradeWorldBuilding, IPlayerSync
     {
         public const string UPGRADE_NAME = "Stimpack";
         internal const string WORLD_BUILDING_TEXT = "\n\nAn experimental Company-offered 'health treatment' program advertised only on old, peeling Ship posters," +
@@ -46,20 +46,12 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades.AttributeUpgrades
         public override void Increment()
         {
             base.Increment();
-            UpgradeBus.instance.playerHealthLevel++;
             PlayerControllerB player = UpgradeBus.instance.GetLocalPlayer();
-            LGUStore.instance.PlayerHealthUpdateLevelServerRpc(player.playerSteamId, UpgradeBus.instance.playerHealthLevel);
-        }
-
-        public override void Load()
-        {
-            LoadUpgradeAttribute(ref UpgradeBus.instance.playerHealth, UpgradeBus.instance.playerHealthLevel);
-            base.Load();
+            LGUStore.instance.PlayerHealthUpdateLevelServerRpc(player.playerSteamId, GetUpgradeLevel(UPGRADE_NAME));
         }
 
         public override void Unwind()
         {
-            UnloadUpgradeAttribute(ref UpgradeBus.instance.playerHealth, ref UpgradeBus.instance.playerHealthLevel);
             base.Unwind();
             PlayerControllerB player = UpgradeBus.instance.GetLocalPlayer();
             LGUStore.instance.PlayerHealthUpdateLevelServerRpc(player.playerSteamId, -1);

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/AttributeUpgrades/StrongLegs.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/AttributeUpgrades/StrongLegs.cs
@@ -6,7 +6,7 @@ using MoreShipUpgrades.UpgradeComponents.Interfaces;
 
 namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades.AttributeUpgrades
 {
-    internal class StrongLegs : GameAttributeTierUpgrade, IUpgradeWorldBuilding
+    internal class StrongLegs : GameAttributeTierUpgrade, IUpgradeWorldBuilding, IPlayerSync
     {
         public const string UPGRADE_NAME = "Strong Legs";
         public static string PRICES_DEFAULT = "150,190,250";
@@ -23,26 +23,9 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades.AttributeUpgrades
             initialValue = UpgradeBus.instance.cfg.JUMP_FORCE_UNLOCK.Value;
             incrementalValue = UpgradeBus.instance.cfg.JUMP_FORCE_INCREMENT.Value;
         }
-
-        public override void Increment()
-        {
-            base.Increment();
-            UpgradeBus.instance.legLevel++;
-        }
-
-        public override void Unwind()
-        {
-            UnloadUpgradeAttribute(ref UpgradeBus.instance.strongLegs, ref UpgradeBus.instance.legLevel);
-            base.Unwind();
-        }
-        public override void Load()
-        {
-            LoadUpgradeAttribute(ref UpgradeBus.instance.strongLegs, UpgradeBus.instance.legLevel);
-            base.Load();
-        }
         public static int ReduceFallDamage(int defaultValue)
         {
-            if (!(UpgradeBus.instance.strongLegs && UpgradeBus.instance.legLevel == UpgradeBus.instance.cfg.STRONG_LEGS_UPGRADE_PRICES.Value.Split(',').Length)) return defaultValue;
+            if (!(GetActiveUpgrade(UPGRADE_NAME) && GetUpgradeLevel(UPGRADE_NAME) == UpgradeBus.instance.cfg.STRONG_LEGS_UPGRADE_PRICES.Value.Split(',').Length)) return defaultValue;
             return (int)(defaultValue * (1.0f - UpgradeBus.instance.cfg.STRONG_LEGS_REDUCE_FALL_DAMAGE_MULTIPLIER.Value));
         }
         public string GetWorldBuildingText(bool shareStatus = false)

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/BackMuscles.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/BackMuscles.cs
@@ -25,28 +25,25 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
 
         public override void Increment()
         {
-            UpgradeBus.instance.backLevel++;
+            base.Increment();
             UpdatePlayerWeight();
         }
 
         public override void Load()
         {
             base.Load();
-            UpgradeBus.instance.exoskeleton = true;
             UpdatePlayerWeight();
         }
         public override void Unwind()
         {
             base.Unwind();
-            UpgradeBus.instance.exoskeleton = false;
-            UpgradeBus.instance.backLevel = 0;
             UpdatePlayerWeight();
         }
 
         public static float DecreasePossibleWeight(float defaultWeight)
         {
-            if (!UpgradeBus.instance.exoskeleton) return defaultWeight;
-            return defaultWeight * (UpgradeBus.instance.cfg.CARRY_WEIGHT_REDUCTION.Value - UpgradeBus.instance.backLevel * UpgradeBus.instance.cfg.CARRY_WEIGHT_INCREMENT.Value);
+            if (!GetActiveUpgrade(UPGRADE_NAME)) return defaultWeight;
+            return defaultWeight * (UpgradeBus.instance.cfg.CARRY_WEIGHT_REDUCTION.Value - GetUpgradeLevel(UPGRADE_NAME) * UpgradeBus.instance.cfg.CARRY_WEIGHT_INCREMENT.Value);
         }
         public static void UpdatePlayerWeight()
         {

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/BargainConnections.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/BargainConnections.cs
@@ -14,29 +14,10 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
             upgradeName = UPGRADE_NAME;
             base.Start();
         }
-
-        public override void Increment()
-        {
-            UpgradeBus.instance.bargainConnectionsLevel++;
-        }
-
-        public override void Load()
-        {
-            base.Load();
-            UpgradeBus.instance.bargainConnections = true;
-        }
-
-        public override void Unwind()
-        {
-            base.Unwind();
-
-            UpgradeBus.instance.bargainConnectionsLevel = 0;
-            UpgradeBus.instance.bargainConnections = false;
-        }
         public static int GetBargainConnectionsAdditionalItems(int defaultAmountItems)
         {
-            if (!UpgradeBus.instance.bargainConnections) return defaultAmountItems;
-            return defaultAmountItems + UpgradeBus.instance.cfg.BARGAIN_CONNECTIONS_INITIAL_ITEM_AMOUNT.Value + (UpgradeBus.instance.bargainConnectionsLevel * UpgradeBus.instance.cfg.BARGAIN_CONNECTIONS_INCREMENTAL_ITEM_AMOUNT.Value);
+            if (!GetActiveUpgrade(UPGRADE_NAME)) return defaultAmountItems;
+            return defaultAmountItems + UpgradeBus.instance.cfg.BARGAIN_CONNECTIONS_INITIAL_ITEM_AMOUNT.Value + (UpgradeBus.instance.upgradeLevels[UPGRADE_NAME] * UpgradeBus.instance.cfg.BARGAIN_CONNECTIONS_INCREMENTAL_ITEM_AMOUNT.Value);
         }
         public override string GetDisplayInfo(int initialPrice = -1, int maxLevels = -1, int[] incrementalPrices = null)
         {

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/Beekeeper.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/Beekeeper.cs
@@ -21,29 +21,15 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
 
         public override void Increment()
         {
-            UpgradeBus.instance.beeLevel++;
-            if (UpgradeBus.instance.beeLevel == UpgradeBus.instance.cfg.BEEKEEPER_UPGRADE_PRICES.Value.Split(',').Length)
+            base.Increment();
+            if (GetUpgradeLevel(UPGRADE_NAME) == UpgradeBus.instance.cfg.BEEKEEPER_UPGRADE_PRICES.Value.Split(',').Length)
                 LGUStore.instance.ToggleIncreaseHivePriceServerRpc();
-        }
-
-        public override void Load()
-        {
-            base.Load();
-            UpgradeBus.instance.beekeeper = true;
-        }
-
-        public override void Unwind()
-        {
-            base.Unwind();
-
-            UpgradeBus.instance.beeLevel = 0;
-            UpgradeBus.instance.beekeeper = false;
         }
 
         public static int CalculateBeeDamage(int damageNumber)
         {
-            if (!UpgradeBus.instance.beekeeper) return damageNumber;
-            return Mathf.Clamp((int)(damageNumber * (UpgradeBus.instance.cfg.BEEKEEPER_DAMAGE_MULTIPLIER.Value - UpgradeBus.instance.beeLevel * UpgradeBus.instance.cfg.BEEKEEPER_DAMAGE_MULTIPLIER_INCREMENT.Value)), 0, damageNumber);
+            if (!GetActiveUpgrade(UPGRADE_NAME)) return damageNumber;
+            return Mathf.Clamp((int)(damageNumber * (UpgradeBus.instance.cfg.BEEKEEPER_DAMAGE_MULTIPLIER.Value - GetUpgradeLevel(UPGRADE_NAME) * UpgradeBus.instance.cfg.BEEKEEPER_DAMAGE_MULTIPLIER_INCREMENT.Value)), 0, damageNumber);
         }
 
         public static int GetHiveScrapValue(int originalValue)

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/BetterScanner.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/BetterScanner.cs
@@ -23,28 +23,9 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
             base.Start();
         }
 
-        public override void Increment()
-        {
-            UpgradeBus.instance.scanLevel++;
-        }
-
-        public override void Load()
-        {
-            base.Load();
-
-            UpgradeBus.instance.scannerUpgrade = true;
-        }
-        public override void Unwind()
-        {
-            base.Unwind();
-
-            UpgradeBus.instance.scannerUpgrade = false;
-            UpgradeBus.instance.scanLevel = 0;
-        }
-
         public static void AddScannerNodeToValve(ref SteamValveHazard steamValveHazard)
         {
-            if (!UpgradeBus.instance.scannerUpgrade) return;
+            if (!GetActiveUpgrade(UPGRADE_NAME)) return;
             logger.LogDebug("Inserting a Scan Node on a broken steam valve...");
             LGUScanNodeProperties.AddGeneralScanNode(objectToAddScanNode: steamValveHazard.gameObject, header: "Bursted Steam Valve", subText: "Fix it to get rid of the steam", minRange: 3);
         }

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/Discombobulator.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/Discombobulator.cs
@@ -33,21 +33,7 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
         public override void Load()
         {
             base.Load();
-            UpgradeBus.instance.terminalFlash = true;
             instance = this;
-        }
-
-        public override void Increment()
-        {
-            UpgradeBus.instance.discoLevel++;
-        }
-
-        public override void Unwind()
-        {
-            base.Unwind();
-
-            UpgradeBus.instance.terminalFlash = false;
-            UpgradeBus.instance.discoLevel = 0;
         }
 
         [ServerRpc(RequireOwnership = false)]
@@ -73,16 +59,16 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
                 EnemyAI enemy = component.mainScript;
                 if (CanDealDamage())
                 {
-                    int forceValue = UpgradeBus.instance.cfg.DISCOMBOBULATOR_INITIAL_DAMAGE.Value + UpgradeBus.instance.cfg.DISCOMBOBULATOR_DAMAGE_INCREASE.Value * (UpgradeBus.instance.discoLevel - UpgradeBus.instance.cfg.DISCOMBOBULATOR_DAMAGE_LEVEL.Value);
+                    int forceValue = UpgradeBus.instance.cfg.DISCOMBOBULATOR_INITIAL_DAMAGE.Value + UpgradeBus.instance.cfg.DISCOMBOBULATOR_DAMAGE_INCREASE.Value * (GetUpgradeLevel(UPGRADE_NAME) - UpgradeBus.instance.cfg.DISCOMBOBULATOR_DAMAGE_LEVEL.Value);
                     enemy.HitEnemy(forceValue);
                 }
-                if (!enemy.isEnemyDead) enemy.SetEnemyStunned(true, UpgradeBus.instance.cfg.DISCOMBOBULATOR_STUN_DURATION.Value + UpgradeBus.instance.cfg.DISCOMBOBULATOR_INCREMENT.Value * UpgradeBus.instance.discoLevel, null);
+                if (!enemy.isEnemyDead) enemy.SetEnemyStunned(true, UpgradeBus.instance.cfg.DISCOMBOBULATOR_STUN_DURATION.Value + UpgradeBus.instance.cfg.DISCOMBOBULATOR_INCREMENT.Value * GetUpgradeLevel(UPGRADE_NAME), null);
             }
         }
 
         private bool CanDealDamage()
         {
-            return UpgradeBus.instance.cfg.DISCOMBOBULATOR_DAMAGE_LEVEL.Value > 0 && UpgradeBus.instance.discoLevel + 1 >= UpgradeBus.instance.cfg.DISCOMBOBULATOR_DAMAGE_LEVEL.Value;
+            return UpgradeBus.instance.cfg.DISCOMBOBULATOR_DAMAGE_LEVEL.Value > 0 && GetUpgradeLevel(UPGRADE_NAME) + 1 >= UpgradeBus.instance.cfg.DISCOMBOBULATOR_DAMAGE_LEVEL.Value;
         }
         private IEnumerator ResetRange(Terminal terminal)
         {

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/Hunter.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/Hunter.cs
@@ -57,25 +57,6 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
             base.Start();
         }
 
-        public override void Increment()
-        {
-            UpgradeBus.instance.huntLevel++;
-        }
-
-        public override void Load()
-        {
-            base.Load();
-
-            UpgradeBus.instance.hunter = true;
-        }
-        public override void Unwind()
-        {
-            base.Unwind();
-
-            UpgradeBus.instance.hunter = false;
-            UpgradeBus.instance.huntLevel = 0;
-        }
-
         public static string GetHunterInfo(int level, int price)
         {
             string enems;

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/MarketInfluence.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/MarketInfluence.cs
@@ -15,29 +15,10 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
             upgradeName = UPGRADE_NAME;
             base.Start();
         }
-
-        public override void Increment()
-        {
-            UpgradeBus.instance.marketInfluenceLevel++;
-        }
-
-        public override void Load()
-        {
-            base.Load();
-            UpgradeBus.instance.marketInfluence = true;
-        }
-
-        public override void Unwind()
-        {
-            base.Unwind();
-
-            UpgradeBus.instance.marketInfluenceLevel = 0;
-            UpgradeBus.instance.marketInfluence = false;
-        }
         public static int GetGuaranteedPercentageSale(int defaultPercentage, int maxValue)
         {
-            if (!UpgradeBus.instance.marketInfluence) return defaultPercentage;
-            return Mathf.Clamp(defaultPercentage + UpgradeBus.instance.cfg.MARKET_INFLUENCE_INITIAL_PERCENTAGE.Value + UpgradeBus.instance.marketInfluenceLevel * UpgradeBus.instance.cfg.MARKET_INFLUENCE_INCREMENTAL_PERCENTAGE.Value, 0, maxValue);
+            if (!GetActiveUpgrade(UPGRADE_NAME)) return defaultPercentage;
+            return Mathf.Clamp(defaultPercentage + UpgradeBus.instance.cfg.MARKET_INFLUENCE_INITIAL_PERCENTAGE.Value + GetUpgradeLevel(UPGRADE_NAME) * UpgradeBus.instance.cfg.MARKET_INFLUENCE_INCREMENTAL_PERCENTAGE.Value, 0, maxValue);
         }
         public override string GetDisplayInfo(int initialPrice = -1, int maxLevels = -1, int[] incrementalPrices = null)
         {

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/NightVision.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/NightVision.cs
@@ -55,11 +55,11 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
                 Toggle();
             }
 
-            float maxBattery = UpgradeBus.instance.cfg.NIGHT_BATTERY_MAX.Value + UpgradeBus.instance.nightVisionLevel * UpgradeBus.instance.cfg.NIGHT_VIS_BATTERY_INCREMENT.Value;
+            float maxBattery = UpgradeBus.instance.cfg.NIGHT_BATTERY_MAX.Value + GetUpgradeLevel(UPGRADE_NAME) * UpgradeBus.instance.cfg.NIGHT_VIS_BATTERY_INCREMENT.Value;
 
             if (UpgradeBus.instance.nightVisionActive)
             {
-                nightBattery -= Time.deltaTime * (UpgradeBus.instance.cfg.NIGHT_VIS_DRAIN_SPEED.Value - UpgradeBus.instance.nightVisionLevel * UpgradeBus.instance.cfg.NIGHT_VIS_DRAIN_INCREMENT.Value);
+                nightBattery -= Time.deltaTime * (UpgradeBus.instance.cfg.NIGHT_VIS_DRAIN_SPEED.Value - GetUpgradeLevel(UPGRADE_NAME) * UpgradeBus.instance.cfg.NIGHT_VIS_DRAIN_INCREMENT.Value);
                 nightBattery = Mathf.Clamp(nightBattery, 0f, maxBattery);
                 batteryBar.parent.gameObject.SetActive(true);
 
@@ -70,7 +70,7 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
             }
             else if (!batteryExhaustion)
             {
-                nightBattery += Time.deltaTime * (UpgradeBus.instance.cfg.NIGHT_VIS_REGEN_SPEED.Value + UpgradeBus.instance.nightVisionLevel * UpgradeBus.instance.cfg.NIGHT_VIS_REGEN_INCREMENT.Value);
+                nightBattery += Time.deltaTime * (UpgradeBus.instance.cfg.NIGHT_VIS_REGEN_SPEED.Value + GetUpgradeLevel(UPGRADE_NAME) * UpgradeBus.instance.cfg.NIGHT_VIS_REGEN_INCREMENT.Value);
                 nightBattery = Mathf.Clamp(nightBattery, 0f, maxBattery);
 
                 if (nightBattery >= maxBattery)
@@ -124,8 +124,8 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
             UpgradeBus.instance.nightVisIntensity = client.nightVision.intensity;
 
             client.nightVision.color = UpgradeBus.instance.cfg.NIGHT_VIS_COLOR.Value;
-            client.nightVision.range = UpgradeBus.instance.cfg.NIGHT_VIS_RANGE.Value + UpgradeBus.instance.nightVisionLevel * UpgradeBus.instance.cfg.NIGHT_VIS_RANGE_INCREMENT.Value;
-            client.nightVision.intensity = UpgradeBus.instance.cfg.NIGHT_VIS_INTENSITY.Value + UpgradeBus.instance.nightVisionLevel * UpgradeBus.instance.cfg.NIGHT_VIS_INTENSITY_INCREMENT.Value;
+            client.nightVision.range = UpgradeBus.instance.cfg.NIGHT_VIS_RANGE.Value + GetUpgradeLevel(UPGRADE_NAME) * UpgradeBus.instance.cfg.NIGHT_VIS_RANGE_INCREMENT.Value;
+            client.nightVision.intensity = UpgradeBus.instance.cfg.NIGHT_VIS_INTENSITY.Value + GetUpgradeLevel(UPGRADE_NAME) * UpgradeBus.instance.cfg.NIGHT_VIS_INTENSITY_INCREMENT.Value;
             nightBattery -= UpgradeBus.instance.cfg.NIGHT_VIS_STARTUP.Value; // 0.1f
         }
 
@@ -137,20 +137,18 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
 
         public override void Increment()
         {
-            UpgradeBus.instance.nightVisionLevel++;
+            base.Increment();
             LGUStore.instance.UpdateLGUSaveServerRpc(GameNetworkManager.Instance.localPlayerController.playerSteamId, JsonConvert.SerializeObject(new SaveInfo()));
         }
 
         public override void Load()
         {
+            base.Load();
             EnableOnClient(false);
         }
         public override void Unwind()
         {
             base.Unwind();
-
-            UpgradeBus.instance.nightVision = false;
-            UpgradeBus.instance.nightVisionLevel = 0;
             DisableOnClient();
         }
 
@@ -179,7 +177,7 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
         {
             if (client == null) { client = GameNetworkManager.Instance.localPlayerController; }
             transform.GetChild(0).gameObject.SetActive(true);
-            UpgradeBus.instance.nightVision = true;
+            UpgradeBus.instance.activeUpgrades[UPGRADE_NAME] = true;
             if (save) { LGUStore.instance.UpdateLGUSaveServerRpc(client.playerSteamId, JsonConvert.SerializeObject(new SaveInfo())); }
             HUDManager.Instance.chatText.text += $"\n<color=#FF0000>Press {UpgradeBus.instance.cfg.TOGGLE_NIGHT_VISION_KEY.Value} to toggle Night Vision!!!</color>";
         }
@@ -192,7 +190,7 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
             client.nightVision.intensity = UpgradeBus.instance.nightVisIntensity;
 
             transform.GetChild(0).gameObject.SetActive(false);
-            UpgradeBus.instance.nightVision = false;
+            UpgradeBus.instance.activeUpgrades[UPGRADE_NAME] = false;
             LGUStore.instance.UpdateLGUSaveServerRpc(client.playerSteamId, JsonConvert.SerializeObject(new SaveInfo()));
             client = null;
         }

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/ProteinPowder.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/ProteinPowder.cs
@@ -42,36 +42,17 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
             base.Start();
         }
 
-        public override void Increment()
-        {
-            UpgradeBus.instance.proteinLevel++;
-        }
-
-        public override void Load()
-        {
-            base.Load();
-
-            UpgradeBus.instance.proteinPowder = true;
-        }
-        public override void Unwind()
-        {
-            base.Unwind();
-
-            UpgradeBus.instance.proteinLevel = 0;
-            UpgradeBus.instance.proteinPowder = false;
-        }
-
         public static int GetShovelHitForce(int force)
         {
             // Truly one of THE ternary operators
-            return (UpgradeBus.instance.proteinPowder ? TryToCritEnemy() ? CRIT_DAMAGE_VALUE : UpgradeBus.instance.cfg.PROTEIN_INCREMENT.Value * UpgradeBus.instance.proteinLevel + UpgradeBus.instance.cfg.PROTEIN_UNLOCK_FORCE.Value + force : force) + UpgradeBus.instance.damageBoost;
+            return (GetActiveUpgrade(UPGRADE_NAME) ? TryToCritEnemy() ? CRIT_DAMAGE_VALUE : UpgradeBus.instance.cfg.PROTEIN_INCREMENT.Value * GetUpgradeLevel(UPGRADE_NAME) + UpgradeBus.instance.cfg.PROTEIN_UNLOCK_FORCE.Value + force : force) + UpgradeBus.instance.damageBoost;
             // .damageBoost is tied to boombox upgrade, it will always be 0 when inactive or x when active.
         }
 
         private static bool TryToCritEnemy()
         {
             int maximumLevel = UpgradeBus.instance.cfg.PROTEIN_UPGRADE_PRICES.Value.Split(',').Length;
-            int currentLevel = UpgradeBus.instance.proteinLevel;
+            int currentLevel = GetUpgradeLevel(UPGRADE_NAME);
 
             if (currentLevel != maximumLevel) return false;
 


### PR DESCRIPTION
This way, each upgrade implemented does not need to know what is the variable they are checking for, they will just ask the dictionary "Hey, is this upgrade currently active or not?" or "Hey, what is my current level?".
This allows streamlining BaseUpgrade and TierUpgrade's implementation to take care of levels and active and derived classes will only need to worry about the logic they wish to implement. We no longer need ``conditions`` and ``levelConditions`` dictionaries as we will just directly extract the values from the dictionaries.
For older saves who did not contain the dictionaries at the time, we will extract the previous variables values and insert them into the respective dictionaries.