### PR TITLE
Fixing Sick Beats being disabled preventing enemy damage

### DIFF
--- a/MoreShipUpgrades/Misc/CommandParser.cs
+++ b/MoreShipUpgrades/Misc/CommandParser.cs
@@ -422,7 +422,7 @@ namespace MoreShipUpgrades.Misc
         }
         static TerminalNode TryGetContract(string possibleMoon, ref Terminal terminal)
         {
-            if (contracts.Count == 0) return DisplayTerminalMessage("Not possible to provide a contracts due to configuration having it disabled.");
+            if (contracts.Count == 0) return DisplayTerminalMessage("Not possible to provide a contracts due to configuration having it disabled.\n\n");
             if (possibleMoon != "") return TryGetMoonContract(possibleMoon, ref terminal);
             string txt = null;
             if(ContractManager.Instance.contractLevel != "None")

--- a/MoreShipUpgrades/Patches/Items/ShovelPatcher.cs
+++ b/MoreShipUpgrades/Patches/Items/ShovelPatcher.cs
@@ -1,9 +1,11 @@
 ﻿using HarmonyLib;
 using MoreShipUpgrades.Misc;
+using MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades;
 using MoreShipUpgrades.UpgradeComponents.TierUpgrades;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Reflection.Emit;
 
 namespace MoreShipUpgrades.Patches.Items
 {
@@ -15,11 +17,13 @@ namespace MoreShipUpgrades.Patches.Items
         public static IEnumerable<CodeInstruction> HitShovelTranspiler(IEnumerable<CodeInstruction> instructions)
         {
             MethodInfo proteinHitFoce = typeof(ProteinPowder).GetMethod(nameof(ProteinPowder.GetShovelHitForce));
+            MethodInfo sickBeatsForce = typeof(SickBeats).GetMethod(nameof(SickBeats.GetShovelHitForce));
             FieldInfo shovelHitForce = typeof(Shovel).GetField(nameof(Shovel.shovelHitForce));
 
             List<CodeInstruction> codes = new List<CodeInstruction>(instructions);
             int index = 0;
             index = Tools.FindField(index, ref codes, findField: shovelHitForce, addCode: proteinHitFoce, errorMessage: "Couldn't find shovel hit force field");
+            index = Tools.FindMethod(index, ref codes, findMethod: proteinHitFoce, addCode: sickBeatsForce, errorMessage: "Couldn't find our Protein Powder shovel hit force method");
             return codes.AsEnumerable();
         }
     }

--- a/MoreShipUpgrades/UpgradeComponents/OneTimeUpgrades/SickBeats.cs
+++ b/MoreShipUpgrades/UpgradeComponents/OneTimeUpgrades/SickBeats.cs
@@ -63,7 +63,7 @@ namespace MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades
             return regenValue * Instance.staminaDrainCoefficient;
         }
 
-        public static float GetShovelHitForce(int force)
+        public static int GetShovelHitForce(int force)
         {
             if (!UpgradeBus.Instance.PluginConfiguration.BEATS_ENABLED.Value) return force;
             if (!GetActiveUpgrade(UPGRADE_NAME)) return force;

--- a/MoreShipUpgrades/UpgradeComponents/OneTimeUpgrades/SickBeats.cs
+++ b/MoreShipUpgrades/UpgradeComponents/OneTimeUpgrades/SickBeats.cs
@@ -63,6 +63,13 @@ namespace MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades
             return regenValue * Instance.staminaDrainCoefficient;
         }
 
+        public static float GetShovelHitForce(int force)
+        {
+            if (!UpgradeBus.Instance.PluginConfiguration.BEATS_ENABLED.Value) return force;
+            if (!GetActiveUpgrade(UPGRADE_NAME)) return force;
+            return force + Instance.damageBoost;
+        }
+
         public static int CalculateDefense(int dmg)
         {
             if (!GetActiveUpgrade(UPGRADE_NAME) || dmg < 0) return dmg; // < 0 check to not hinder healing

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/ProteinPowder.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/ProteinPowder.cs
@@ -45,9 +45,10 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
 
         public static int GetShovelHitForce(int force)
         {
-            // Truly one of THE ternary operators
-            return (GetActiveUpgrade(UPGRADE_NAME) ? TryToCritEnemy() ? CRIT_DAMAGE_VALUE : UpgradeBus.Instance.PluginConfiguration.PROTEIN_INCREMENT.Value * GetUpgradeLevel(UPGRADE_NAME) + UpgradeBus.Instance.PluginConfiguration.PROTEIN_UNLOCK_FORCE.Value + force : force) + (GetActiveUpgrade(SickBeats.UPGRADE_NAME) ? SickBeats.Instance.damageBoost : 0);
-            // .damageBoost is tied to boombox upgrade, it will always be 0 when inactive or x when active.
+            if (!UpgradeBus.Instance.PluginConfiguration.PROTEIN_ENABLED.Value) return force;
+            if (!GetActiveUpgrade(UPGRADE_NAME)) return force;
+            int proteinForce = TryToCritEnemy() ? CRIT_DAMAGE_VALUE : UpgradeBus.Instance.PluginConfiguration.PROTEIN_UNLOCK_FORCE.Value + UpgradeBus.Instance.PluginConfiguration.PROTEIN_INCREMENT.Value * GetUpgradeLevel(UPGRADE_NAME);
+            return force + proteinForce;
         }
 
         private static bool TryToCritEnemy()

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/ProteinPowder.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/ProteinPowder.cs
@@ -46,7 +46,7 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
         public static int GetShovelHitForce(int force)
         {
             // Truly one of THE ternary operators
-            return (GetActiveUpgrade(UPGRADE_NAME) ? TryToCritEnemy() ? CRIT_DAMAGE_VALUE : UpgradeBus.Instance.PluginConfiguration.PROTEIN_INCREMENT.Value * GetUpgradeLevel(UPGRADE_NAME) + UpgradeBus.Instance.PluginConfiguration.PROTEIN_UNLOCK_FORCE.Value + force : force) + SickBeats.Instance.damageBoost;
+            return (GetActiveUpgrade(UPGRADE_NAME) ? TryToCritEnemy() ? CRIT_DAMAGE_VALUE : UpgradeBus.Instance.PluginConfiguration.PROTEIN_INCREMENT.Value * GetUpgradeLevel(UPGRADE_NAME) + UpgradeBus.Instance.PluginConfiguration.PROTEIN_UNLOCK_FORCE.Value + force : force) + (GetActiveUpgrade(SickBeats.UPGRADE_NAME) ? SickBeats.Instance.damageBoost : 0);
             // .damageBoost is tied to boombox upgrade, it will always be 0 when inactive or x when active.
         }
 


### PR DESCRIPTION
Split the ``GetShovelHitForce()`` implementation between ProteinPowder and SickBeats for easier logic handling and to distribute responsibilities to respective classes.