### PR TITLE
Fixes on sample spawning and contract during reboot

### DIFF
--- a/MoreShipUpgrades/Patches/Enemies/EnemyAIPatcher.cs
+++ b/MoreShipUpgrades/Patches/Enemies/EnemyAIPatcher.cs
@@ -31,7 +31,7 @@ namespace MoreShipUpgrades.Patches.Enemies
                 return;
             }
             logger.LogDebug($"Spawning sample for {name}");
-            SpawnItemManager.Instance.SpawnSample(name.ToLower(), __instance.transform.position);
+            if (__instance.IsServer || __instance.IsHost) SpawnItemManager.Instance.SpawnSample(name.ToLower(), __instance.transform.position);
         }
     }
 

--- a/MoreShipUpgrades/UpgradeComponents/Contracts/DefusalContract.cs
+++ b/MoreShipUpgrades/UpgradeComponents/Contracts/DefusalContract.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using MoreShipUpgrades.UpgradeComponents.Items.Contracts.BombDefusal;
 
 namespace MoreShipUpgrades.UpgradeComponents.Contracts
 {
@@ -9,7 +7,12 @@ namespace MoreShipUpgrades.UpgradeComponents.Contracts
         public override void Start()
         {
             contractType = "defusal";
-            base.Start();
+            if (GetComponent<PhysicsProp>().isInShipRoom || GetComponent<PhysicsProp>().isInElevator) // Already in the ship, don't make it disappear
+            {
+                BombDefusalScript bomb = GetComponent<BombDefusalScript>();
+                bomb.MakeBombGrabbable();
+            }
+            else base.Start();
         }
     }
 }

--- a/MoreShipUpgrades/UpgradeComponents/Contracts/ExtractionContract.cs
+++ b/MoreShipUpgrades/UpgradeComponents/Contracts/ExtractionContract.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using MoreShipUpgrades.UpgradeComponents.Items.Contracts.BombDefusal;
+using MoreShipUpgrades.UpgradeComponents.Items.Contracts.Extraction;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -9,7 +11,12 @@ namespace MoreShipUpgrades.UpgradeComponents.Contracts
         public override void Start()
         {
             contractType = "extraction";
-            base.Start();
+            if (GetComponent<PhysicsProp>().isInShipRoom || GetComponent<PhysicsProp>().isInElevator) // Already in the ship, don't make it disappear
+            {
+                ExtractPlayerScript scavenger = GetComponent<ExtractPlayerScript>();
+                scavenger.MakeScavengerGrabbable();
+            }
+            else base.Start();
         }
     }
 }

