### PR TITLE
Fixes for items, Sick Beats and Stimpack

### DIFF
--- a/MoreShipUpgrades/Managers/LGUStore.cs
+++ b/MoreShipUpgrades/Managers/LGUStore.cs
@@ -278,7 +278,7 @@ namespace MoreShipUpgrades.Managers
 
             ContractManager.Instance.contractLevel = SaveInfo.contractLevel;
             ContractManager.Instance.contractType = SaveInfo.contractType;
-            if (UpgradeBus.Instance.PluginConfiguration.PLAYER_HEALTH_ENABLED.Value) Stimpack.Instance.playerHealthLevels = SaveInfo.healthLevels;
+            
             UpgradeBus.Instance.wearingHelmet = SaveInfo.wearingHelmet;
 
             UpgradeBus.Instance.SaleData = SaveInfo.SaleData;
@@ -516,7 +516,6 @@ namespace MoreShipUpgrades.Managers
         public string contractType = ContractManager.Instance.contractType;
         public string contractLevel = ContractManager.Instance.contractLevel;
         public Dictionary<string, float> SaleData = UpgradeBus.Instance.SaleData;
-        public Dictionary<ulong, int> healthLevels = Stimpack.Instance?.playerHealthLevels;
         public bool wearingHelmet = UpgradeBus.Instance.wearingHelmet;
     }
 

--- a/MoreShipUpgrades/Managers/LGUStore.cs
+++ b/MoreShipUpgrades/Managers/LGUStore.cs
@@ -278,6 +278,7 @@ namespace MoreShipUpgrades.Managers
 
             ContractManager.Instance.contractLevel = SaveInfo.contractLevel;
             ContractManager.Instance.contractType = SaveInfo.contractType;
+            if (UpgradeBus.Instance.PluginConfiguration.PLAYER_HEALTH_ENABLED.Value) Stimpack.Instance.playerHealthLevels = SaveInfo.healthLevels;
             UpgradeBus.Instance.wearingHelmet = SaveInfo.wearingHelmet;
 
             UpgradeBus.Instance.SaleData = SaveInfo.SaleData;
@@ -515,6 +516,7 @@ namespace MoreShipUpgrades.Managers
         public string contractType = ContractManager.Instance.contractType;
         public string contractLevel = ContractManager.Instance.contractLevel;
         public Dictionary<string, float> SaleData = UpgradeBus.Instance.SaleData;
+        public Dictionary<ulong, int> healthLevels = Stimpack.Instance?.playerHealthLevels;
         public bool wearingHelmet = UpgradeBus.Instance.wearingHelmet;
     }
 

--- a/MoreShipUpgrades/Patches/PlayerController/PlayerControllerBPatcher.cs
+++ b/MoreShipUpgrades/Patches/PlayerController/PlayerControllerBPatcher.cs
@@ -170,6 +170,7 @@ namespace MoreShipUpgrades.Patches.PlayerController
         [HarmonyPatch(nameof(PlayerControllerB.Update))]
         static void CheckForBoomboxes(PlayerControllerB __instance)
         {
+            if (!UpgradeBus.Instance.PluginConfiguration.BEATS_ENABLED.Value) return;
             if (!BaseUpgrade.GetActiveUpgrade(SickBeats.UPGRADE_NAME) || __instance != GameNetworkManager.Instance.localPlayerController) return;
             SickBeats.Instance.boomBoxes.RemoveAll(b => b == null);
             bool result = false;

--- a/MoreShipUpgrades/UpgradeComponents/Items/Peeper.cs
+++ b/MoreShipUpgrades/UpgradeComponents/Items/Peeper.cs
@@ -1,5 +1,6 @@
 ﻿using MoreShipUpgrades.Managers;
 using MoreShipUpgrades.UpgradeComponents.Interfaces;
+using System.Linq;
 using UnityEngine;
 
 namespace MoreShipUpgrades.UpgradeComponents.Items
@@ -43,7 +44,7 @@ namespace MoreShipUpgrades.UpgradeComponents.Items
 
         public static bool HasLineOfSightToPeepers(Vector3 springPosition)
         {
-            foreach (Peeper peeper in UpgradeBus.Instance.coilHeadItems)
+            foreach (Peeper peeper in UpgradeBus.Instance.coilHeadItems.ToList())
             {
                 if (peeper == null)
                 {

--- a/MoreShipUpgrades/UpgradeComponents/Items/PortableTeleporter/BasePortableTeleporter.cs
+++ b/MoreShipUpgrades/UpgradeComponents/Items/PortableTeleporter/BasePortableTeleporter.cs
@@ -103,7 +103,6 @@ namespace MoreShipUpgrades.UpgradeComponents.Items.PortableTeleporter
         /// <returns>Wether the player can use the item or not</returns>
         private bool CanUsePortableTeleporter()
         {
-            if (!Mouse.current.leftButton.isPressed) return false;
             audio.PlayOneShot(buttonPress);
             if (itemUsedUp)
             {

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/AttributeUpgrades/Stimpack.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/AttributeUpgrades/Stimpack.cs
@@ -46,14 +46,21 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades.AttributeUpgrades
             initialValue = UpgradeBus.Instance.PluginConfiguration.PLAYER_HEALTH_ADDITIONAL_HEALTH_UNLOCK.Value;
             incrementalValue = UpgradeBus.Instance.PluginConfiguration.PLAYER_HEALTH_ADDITIONAL_HEALTH_INCREMENT.Value;
         }
-
+        public override void Load()
+        {
+            base.Load();
+            UpdatePlayerHealthLevel();
+        }
         public override void Increment()
         {
             base.Increment();
+            UpdatePlayerHealthLevel();
+        }
+        void UpdatePlayerHealthLevel()
+        {
             PlayerControllerB player = UpgradeBus.Instance.GetLocalPlayer();
             PlayerHealthUpdateLevelServerRpc(player.playerSteamId, GetUpgradeLevel(UPGRADE_NAME));
         }
-
         public override void Unwind()
         {
             base.Unwind();


### PR DESCRIPTION
- Fixed Stimpack not working when reviving players/regenerating them back to full health.
- Stopped Beats check on PlayerControllerB if it's disabled.
- Fixed Portable Teleporters being restricted to mouse left click regardless of binding change for item interaction.
- Fixed Peeper throwing error when the list of peepers is changed during iteration.