### PR TITLE
BrutalCompanyMinusExtra compatibility and Beekeeper fix

### DIFF
--- a/MoreShipUpgrades/Compat/BrutalCompanyMinusExtraCompat.cs
+++ b/MoreShipUpgrades/Compat/BrutalCompanyMinusExtraCompat.cs
@@ -1,0 +1,158 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BrutalCompanyMinus;
+using BrutalCompanyMinus.Minus;
+using BrutalCompanyMinus.Minus.Handlers;
+using BrutalCompanyMinus.Minus.MonoBehaviours;
+using HarmonyLib;
+using MoreShipUpgrades.Misc.Util;
+using MoreShipUpgrades.UpgradeComponents.TierUpgrades.Ship;
+
+namespace MoreShipUpgrades.Compat
+{
+    public static class BrutalCompanyMinusExtraCompat // pull request 22.12.2024 from tixomirof
+    {
+        public static bool Enabled =>
+            BepInEx.Bootstrap.Chainloader.PluginInfos.ContainsKey(BrutalCompanyMinus.Plugin.GUID);
+        public static string BeforePatchMessage =>
+            "Brutal Company Minus Extra has been detected. Proceeding to patch...";
+        public static string SuccessfulPatchMessage =>
+            "Patched Brutal Company Minus Extra mod related components for correct behaviour " +
+            "on Midas Touch upgrade for scrap that is spawned by Brutal's events/ScrapAmount multiplier stat. " + 
+            "If any issues arise related to the scrap value calculation when both LGU and BCME mods are present, " +
+            "report to LGU first.";
+
+        #region Compat Tool Classes
+        class GrabbableHazardState
+        {
+            public int minValue;
+            public int maxValue;
+        }
+        #endregion
+        #region Compat Tool Methods
+        /// <summary>
+        /// Multiplies <see cref="RoundManager.scrapValueMultiplier"/> by <see cref="MidasTouch.IncreaseScrapValue(float)"/>
+        /// for scrap value calculation in given code <paramref name="instructions"/>
+        /// </summary>
+        /// <param name="instructions">Method's CIL instructions</param>
+        /// <param name="scrapErrorMessagePrefix">String prefix for errorMessage param in
+        /// <see cref="Tools.FindField(ref int, ref List{CodeInstruction}, System.Reflection.FieldInfo, System.Reflection.MethodInfo, bool, bool, bool, bool, bool, bool, string)"/></param>
+        /// <returns>New method's CIL instructions</returns>
+        private static IEnumerable<CodeInstruction> MultiplyScrapValueOnSpawn(
+            IEnumerable<CodeInstruction> instructions, string scrapErrorMessagePrefix)
+        {
+            var midasMultiplier = typeof(MidasTouch).GetMethod(nameof(MidasTouch.IncreaseScrapValue));
+            var managerMultiplier = typeof(RoundManager).GetField(nameof(RoundManager.scrapValueMultiplier));
+
+            var codes = new List<CodeInstruction>(instructions);
+            var index = 0;
+            Tools.FindField(ref index, ref codes, findField: managerMultiplier, addCode: midasMultiplier,
+                errorMessage: $"Scrap value multiplier for brutal company minus extra's {scrapErrorMessagePrefix} scrap generation was not found.");
+            return codes;
+        }
+
+        /// <summary>
+        /// Multiplies <see cref="Item.minValue"/> and <see cref="Item.maxValue"/> for <paramref name="grabbableHazard"/> 
+        /// by <see cref="MidasTouch.IncreaseScrapValueInteger(int)"/>.<br></br>Must be called before dungeon generation starts.
+        /// </summary>
+        /// <param name="__state">Original state of <paramref name="grabbableHazard"/></param>
+        /// <param name="isProcessing">Check for multiply method calls to prevent unwanted 1 billion scrap value items</param>
+        /// <param name="grabbableHazard">Expected <see cref="GrabbableTurret"/>'s or <see cref="GrabbableLandmine"/>'s in-game asset</param>
+        private static void GrabbableHazardPrefix(out GrabbableHazardState __state, ref bool isProcessing, Item grabbableHazard)
+        {
+            __state = new GrabbableHazardState
+            {
+                minValue = 0,
+                maxValue = 0
+            };
+
+            if (!isProcessing)
+            {
+                isProcessing = true;
+                __state.minValue = grabbableHazard.minValue;
+                __state.maxValue = grabbableHazard.maxValue;
+                grabbableHazard.minValue = MidasTouch.IncreaseScrapValueInteger(grabbableHazard.minValue);
+                grabbableHazard.maxValue = MidasTouch.IncreaseScrapValueInteger(grabbableHazard.maxValue);
+            }
+        }
+
+        /// <summary>
+        /// Returns <see cref="Item.minValue"/> and <see cref="Item.maxValue"/> for <paramref name="grabbableHazard"/>
+        /// back to original values using <paramref name="__state"/>.<br></br>Must be called after dungeon generation finishes.
+        /// </summary>
+        /// <param name="__state">Original state of <paramref name="grabbableHazard"/>, must be prefilled by
+        /// <see cref="GrabbableHazardPrefix(out GrabbableHazardState, ref bool, Item)"/></param>
+        /// <param name="isProcessing">Link for internal class <see cref="Boolean"/> value, which will set it to <see langword="false"/>, to prevent multiple method calls</param>
+        /// <param name="grabbableHazard">Expected <see cref="GrabbableTurret"/>'s or <see cref="GrabbableLandmine"/>'s in-game asset</param>
+        private static void GrabbableHazardPostfix(GrabbableHazardState __state, Action isProcessing, Item grabbableHazard)
+        {
+            if (__state.minValue == __state.maxValue && __state.minValue == 0) return;
+
+            Task.Run(async () =>
+            {
+                const int generationWait = 10000;
+
+                await Task.Delay(generationWait);
+                grabbableHazard.minValue = __state.minValue;
+                grabbableHazard.maxValue = __state.maxValue;
+                isProcessing();
+            });
+        }
+        #endregion
+        #region Patchers
+        [HarmonyPatch(typeof(Manager.Spawn))]
+        internal static class ManagerSpawnPatcher // patch for brutal's outside/inside scrap spawns
+        {
+            [HarmonyPatch(nameof(Manager.Spawn.DoSpawnScrapInside))]
+            [HarmonyTranspiler]
+            private static IEnumerable<CodeInstruction> DoSpawnScrapInsideTranspiler(IEnumerable<CodeInstruction> instructions)
+                => MultiplyScrapValueOnSpawn(instructions, "inside");
+
+            [HarmonyPatch(nameof(Manager.Spawn.DoSpawnScrapOutside))]
+            [HarmonyTranspiler]
+            private static IEnumerable<CodeInstruction> DoSpawnScrapOutsideTranspiler(IEnumerable<CodeInstruction> instructions)
+                => MultiplyScrapValueOnSpawn(instructions, "outside");
+        }
+
+        [HarmonyPatch(typeof(GrabbableTurret), nameof(GrabbableTurret.onTurretStart))]
+        internal static class GrabbableTurretPatcher // patch for grabbable turret event item to use midas touch multiplier
+        {
+            [HarmonyPrefix]
+            private static void OnTurretStartPrefix(out GrabbableHazardState __state)
+                => GrabbableHazardPrefix(out __state, ref isProcessing, Assets.grabbableTurret);
+
+            [HarmonyPostfix]
+            private static void OnTurretStartPostfix(GrabbableHazardState __state)
+                => GrabbableHazardPostfix(__state, () => isProcessing = false, Assets.grabbableTurret);
+
+            private static bool isProcessing = false;
+        }
+
+        [HarmonyPatch(typeof(GrabbableLandmine), nameof(GrabbableLandmine.onLandmineStart))]
+        internal static class GrabbableLandminePatcher // patch for grabbable landmine event item to use midas touch multiplier
+        {
+            [HarmonyPrefix]
+            private static void OnLandmineStartPrefix(out GrabbableHazardState __state)
+                => GrabbableHazardPrefix(out __state, ref isProcessing, Assets.grabbableLandmine);
+
+            [HarmonyPostfix]
+            private static void OnLandmineStartPostfix(GrabbableHazardState __state)
+                => GrabbableHazardPostfix(__state, () => isProcessing = false, Assets.grabbableLandmine);
+
+            private static bool isProcessing = false;
+        }
+
+        [HarmonyPatch(typeof(LevelModifications))]
+        internal static class LevelModificationsPatcher // patch for transmuted scrap (aka pickles, teeth, gold bar events) to use midas touch multiplier
+        {
+            [HarmonyPatch(nameof(LevelModifications.OnwaitForScrapToSpawnToSync))]
+            [HarmonyTranspiler]
+            private static IEnumerable<CodeInstruction> OnwaitForScrapToSpawnToSyncTranspiler(IEnumerable<CodeInstruction> instructions)
+                => MultiplyScrapValueOnSpawn(instructions, "transmuted");
+        }
+        #endregion
+    }
+}

