### PR TITLE
BCME Reborn Compat + Mechanical Arms Belt Bag fix

### DIFF
--- a/MoreShipUpgrades/Compat/BrutalCompanyMinusExtraCompat.cs
+++ b/MoreShipUpgrades/Compat/BrutalCompanyMinusExtraCompat.cs
@@ -16,6 +16,7 @@ namespace MoreShipUpgrades.Compat
     public static class BrutalCompanyMinusExtraCompat // pull request 22.12.2024 from tixomirof
     {
         public static bool Enabled =>
+            BepInEx.Bootstrap.Chainloader.PluginInfos.ContainsKey(BCMERebornGUID) ||
             BepInEx.Bootstrap.Chainloader.PluginInfos.ContainsKey(BrutalCompanyMinus.Plugin.GUID);
         public static string BeforePatchMessage =>
             "Brutal Company Minus Extra has been detected. Proceeding to patch...";
@@ -24,6 +25,8 @@ namespace MoreShipUpgrades.Compat
             "on Midas Touch upgrade for scrap that is spawned by Brutal's events/ScrapAmount multiplier stat. " + 
             "If any issues arise related to the scrap value calculation when both LGU and BCME mods are present, " +
             "report to LGU first.";
+
+        public const string BCMERebornGUID = "SoftDiamond.BrutalCompanyMinusExtraReborn";
 
         #region Compat Tool Classes
         class GrabbableHazardState

--- a/MoreShipUpgrades/Managers/PatchManager.cs
+++ b/MoreShipUpgrades/Managers/PatchManager.cs
@@ -98,6 +98,7 @@ namespace MoreShipUpgrades.Managers
 
         static void PatchItems()
         {
+            harmony.PatchAll(typeof(BeltBagItemPatcher));
             harmony.PatchAll(typeof(BoomBoxPatcher));
             harmony.PatchAll(typeof(DropPodPatcher));
             harmony.PatchAll(typeof(GrabbableObjectPatcher));

--- a/MoreShipUpgrades/Patches/Items/BeltBagItemPatcher.cs
+++ b/MoreShipUpgrades/Patches/Items/BeltBagItemPatcher.cs
@@ -1,0 +1,26 @@
+﻿using HarmonyLib;
+using MoreShipUpgrades.Misc.Util;
+using MoreShipUpgrades.UpgradeComponents.TierUpgrades.Player;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace MoreShipUpgrades.Patches.Items
+{
+    [HarmonyPatch(typeof(BeltBagItem))]
+    internal static class BeltBagItemPatcher
+    {
+        [HarmonyTranspiler]
+        [HarmonyPatch(nameof(BeltBagItem.ItemInteractLeftRight))]
+        public static IEnumerable<CodeInstruction> BeltBagItemInteractTranspiler(IEnumerable<CodeInstruction> instructions)
+        {
+            MethodInfo bonusDistance = typeof(MechanicalArms).GetMethod(nameof(MechanicalArms.GetIncreasedGrabDistance));
+
+            var codes = new List<CodeInstruction>(instructions);
+            var index = 0;
+            Tools.FindFloat(ref index, ref codes, 4f, bonusDistance, errorMessage: "Couldn't find belt bag item's debug pickup distance");
+            Tools.FindFloat(ref index, ref codes, 4f, bonusDistance, errorMessage: "Couldn't find belt bag item's pickup distance");
+            return codes.AsEnumerable();
+        }
+    }
+}

--- a/MoreShipUpgrades/Plugin.cs
+++ b/MoreShipUpgrades/Plugin.cs
@@ -30,6 +30,7 @@ namespace MoreShipUpgrades
     [BepInDependency(LCVR.Plugin.PLUGIN_GUID, DependencyFlags.SoftDependency)]
     [BepInDependency(ShipInventory.MyPluginInfo.PLUGIN_GUID, DependencyFlags.SoftDependency)]
     [BepInDependency(BrutalCompanyMinus.Plugin.GUID, DependencyFlags.SoftDependency)]
+    [BepInDependency(BrutalCompanyMinusExtraCompat.BCMERebornGUID, DependencyFlags.SoftDependency)]
     public class Plugin : BaseUnityPlugin
     {
         internal static ManualLogSource mls;


### PR DESCRIPTION
Hello!

This PR fixes:
- Compatibility between LGU's Midas Touch and [Brutal Company Minus Extra Reborn](https://thunderstore.io/c/lethal-company/p/SoftDiamond/BrutalCompanyMinusExtraReborn/). That was already done to Brutal Company Minus Extra, so fixes are the same, but now they work for Reborn version. This time **no need to insert new dependencies** in .csproj file.
- Mechanical Arms not increasing Belt Bag interaction distance (pressing Q to store items), which was confusing to me.

Tested both fixes in singleplayer, for me everything works fine.