### PR TITLE
Update Hunter mod to (a) work and (b) be more extensible/configurable

### DIFF
--- a/MoreShipUpgrades/Managers/UpgradeBus.cs
+++ b/MoreShipUpgrades/Managers/UpgradeBus.cs
@@ -482,7 +482,7 @@ namespace MoreShipUpgrades.Managers
         }
         private void SetupHunterTerminalNode()
         {
-            Hunter.SetupTierList();
+            Hunter.SetupLevels();
             SetupMultiplePurchasableTerminalNode(Hunter.UPGRADE_NAME,
                                                 true,
                                                 PluginConfiguration.HUNTER_ENABLED.Value,

--- a/MoreShipUpgrades/Patches/Enemies/EnemyAIPatcher.cs
+++ b/MoreShipUpgrades/Patches/Enemies/EnemyAIPatcher.cs
@@ -18,20 +18,20 @@ namespace MoreShipUpgrades.Patches.Enemies
         [HarmonyPatch(nameof(EnemyAI.KillEnemy))]
         private static void SpawnSample(EnemyAI __instance)
         {
+            if (!(__instance.IsServer || __instance.IsHost)) return;
+
             if (currentEnemy == __instance.NetworkObject.NetworkObjectId) return;
+
             currentEnemy = __instance.NetworkObject.NetworkObjectId;
             string name = __instance.enemyType.enemyName;
 
-            if (!(BaseUpgrade.GetActiveUpgrade(Hunter.UPGRADE_NAME) && Hunter.tiers[BaseUpgrade.GetUpgradeLevel(Hunter.UPGRADE_NAME)].Contains(name.ToLower())))
+            if (BaseUpgrade.GetActiveUpgrade(Hunter.UPGRADE_NAME) && Hunter.CanHarvest(name))
             {
+                logger.LogDebug($"Spawning sample for {name}");
+                SpawnItemManager.Instance.SpawnSample(name.ToLower(), __instance.transform.position);
+            } else {
                 logger.LogDebug($"No sample was found to spawn for {name.ToLower()}");
-                logger.LogDebug("Enemies in the Hunter list");
-                foreach (string monsterName in Hunter.tiers[BaseUpgrade.GetUpgradeLevel(Hunter.UPGRADE_NAME)])
-                    logger.LogDebug($"{monsterName}");
-                return;
             }
-            logger.LogDebug($"Spawning sample for {name}");
-            if (__instance.IsServer || __instance.IsHost) SpawnItemManager.Instance.SpawnSample(name.ToLower(), __instance.transform.position);
         }
     }
 


### PR DESCRIPTION
Currently, the Hunter mod is hard-coded to only supporting three levels, and an off-by-one bug means that at level 3 everything breaks on a key not found error:
```
KeyNotFoundException: The given key '3' was not present in the dictionary.
  at System.Collections.Generic.Dictionary`2[TKey,TValue].get_Item (TKey key) [0x0001e] in <787acc3c9a4c471ba7d971300105af24>:IL_001E
  at MoreShipUpgrades.Patches.Enemies.EnemyAIPatcher.SpawnSample (EnemyAI __instance) [0x00053] in
```

This change reworks how enemy tiers are stored and retreived to avoid this issue and also allow for a variable number of monster tiers to be configurable.