--- a/MoreShipUpgrades/Managers/PatchManager.cs
+++ b/MoreShipUpgrades/Managers/PatchManager.cs
@@ -47,6 +47,15 @@ namespace MoreShipUpgrades.Managers
                 harmony.PatchAll(typeof(RoundManagerPatchesPatcher));
                 Plugin.mls.LogInfo("Patched ShipInventory mod related components for correct behaviour on Scrap Keeper in relation of keeping items in the chute based on chance. If any issues arise related to the item chute being cleared on team wipe when both LGU and ShipInventory mods are present, report to LGU first.");
             }
+            if (BrutalCompanyMinusExtraCompat.Enabled)
+            {
+                Plugin.mls.LogInfo(BrutalCompanyMinusExtraCompat.BeforePatchMessage);
+                harmony.PatchAll(typeof(BrutalCompanyMinusExtraCompat.ManagerSpawnPatcher));
+                harmony.PatchAll(typeof(BrutalCompanyMinusExtraCompat.GrabbableTurretPatcher));
+                harmony.PatchAll(typeof(BrutalCompanyMinusExtraCompat.GrabbableLandminePatcher));
+                harmony.PatchAll(typeof(BrutalCompanyMinusExtraCompat.LevelModificationsPatcher));
+                Plugin.mls.LogInfo(BrutalCompanyMinusExtraCompat.SuccessfulPatchMessage);
+            }
         }
         static void PatchEnemies()
         {

--- a/MoreShipUpgrades/Plugin.cs
+++ b/MoreShipUpgrades/Plugin.cs
@@ -28,6 +28,7 @@ namespace MoreShipUpgrades
     [BepInDependency(Oxygen.OxygenBase.modGUID, DependencyFlags.SoftDependency)]
     [BepInDependency(LCVR.Plugin.PLUGIN_GUID, DependencyFlags.SoftDependency)]
     [BepInDependency(ShipInventory.MyPluginInfo.PLUGIN_GUID, DependencyFlags.SoftDependency)]
+    [BepInDependency(BrutalCompanyMinus.Plugin.GUID, DependencyFlags.SoftDependency)]
     public class Plugin : BaseUnityPlugin
     {
         internal static ManualLogSource mls;

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/Player/Beekeeper.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/Player/Beekeeper.cs
@@ -11,25 +11,20 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
 {
     class Beekeeper : TierUpgrade, IUpgradeWorldBuilding
     {
-        internal bool increaseHivePrice = false;
         internal static Beekeeper Instance;
 
         public const string UPGRADE_NAME = "Beekeeper";
         public const string PRICES_DEFAULT = "225,280,340";
         internal const string WORLD_BUILDING_TEXT = "\n\nOn-the-job training package that instructs {0} how to more safely and efficiently handle Circuit Bee Nests." +
             " Departments with a LVL {1} Certification in Circuit Bee Nest Handling earn an extra commission for every Nest they sell.\n\n";
+
+        protected bool CanIncreaseHivePrice => GetUpgradeLevel(UPGRADE_NAME) == GetConfiguration().BEEKEEPER_UPGRADE_PRICES.Value.Split(',').Length;
+
         void Awake()
         {
             upgradeName = UPGRADE_NAME;
             overridenUpgradeName = GetConfiguration().BEEKEEPER_OVERRIDE_NAME;
             Instance = this;
-        }
-
-        public override void Increment()
-        {
-            base.Increment();
-            if (GetUpgradeLevel(UPGRADE_NAME) == GetConfiguration().BEEKEEPER_UPGRADE_PRICES.Value.Split(',').Length)
-                ToggleIncreaseHivePriceServerRpc();
         }
 
         public static int CalculateBeeDamage(int damageNumber)
@@ -43,7 +38,7 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
         public static int GetHiveScrapValue(int originalValue)
         {
             LategameConfiguration config = GetConfiguration();
-            if (!config.BEEKEEPER_ENABLED.Value || !Instance.increaseHivePrice) return originalValue;
+            if (!config.BEEKEEPER_ENABLED.Value || !Instance.CanIncreaseHivePrice) return originalValue;
             return (int)(originalValue * config.BEEKEEPER_HIVE_VALUE_INCREASE.Value);
         }
 
@@ -62,17 +57,7 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
             string infoFormat = AssetBundleHandler.GetInfoFromJSON(UPGRADE_NAME);
             return Tools.GenerateInfoForUpgrade(infoFormat, initialPrice, incrementalPrices, infoFunction) + $"\nOn maximum level, applies a {(GetConfiguration().BEEKEEPER_HIVE_VALUE_INCREASE - 1f)*100f:F0}% scrap value increase on beehives.";
         }
-        [ServerRpc(RequireOwnership = false)]
-        public void ToggleIncreaseHivePriceServerRpc()
-        {
-            ToggleIncreaseHivePriceClientRpc();
-        }
 
-        [ClientRpc]
-        public void ToggleIncreaseHivePriceClientRpc()
-        {
-            increaseHivePrice = true;
-        }
         public override bool CanInitializeOnStart
         {
             get


### PR DESCRIPTION
Fixes:
- Brutal Company Minus Extra mod uses it's own code to spawn scrap inside and outside, which obviously doesnt use Midas Touch scrap value multipliers. Also brutal company can transmute scrap or hazards into different scraps, which wont use Midas Touch multiplier aswell. First commit fixes that.
- Beekeeper upgrade applied hive scrap value increase only until host restarts the lobby. Second commit fixes that.

Tested everything both in multiplayer and singleplayer, everything worked well on our config. I hope no further issues arise from these changes.