--- a/MoreShipUpgrades/UpgradeComponents/Items/Contracts/BombDefusal/BombDefusalScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/Items/Contracts/BombDefusal/BombDefusalScript.cs
@@ -44,38 +44,15 @@ namespace MoreShipUpgrades.UpgradeComponents.Items.Contracts.BombDefusal
 
         void Start()
         {
+            InitializeFields();
             GetComponent<ScrapValueSyncer>().SetScrapValue(UpgradeBus.Instance.PluginConfiguration.CONTRACT_DEFUSE_REWARD.Value);
-            grabBox = GetComponent<BoxCollider>();
 
-            Transform intactWires = transform.GetChild(0).GetChild(0);
-            wires["blue"] = intactWires.GetChild(0).gameObject;
-            wires["green"] = intactWires.GetChild(1).gameObject;
-            wires["red"] = intactWires.GetChild(2).gameObject;
-
-            Transform destroyedWires = transform.GetChild(0).GetChild(1);
-            cutWires["blue"] = destroyedWires.GetChild(0).gameObject;
-            cutWires["green"] = destroyedWires.GetChild(1).gameObject;
-            cutWires["red"] = destroyedWires.GetChild(2).gameObject;
-
-            audio = GetComponent<AudioSource>();
             audio.clip = tick;
             audio.Play();
-
-            trigs["red"] = transform.GetChild(0).GetChild(4).GetComponent<InteractTrigger>();
-            trigs["blue"] = transform.GetChild(0).GetChild(5).GetComponent<InteractTrigger>();
-            trigs["green"] = transform.GetChild(0).GetChild(6).GetComponent<InteractTrigger>();
 
             trigs["red"].onInteract.AddListener(CutRed);
             trigs["blue"].onInteract.AddListener(CutBlue);
             trigs["green"].onInteract.AddListener(CutGreen);
-
-            serialNumberMesh = transform.GetChild(0).GetChild(2).GetComponent<TextMesh>();
-            if (serialNumberMesh == null)
-            {
-                logger.LogError("FAILED TO GET SERIAL NUMBER MESH");
-            }
-
-            countdown = transform.GetChild(0).GetChild(3).GetComponent<TextMesh>();
 
             if (IsHost || IsServer)
             {
@@ -194,6 +171,48 @@ namespace MoreShipUpgrades.UpgradeComponents.Items.Contracts.BombDefusal
             ContractManager.Instance.bombOrder = newOrder.Split(",").ToList();
             serialNumberMesh.text = serial;
         }
+        void InitializeFields()
+        {
+            grabBox = GetComponent<BoxCollider>();
+            audio = GetComponent<AudioSource>();
+            Transform intactWires = transform.GetChild(0).GetChild(0);
+            wires["blue"] = intactWires.GetChild(0).gameObject;
+            wires["green"] = intactWires.GetChild(1).gameObject;
+            wires["red"] = intactWires.GetChild(2).gameObject;
 
+            Transform destroyedWires = transform.GetChild(0).GetChild(1);
+            cutWires["blue"] = destroyedWires.GetChild(0).gameObject;
+            cutWires["green"] = destroyedWires.GetChild(1).gameObject;
+            cutWires["red"] = destroyedWires.GetChild(2).gameObject;
+
+            trigs["red"] = transform.GetChild(0).GetChild(4).GetComponent<InteractTrigger>();
+            trigs["blue"] = transform.GetChild(0).GetChild(5).GetComponent<InteractTrigger>();
+            trigs["green"] = transform.GetChild(0).GetChild(6).GetComponent<InteractTrigger>();
+
+            serialNumberMesh = transform.GetChild(0).GetChild(2).GetComponent<TextMesh>();
+            if (serialNumberMesh == null)
+            {
+                logger.LogError("FAILED TO GET SERIAL NUMBER MESH");
+            }
+
+            countdown = transform.GetChild(0).GetChild(3).GetComponent<TextMesh>();
+        }
+
+        internal void MakeBombGrabbable()
+        {
+            InitializeFields();
+            armed = false;
+            grabBox.enabled = true;
+            audio.Stop();
+            enabled = false;
+            foreach (string wire in wires.Keys)
+            {
+                wires[wire].SetActive(false);
+                cutWires[wire].SetActive(true);
+                trigs[wire].enabled = false;
+                trigs[wire].GetComponent<BoxCollider>().enabled = false;
+            }
+            GetComponent<PhysicsProp>().enabled = true;
+        }
     }
 }

--- a/MoreShipUpgrades/UpgradeComponents/Items/Contracts/Extraction/ExtractPlayerScript.cs
+++ b/MoreShipUpgrades/UpgradeComponents/Items/Contracts/Extraction/ExtractPlayerScript.cs
@@ -115,5 +115,16 @@ namespace MoreShipUpgrades.UpgradeComponents.Items.Contracts.Extraction
             audio.PlayOneShot(clipDict[soundType][index], UpgradeBus.Instance.PluginConfiguration.SCAV_VOLUME.Value);
             RoundManager.Instance.PlayAudibleNoise(transform.position, 30f, 0.9f, 0, prop.isInShipRoom, 5);
         }
+
+        internal void MakeScavengerGrabbable()
+        {
+            trig = GetComponentInChildren<InteractTrigger>();
+            trig.GetComponent<BoxCollider>().enabled = false;
+            anim = GetComponent<Animator>();
+            anim.SetTrigger("heal");
+            hurtState = false;
+            StartCoroutine(WaitForHealAnim());
+            GetComponent<PhysicsProp>().enabled = true;
+        }
     }
 }


### PR DESCRIPTION
- Possibly fixed samples spawning more than once, leading to the other being not interactable.
- Fixed bomb and scavenger item disappearing after a save reboot due its initial state initialization ignoring if it was stored in the ship.