### PR TITLE
Fixed issue between DiscJockey and this mod

### DIFF
--- a/MoreShipUpgrades/Managers/ConfigSynchronizationManager.cs
+++ b/MoreShipUpgrades/Managers/ConfigSynchronizationManager.cs
@@ -65,7 +65,7 @@ namespace MoreShipUpgrades.Managers
         }
         private IEnumerator WaitALittleToShareTheFile()
         {
-            yield return new WaitForSeconds(0.5f);
+            yield return new WaitForSeconds(2.5f);
             logger.LogInfo("Now sharing save file with clients...");
             LguStore.Instance.ShareSaveServerRpc();
         }

--- a/MoreShipUpgrades/Managers/LGUStore.cs
+++ b/MoreShipUpgrades/Managers/LGUStore.cs
@@ -318,7 +318,7 @@ namespace MoreShipUpgrades.Managers
 
         private IEnumerator WaitForUpgradeObject()
         {
-            yield return new WaitForSeconds(1f);
+            yield return new WaitForSeconds(2f);
             logger.LogInfo("Applying loaded upgrades...");
             foreach (CustomTerminalNode customNode in UpgradeBus.Instance.terminalNodes)
             {

--- a/MoreShipUpgrades/Patches/Items/BoomBoxPatcher.cs
+++ b/MoreShipUpgrades/Patches/Items/BoomBoxPatcher.cs
@@ -7,11 +7,11 @@ namespace MoreShipUpgrades.Patches.Items
     [HarmonyPatch(typeof(BoomboxItem))]
     internal static class BoomBoxPatcher
     {
-        [HarmonyPostfix]
-        [HarmonyPatch(nameof(BoomboxItem.Start))]
-        static void AddToList(BoomboxItem __instance)
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(BoomboxItem.StartMusic))]
+        static void StartMusicPrefix(BoomboxItem __instance)
         {
-            if (UpgradeBus.Instance.PluginConfiguration.BEATS_ENABLED.Value) SickBeats.Instance.boomBoxes.Add(__instance);
+            if (UpgradeBus.Instance.PluginConfiguration.BEATS_ENABLED.Value && !SickBeats.Instance.boomBoxes.Contains(__instance)) SickBeats.Instance.boomBoxes.Add(__instance);
         }
     }
 }


### PR DESCRIPTION
- Changed the patch from applying on ``BoomboxItem.Start`` to apply on ``BoomboxItem.StartMusic`` where it adds to the list used by Sick Beats if it's not already in.
- Added more time between config sync and loading gameobjects for no mix of synchronized and unsynchronized values.