### PR TITLE
Prevent deeper pockets from letting you switch off a wheelbarrow

### DIFF
--- a/MoreShipUpgrades/Misc/PluginConfig.cs
+++ b/MoreShipUpgrades/Misc/PluginConfig.cs
@@ -146,6 +146,7 @@ namespace MoreShipUpgrades.Misc
         [field: DataMember] public SyncedEntry<string> DEEPER_POCKETS_PRICES { get; set; }
         [field: DataMember] public SyncedEntry<int> DEEPER_POCKETS_INITIAL_TWO_HANDED_ITEMS {  get; set; }
         [field: DataMember] public SyncedEntry<int> DEEPER_POCKETS_INCREMENTAL_TWO_HANDED_ITEMS { get; set; }
+        [field: DataMember] public SyncedEntry<bool> DEEPER_POCKETS_ALLOW_WHEELBARROWS { get; set; }
         [field: DataMember] public SyncedEntry<string> ALUMINIUM_COILS_OVERRIDE_NAME { get; set; }
         [field: DataMember] public SyncedEntry<string> BACK_MUSCLES_OVERRIDE_NAME { get; set; }
         [field: DataMember] public SyncedEntry<string> BARGAIN_CONNECTIONS_OVERRIDE_NAME { get; set; }
@@ -568,6 +569,7 @@ namespace MoreShipUpgrades.Misc
             DEEPER_POCKETS_PRICES = SyncedBindingExtensions.BindSyncedEntry(cfg, topSection, BaseUpgrade.PRICES_SECTION, DeepPockets.DEFAULT_PRICES, BaseUpgrade.PRICES_DESCRIPTION);
             DEEPER_POCKETS_INITIAL_TWO_HANDED_ITEMS = SyncedBindingExtensions.BindSyncedEntry(cfg, topSection, LGUConstants.DEEPER_POCKETS_INITIAL_TWO_HANDED_AMOUNT_KEY, LGUConstants.DEEPER_POCKETS_INITIAL_TWO_HANDED_AMOUNT_DEFAULT, LGUConstants.DEEPER_POCKETS_INITIAL_TWO_HANDED_AMOUNT_DESCRIPTION);
             DEEPER_POCKETS_INCREMENTAL_TWO_HANDED_ITEMS = SyncedBindingExtensions.BindSyncedEntry(cfg, topSection, LGUConstants.DEEPER_POCKETS_INCREMENTAL_TWO_HANDED_AMOUNT_KEY, LGUConstants.DEEPER_POCKETS_INCREMENTAL_TWO_HANDED_AMOUNT_DEFAULT, LGUConstants.DEEPER_POCKETS_INCREMENTAL_TWO_HANDED_AMOUNT_DESCRIPTION);
+            DEEPER_POCKETS_ALLOW_WHEELBARROWS = SyncedBindingExtensions.BindSyncedEntry(cfg, topSection, LGUConstants.DEEPER_POCKETS_ALLOW_WHEELBARROWS_KEY, LGUConstants.DEEPER_POCKETS_ALLOW_WHEELBARROWS_DEFAULT, LGUConstants.DEEPER_POCKETS_ALLOW_WHEELBARROWS_DESCRIPTION);
 
             #endregion
 

--- a/MoreShipUpgrades/Misc/Util/LGUConstants.cs
+++ b/MoreShipUpgrades/Misc/Util/LGUConstants.cs
@@ -444,6 +444,10 @@ namespace MoreShipUpgrades.Misc.Util
         internal const int DEEPER_POCKETS_INCREMENTAL_TWO_HANDED_AMOUNT_DEFAULT = 1;
         internal const string DEEPER_POCKETS_INCREMENTAL_TWO_HANDED_AMOUNT_DESCRIPTION = "The amount of two handed carry capacity increased to the player when increase the upgrade level";
 
+        internal const string DEEPER_POCKETS_ALLOW_WHEELBARROWS_KEY = "Allow wheelbarrows to be stored in deeper pockets";
+        internal const bool DEEPER_POCKETS_ALLOW_WHEELBARROWS_DEFAULT = true;
+        internal const string DEEPER_POCKETS_ALLOW_WHEELBARROWS_DESCRIPTION = "Whether or not wheelbarrows and shopping carts can be stored in deeper pockets";
+
         #endregion 
 
         #region Aluminium Coils

--- a/MoreShipUpgrades/Patches/PlayerController/PlayerControllerBPatcher.cs
+++ b/MoreShipUpgrades/Patches/PlayerController/PlayerControllerBPatcher.cs
@@ -161,6 +161,11 @@ namespace MoreShipUpgrades.Patches.PlayerController
         {
             if (!player.twoHanded) return;
             if (!BaseUpgrade.GetActiveUpgrade(DeepPockets.UPGRADE_NAME)) return;
+
+            // No switching off the wheelbarrows
+            if (player.currentlyHeldObjectServer  != null && player.currentlyHeldObjectServer is WheelbarrowScript) return;
+            if (player.currentlyHeldObject != null && player.currentlyHeldObject is WheelbarrowScript) return;
+
             int twoHandedCount = 0;
             int maxTwoHandedCount = 1 + UpgradeBus.Instance.PluginConfiguration.DEEPER_POCKETS_INITIAL_TWO_HANDED_ITEMS + BaseUpgrade.GetUpgradeLevel(DeepPockets.UPGRADE_NAME) * UpgradeBus.Instance.PluginConfiguration.DEEPER_POCKETS_INCREMENTAL_TWO_HANDED_ITEMS;
 

--- a/MoreShipUpgrades/Patches/PlayerController/PlayerControllerBPatcher.cs
+++ b/MoreShipUpgrades/Patches/PlayerController/PlayerControllerBPatcher.cs
@@ -162,10 +162,12 @@ namespace MoreShipUpgrades.Patches.PlayerController
             if (!player.twoHanded) return;
             if (!BaseUpgrade.GetActiveUpgrade(DeepPockets.UPGRADE_NAME)) return;
 
-            // No switching off the wheelbarrows
-            if (player.currentlyHeldObjectServer  != null && player.currentlyHeldObjectServer is WheelbarrowScript) return;
-            if (player.currentlyHeldObject != null && player.currentlyHeldObject is WheelbarrowScript) return;
-
+            if (!UpgradeBus.Instance.PluginConfiguration.DEEPER_POCKETS_ALLOW_WHEELBARROWS)
+            {
+                // No putting wheelbarrows in your deeper pockets
+                if (player.currentlyHeldObjectServer != null && player.currentlyHeldObjectServer is WheelbarrowScript) return;
+                if (player.currentlyHeldObject != null && player.currentlyHeldObject is WheelbarrowScript) return;
+            }
             int twoHandedCount = 0;
             int maxTwoHandedCount = 1 + UpgradeBus.Instance.PluginConfiguration.DEEPER_POCKETS_INITIAL_TWO_HANDED_ITEMS + BaseUpgrade.GetUpgradeLevel(DeepPockets.UPGRADE_NAME) * UpgradeBus.Instance.PluginConfiguration.DEEPER_POCKETS_INCREMENTAL_TWO_HANDED_ITEMS;
 


### PR DESCRIPTION
Currently, nothing prevents you from switching off of a wheelbarrow / shopping cart when deeper pockets is enabled. This creates
a glitch and the player becomes unable to drop any items or interact with anything.

This patch basically prevents the wheelbarrow from ever being treated as one-handed by deeper pockets.

Fixes #458.