### PR TITLE
Fix for hunter upgrade and other small fixes

### DIFF
--- a/MoreShipUpgrades/API/HunterSamples.cs
+++ b/MoreShipUpgrades/API/HunterSamples.cs
@@ -148,6 +148,11 @@ namespace MoreShipUpgrades.API
             if (!moddedLevels.ContainsKey(monsterName)) moddedLevels.Add(monsterName, hunterLevel - 1);
         }
 
+        public static bool IsHunterEnabled()
+        {
+            return UpgradeBus.Instance.PluginConfiguration.HUNTER_ENABLED.Value;
+        }
+
         internal static void RegisterSampleItem<T>(Item sampleItem, string monsterName, bool registerNetworkPrefab = false, double weight = 50) where T : GrabbableObject
         {
             GrabbableObject sampleScript = sampleItem.spawnPrefab.AddComponent<T>();

--- a/MoreShipUpgrades/Misc/AssetBundleHandler.cs
+++ b/MoreShipUpgrades/Misc/AssetBundleHandler.cs
@@ -56,7 +56,7 @@ namespace MoreShipUpgrades.Misc
             { "mouthdog", sampleItems+ "EyelessDogSample.asset" },
             { "baboon hawk", sampleItems+ "BaboonHawkSample.asset" },
             { "crawler", sampleItems+ "ThumperSample.asset" },
-            { "forest keeper", sampleItems+ "ForestKeeperSample.asset" },
+            { "forestgiant", sampleItems+ "ForestKeeperSample.asset" },
             { "manticoil", sampleItems+ "ManticoilSample.asset" },
             { "tulip snake", sampleItems+ "TulipSnakeSample.asset" },
         };

--- a/MoreShipUpgrades/Misc/UI/Application/UpgradeStoreApplication.cs
+++ b/MoreShipUpgrades/Misc/UI/Application/UpgradeStoreApplication.cs
@@ -14,7 +14,7 @@ namespace MoreShipUpgrades.Misc.UI.Application
 {
     internal class UpgradeStoreApplication : PageApplication
     {
-        protected override int GetEntriesPerPage<T>(T[] entries)
+        public override int GetEntriesPerPage<T>(T[] entries)
         {
             return Mathf.CeilToInt(entries.Length / 2.5f);
         }

--- a/MoreShipUpgrades/MoreShipUpgrades.csproj
+++ b/MoreShipUpgrades/MoreShipUpgrades.csproj
@@ -40,8 +40,8 @@
     <Reference Include="lethallevelloader">
       <HintPath>$(LC_PLUGIN_PATH)\IAmBatby-LethalLevelLoader\LethalLevelLoader.dll</HintPath>
     </Reference>
-    <Reference Include="InteractiveTerminalAPI">
-      <HintPath>$(LC_PLUGIN_PATH)\InteractiveTerminalAPI\InteractiveTerminalAPI.dll</HintPath>
+    <Reference Include="InteractiveTerminalAPI" Publicize="true">
+      <HintPath>$(LC_PLUGIN_PATH)\WhiteSpike-Interactive_Terminal_API\InteractiveTerminalAPI\InteractiveTerminalAPI.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>$(LC_PATH)\Newtonsoft.Json.dll</HintPath>

--- a/MoreShipUpgrades/Plugin.cs
+++ b/MoreShipUpgrades/Plugin.cs
@@ -399,7 +399,7 @@ namespace MoreShipUpgrades
                 { "mouthdog", UpgradeBus.Instance.PluginConfiguration.EYELESS_DOG_SAMPLE_MINIMUM_VALUE.Value },
                 { "baboon hawk", UpgradeBus.Instance.PluginConfiguration.BABOON_HAWK_SAMPLE_MINIMUM_VALUE.Value },
                 { "crawler", UpgradeBus.Instance.PluginConfiguration.THUMPER_SAMPLE_MINIMUM_VALUE.Value },
-                { "forest keeper", UpgradeBus.Instance.PluginConfiguration.FOREST_KEEPER_SAMPLE_MINIMUM_VALUE.Value },
+                { "forestgiant", UpgradeBus.Instance.PluginConfiguration.FOREST_KEEPER_SAMPLE_MINIMUM_VALUE.Value },
                 { "manticoil", UpgradeBus.Instance.PluginConfiguration.MANTICOIL_SAMPLE_MINIMUM_VALUE.Value },
                 { "tulip snake", UpgradeBus.Instance.PluginConfiguration.TULIP_SNAKE_SAMPLE_MINIMUM_VALUE.Value },
             };
@@ -412,7 +412,7 @@ namespace MoreShipUpgrades
                 { "mouthdog", UpgradeBus.Instance.PluginConfiguration.EYELESS_DOG_SAMPLE_MAXIMUM_VALUE.Value },
                 { "baboon hawk", UpgradeBus.Instance.PluginConfiguration.BABOON_HAWK_SAMPLE_MAXIMUM_VALUE.Value },
                 { "crawler", UpgradeBus.Instance.PluginConfiguration.THUMPER_SAMPLE_MAXIMUM_VALUE.Value },
-                { "forest keeper", UpgradeBus.Instance.PluginConfiguration.FOREST_KEEPER_SAMPLE_MAXIMUM_VALUE.Value },
+                { "forestgiant", UpgradeBus.Instance.PluginConfiguration.FOREST_KEEPER_SAMPLE_MAXIMUM_VALUE.Value },
                 { "manticoil", UpgradeBus.Instance.PluginConfiguration.MANTICOIL_SAMPLE_MAXIMUM_VALUE.Value },
                 { "tulip snake", UpgradeBus.Instance.PluginConfiguration.TULIP_SNAKE_SAMPLE_MAXIMUM_VALUE.Value },
             };

--- a/MoreShipUpgrades/UpgradeComponents/Items/MonsterSample.cs
+++ b/MoreShipUpgrades/UpgradeComponents/Items/MonsterSample.cs
@@ -26,7 +26,7 @@ namespace MoreShipUpgrades.UpgradeComponents.Items
             base.EquipItem();
             ParticleSystem particles = GetComponentInChildren<ParticleSystem>();
             if (particles == null) return;
-            particles.Play();
+            particles.Play(true);
         }
 
         public override void DiscardItem()
@@ -34,8 +34,7 @@ namespace MoreShipUpgrades.UpgradeComponents.Items
             base.DiscardItem();
             ParticleSystem particles = GetComponentInChildren<ParticleSystem>();
             if (particles == null) return;
-            particles.Stop();
-            particles.Clear();
+            particles.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
         }
 
         public override void PocketItem()
@@ -43,8 +42,7 @@ namespace MoreShipUpgrades.UpgradeComponents.Items
             base.PocketItem();
             ParticleSystem particles = GetComponentInChildren<ParticleSystem>();
             if (particles == null) return;
-            particles.Stop();
-            particles.Clear();
+            particles.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
         }
     }
 }


### PR DESCRIPTION
potential fix for particles not stopping/cleaning (not sure if it's really a problem or not)
fix forestgiant samplePaths
change InteractiveTerminalAPI to publicize and use the thunderstore folder structure 
add IsHunterEnabled to hunter api so other mods can test without making csync a dependency (maybe useful?)