### PR TITLE
3.14.0 release

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,7 @@
 - Fixed Fusion Matter not working as expected due to changes to the logic related to dropping items when teleporting from v80 game release.
 - Reworked patch involving scanner nodes and Better Scanner.
     - Essentialy turned the postfix patch (which would always override whatever vanilla was doing and anything before) into a transpiler patch (modifying the vanilla code to include additional checks from using Better Scanner)
-    
+- Fixed Market Influence not always working as expected due to a second randomization which picks a value between zero and the value influenced by Market Influence, allowing sale percentages lower than the intended minimum.
 </details>
 
 <details>

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@
 - Reworked patch involving scanner nodes and Better Scanner.
     - Essentialy turned the postfix patch (which would always override whatever vanilla was doing and anything before) into a transpiler patch (modifying the vanilla code to include additional checks from using Better Scanner)
 - Fixed Market Influence not always working as expected due to a second randomization which picks a value between zero and the value influenced by Market Influence, allowing sale percentages lower than the intended minimum.
+- Fixed Item Progression modes not working as expected due to code alterations in the selling desk from The Company (mainly, the additional check for an item that isn't considered scrap but has some scrap value)
 </details>
 
 <details>

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,11 @@
 <details>
+<summary> 3.13.1 - 2026-04-05 </summary>
+
+- Fixed Fusion Matter not working as expected due to changes to the logic related to dropping items when teleporting from v80 game release.
+
+</details>
+
+<details>
 <summary> 3.13.0 - 2026-04-05 </summary>
 
 - Added code related to LethalLevelLoader's ExtendedLevels as DunGen is no longer included in ``AssemblyCSharp.dll`` but rather its own assembly (``DunGen.dll``).

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,9 @@
 <summary> 3.13.1 - 2026-04-05 </summary>
 
 - Fixed Fusion Matter not working as expected due to changes to the logic related to dropping items when teleporting from v80 game release.
-
+- Reworked patch involving scanner nodes and Better Scanner.
+    - Essentialy turned the postfix patch (which would always override whatever vanilla was doing and anything before) into a transpiler patch (modifying the vanilla code to include additional checks from using Better Scanner)
+    
 </details>
 
 <details>

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,9 @@
 - Added Bullet Resistance upgrade which reduces incoming damage from bullets by a percentage.
     - The affected damage sources are the turrets and the shotgun (both when used by the nutcracker and the player).
 - Added Explosion Resistance upgrade which reduces incoming damage from explosions by a percentage.
+- Implemented configuration for Night Vision where equipping the goggles activates the night vision mechanic for the whole team or only for the player equipping it.
+    - Previously, this was done with just the "Individual Upgrade" setting, however this would also make the NV Headset Battery upgrade to be individual aswell, which is undesireable for some situations.
+    - Now, "Individual Upgrade" only affects NV Headset Battery upgrade while this new setting ("Individual Night Vision Upgrade") only affects the goggles item.
 - Fixed Beekeeper's last level not applying correctly when increasing the hive's scrap value.
 - Fixed issue with Fusion Matter causing items to be discarded incorrectly.
 - Fixed issue with NV Headset Batteries upgrade applying too early when activating night vision from the goggles item.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 <details>
-<summary> 3.13.1 - 2026-04-05 </summary>
+<summary> 3.13.2 - 2026-??-?? </summary>
+
+- Added ``OverSpending`` attribute in the UpgradeAPI related code where it allows credit purchases to go negative
+</details>
+
+<details>
+<summary> 3.13.1 - 2026-04-15 </summary>
 
 - Fixed Fusion Matter not working as expected due to changes to the logic related to dropping items when teleporting from v80 game release.
 - Reworked patch involving scanner nodes and Better Scanner.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@
 - Added configuration for enabling force credits command to be used during the run.
     - This is a consensus configuration, if at least one of the clients does not wish to use the command, the command is unavailable to the host.
     - Once all clients (including host) agree to use the force credits command, the host is allowed to use the command.
+- Fixed issue with Fusion Matter causing items to be discarded incorrectly.
 
 </details>
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,8 @@
 - Fixed issue with Fusion Matter causing items to be discarded incorrectly.
 - Fixed issue with NV Headset Batteries upgrade applying too early when activating night vision from the goggles item.
 - Fixed issue with NV Headset Batteries refund causing night vision being disabled, having to rebuy the goggles to turn it back on.
+- Removed code related to save sharing when globally sharing upgrades.
+    - This code was never updated and/or looked at and caused more issues than it solved and the current save system already shares the contents of the save file between clients and it still functions when upgrades become individual later.
 
 </details>
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,10 @@
 - Added Bullet Resistance upgrade which reduces incoming damage from bullets by a percentage.
     - The affected damage sources are the turrets and the shotgun (both when used by the nutcracker and the player).
 - Added Explosion Resistance upgrade which reduces incoming damage from explosions by a percentage.
+- Added TZP Buffer upgrade which increases the effectiveness of its positive buffs (movement speed and stamina effieciency) and reduces the effectiveness of its negative debuffs (visual impairment).
+    - Separate configurable values for both positive and negative effects.
+    - At 100% effectiveness of positive buff, you won't lose any stamina while in the effect of TZP.
+    - At 100% effectiveness loss of negative debuff, the gas visual impairment will be completely removed.
 - Implemented configuration for Night Vision where equipping the goggles activates the night vision mechanic for the whole team or only for the player equipping it.
     - Previously, this was done with just the "Individual Upgrade" setting, however this would also make the NV Headset Battery upgrade to be individual aswell, which is undesireable for some situations.
     - Now, "Individual Upgrade" only affects NV Headset Battery upgrade while this new setting ("Individual Night Vision Upgrade") only affects the goggles item.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@
     - Once all clients (including host) agree to use the force credits command, the host is allowed to use the command.
 - Added Bullet Resistance upgrade which reduces incoming damage from bullets by a percentage.
     - The affected damage sources are the turrets and the shotgun (both when used by the nutcracker and the player).
+- Added Explosion Resistance upgrade which reduces incoming damage from explosions by a percentage.
 - Fixed Beekeeper's last level not applying correctly when increasing the hive's scrap value.
 - Fixed issue with Fusion Matter causing items to be discarded incorrectly.
 - Fixed issue with NV Headset Batteries upgrade applying too early when activating night vision from the goggles item.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@
 - Added configuration for enabling force credits command to be used during the run.
     - This is a consensus configuration, if at least one of the clients does not wish to use the command, the command is unavailable to the host.
     - Once all clients (including host) agree to use the force credits command, the host is allowed to use the command.
+- Fixed Beekeeper's last level not applying correctly when increasing the hive's scrap value.
 - Fixed issue with Fusion Matter causing items to be discarded incorrectly.
 
 </details>

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,11 +5,13 @@
 - Added configuration for enabling force credits command to be used during the run.
     - This is a consensus configuration, if at least one of the clients does not wish to use the command, the command is unavailable to the host.
     - Once all clients (including host) agree to use the force credits command, the host is allowed to use the command.
+- Added Bullet Resistance upgrade which reduces incoming damage from bullets by a percentage.
+    - The affected damage sources are the turrets and the shotgun (both when used by the nutcracker and the player).
 - Fixed Beekeeper's last level not applying correctly when increasing the hive's scrap value.
 - Fixed issue with Fusion Matter causing items to be discarded incorrectly.
 - Fixed issue with NV Headset Batteries upgrade applying too early when activating night vision from the goggles item.
 - Fixed issue with NV Headset Batteries refund causing night vision being disabled, having to rebuy the goggles to turn it back on.
-- Fixed Bigger Lungs displaying incorrect values related with stamina regeneration and stamina cost decrease when jumping.
+- Fixed Bigger Lungs upgrade displaying incorrect values related with stamina regeneration and stamina cost decrease when jumping.
 - Removed code related to save sharing when globally sharing upgrades.
     - This code was never updated and/or looked at and caused more issues than it solved and the current save system already shares the contents of the save file between clients and it still functions when upgrades become individual later.
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,5 @@
 <details>
-<summary> 3.13.2 - 2026-??-?? </summary>
+<summary> 3.14.0 - 2026-05-24 </summary>
 
 - Added ``OverSpending`` attribute in the UpgradeAPI related code where it allows credit purchases to go negative
 - Added configuration for enabling force credits command to be used during the run.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,7 @@
 - Fixed issue with Fusion Matter causing items to be discarded incorrectly.
 - Fixed issue with NV Headset Batteries upgrade applying too early when activating night vision from the goggles item.
 - Fixed issue with NV Headset Batteries refund causing night vision being disabled, having to rebuy the goggles to turn it back on.
+- Fixed Bigger Lungs displaying incorrect values related with stamina regeneration and stamina cost decrease when jumping.
 - Removed code related to save sharing when globally sharing upgrades.
     - This code was never updated and/or looked at and caused more issues than it solved and the current save system already shares the contents of the save file between clients and it still functions when upgrades become individual later.
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,10 @@
 <summary> 3.13.2 - 2026-??-?? </summary>
 
 - Added ``OverSpending`` attribute in the UpgradeAPI related code where it allows credit purchases to go negative
+- Added configuration for enabling force credits command to be used during the run.
+    - This is a consensus configuration, if at least one of the clients does not wish to use the command, the command is unavailable to the host.
+    - Once all clients (including host) agree to use the force credits command, the host is allowed to use the command.
+
 </details>
 
 <details>

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,8 @@
     - Once all clients (including host) agree to use the force credits command, the host is allowed to use the command.
 - Fixed Beekeeper's last level not applying correctly when increasing the hive's scrap value.
 - Fixed issue with Fusion Matter causing items to be discarded incorrectly.
+- Fixed issue with NV Headset Batteries upgrade applying too early when activating night vision from the goggles item.
+- Fixed issue with NV Headset Batteries refund causing night vision being disabled, having to rebuy the goggles to turn it back on.
 
 </details>
 

--- a/MoreShipUpgrades/API/UpgradeApi.cs
+++ b/MoreShipUpgrades/API/UpgradeApi.cs
@@ -8,6 +8,25 @@ namespace MoreShipUpgrades.API
 {
     public static class UpgradeApi
     {
+        public static void TurnOnOverspending()
+        {
+            if (UpgradeBus.Instance.AllowOverspending)
+            {
+                Plugin.mls.LogInfo("Overspending on upgrades is already enabled, ignoring request...");
+                return;
+            }
+            UpgradeBus.Instance.ToggleOverspending(true);
+        }
+
+        public static void TurnOffOverspending()
+		{
+			if (!UpgradeBus.Instance.AllowOverspending)
+			{
+				Plugin.mls.LogInfo("Overspending on upgrades is already disabled, ignoring request...");
+				return;
+			}
+			UpgradeBus.Instance.ToggleOverspending(false);
+		}
         public static void TriggerUpgradeRankup(string upgradeName)
         {
             CustomTerminalNode pickedNode = UpgradeBus.Instance.GetUpgradeNode(upgradeName);

--- a/MoreShipUpgrades/Configuration/LategameConfiguration.cs
+++ b/MoreShipUpgrades/Configuration/LategameConfiguration.cs
@@ -154,6 +154,7 @@ namespace MoreShipUpgrades.Configuration
         [field: SyncedEntryField] public SyncedEntry<bool> BuyableUpgradeOnce { get; set; }
         [field: SyncedEntryField] public SyncedEntry<bool> ShowLockedUpgrades { get; set; }
         [field: SyncedEntryField] public SyncedEntry<bool> UseDawnLib {  get; set; }
+        public ConfigEntry<bool> EnableForceCredits { get; set; }
 
         #endregion
 
@@ -226,6 +227,7 @@ namespace MoreShipUpgrades.Configuration
             OVERRIDE_UPGRADE_NAMES = cfg.BindSyncedEntry(topSection, LguConstants.OVERRIDE_NAMES_ENABLED_KEY, LguConstants.OVERRIDE_NAMES_ENABLED_DEFAULT, LguConstants.OVERRIDE_NAMES_ENABLED_DESCRIPTION);
             UseDawnLib = cfg.BindSyncedEntry(topSection, "Use DawnLib for Initialization", false, "Replaces initialization phase that utilizes LethalLib with DawnLib callbacks instead. Use this if you are experiencing issues with LethalLib and believe DawnLib won't have the same issues.");
             MaximumIndividualUpgrades = cfg.BindSyncedEntry(topSection, "Maximum purchaseable individual upgrades", 0, "If greater than zero, limits each player's amount of purchased individual upgrades to the configurated value.");
+            EnableForceCredits = cfg.Bind(topSection, "Enable force credits command", false, "If enabled, you can use the forcecredits command to change the current amount of credits. Should only be used incase an error has happened during gameplay");
 			#endregion
 
 			topSection = LguConstants.CONTRACTS_SECTION;

--- a/MoreShipUpgrades/Configuration/LategameConfiguration.cs
+++ b/MoreShipUpgrades/Configuration/LategameConfiguration.cs
@@ -39,6 +39,7 @@ namespace MoreShipUpgrades.Configuration
     [DataContract]
     public class LategameConfiguration : SyncedConfig2<LategameConfiguration>
     {
+        public ITierEffectUpgradeConfiguration<int> ExplosionReistanceConfiguration { get; set; }
         public ITierEffectUpgradeConfiguration<int> SmarterLockpickUpgradeConfiguration { get; set; }
         public ITierEffectUpgradeConfiguration<int> EffectiveBandaidsConfiguration { get; set; }
         public ITierEffectUpgradeConfiguration<int> MedicalNanobotsConfiguration { get; set; }
@@ -249,6 +250,13 @@ namespace MoreShipUpgrades.Configuration
             #endregion
 
             #region Upgrades
+
+            topSection = ExplosionResistance.UPGRADE_NAME;
+            ExplosionReistanceConfiguration = new TierPrimitiveUpgradeConfiguration<int>(cfg, topSection, LguConstants.EXPLOSION_RESISTANCE_ENABLED_DESCRIPTION, ExplosionResistance.DEFAULT_PRICES)
+            {
+                InitialEffect = cfg.BindSyncedEntry(topSection, LguConstants.EXPLOSION_RESISTANCE_INITIAL_DAMAGE_REDUCTION_KEY, LguConstants.EXPLOSION_RESISTANCE_INITIAL_DAMAGE_REDUCTION_DEFAULT, LguConstants.EXPLOSION_RESISTANCE_INITIAL_DAMAGE_REDUCTION_DESCRIPTION),
+                IncrementalEffect = cfg.BindSyncedEntry(topSection, LguConstants.EXPLOSION_RESISTANCE_INCREMENTAL_DAMAGE_REDUCTION_KEY, LguConstants.EXPLOSION_RESISTANCE_INCREMENTAL_DAMAGE_REDUCTION_DEFAULT, LguConstants.EXPLOSION_RESISTANCE_INCREMENTAL_DAMAGE_REDUCTION_DESCRIPTION),
+            };
 
             topSection = SmarterLockpick.UPGRADE_NAME;
             SmarterLockpickUpgradeConfiguration = new TierPrimitiveUpgradeConfiguration<int>(cfg, topSection, LguConstants.SMARTER_LOCKPICK_ENABLED_DESCRIPTION, SmarterLockpick.PRICES_DEFAULT)

--- a/MoreShipUpgrades/Configuration/LategameConfiguration.cs
+++ b/MoreShipUpgrades/Configuration/LategameConfiguration.cs
@@ -33,12 +33,14 @@ using MoreShipUpgrades.Configuration.Upgrades.Custom;
 using MoreShipUpgrades.Configuration.Upgrades.Abstractions.TIerUpgrades;
 using MoreShipUpgrades.Configuration.Upgrades.Abstractions.OneTimeUpgrades;
 using MoreShipUpgrades.Configuration.Contracts;
+using MoreShipUpgrades.UpgradeComponents.TierUpgrades.Items.TZP;
 
 namespace MoreShipUpgrades.Configuration
 {
     [DataContract]
     public class LategameConfiguration : SyncedConfig2<LategameConfiguration>
     {
+        public TZPBufferUpgradeConfiguration TZPBufferConfiguration { get; set; }
         public ITierEffectUpgradeConfiguration<int> BulletResistanceConfiguration {  get; set; }
         public ITierEffectUpgradeConfiguration<int> ExplosionReistanceConfiguration { get; set; }
         public ITierEffectUpgradeConfiguration<int> SmarterLockpickUpgradeConfiguration { get; set; }
@@ -251,6 +253,21 @@ namespace MoreShipUpgrades.Configuration
             #endregion
 
             #region Upgrades
+
+            topSection = TZPBuffer.UPGRADE_NAME;
+            TZPBufferConfiguration = new TZPBufferUpgradeConfiguration(cfg, topSection, LguConstants.TZP_BUFFER_ENABLED_DESCRIPTION, TZPBuffer.DEFAULT_PRICES)
+            {
+                InitialEffects =
+                {
+                    cfg.BindSyncedEntry(topSection, LguConstants.TZP_BUFFER_INITIAL_BUFF_DURATION_INCREASE_KEY, LguConstants.TZP_BUFFER_INITIAL_BUFF_DURATION_INCREASE_DEFAULT, LguConstants.TZP_BUFFER_INITIAL_BUFF_DURATION_INCREASE_DESCRIPTION),
+                    cfg.BindSyncedEntry(topSection, LguConstants.TZP_BUFFER_INITIAL_DEBUFF_DURATION_REDUCTION_KEY, LguConstants.TZP_BUFFER_INITIAL_DEBUFF_DURATION_REDUCTION_DEFAULT, LguConstants.TZP_BUFFER_INITIAL_DEBUFF_DURATION_REDUCTION_DESCRIPTION),
+                },
+                IncrementalEffects =
+                {
+                    cfg.BindSyncedEntry(topSection, LguConstants.TZP_BUFFER_INCREMENTAL_BUFF_DURATION_INCREASE_KEY, LguConstants.TZP_BUFFER_INCREMENTAL_BUFF_DURATION_INCREASE_DEFAULT, LguConstants.TZP_BUFFER_INCREMENTAL_BUFF_DURATION_INCREASE_DESCRIPTION),
+                    cfg.BindSyncedEntry(topSection, LguConstants.TZP_BUFFER_INCREMENTAL_DEBUFF_DURATION_REDUCTION_KEY, LguConstants.TZP_BUFFER_INCREMENTAL_DEBUFF_DURATION_REDUCTION_DEFAULT, LguConstants.TZP_BUFFER_INCREMENTAL_DEBUFF_DURATION_REDUCTION_DESCRIPTION),
+                },
+            };
 
             topSection = BulletResistance.UPGRADE_NAME;
             BulletResistanceConfiguration = new TierPrimitiveUpgradeConfiguration<int>(cfg, topSection, LguConstants.BULLET_RESISTANCE_ENABLED_DESCRIPTION, BulletResistance.DEFAULT_PRICES)

--- a/MoreShipUpgrades/Configuration/LategameConfiguration.cs
+++ b/MoreShipUpgrades/Configuration/LategameConfiguration.cs
@@ -39,6 +39,7 @@ namespace MoreShipUpgrades.Configuration
     [DataContract]
     public class LategameConfiguration : SyncedConfig2<LategameConfiguration>
     {
+        public ITierEffectUpgradeConfiguration<int> BulletResistanceConfiguration {  get; set; }
         public ITierEffectUpgradeConfiguration<int> ExplosionReistanceConfiguration { get; set; }
         public ITierEffectUpgradeConfiguration<int> SmarterLockpickUpgradeConfiguration { get; set; }
         public ITierEffectUpgradeConfiguration<int> EffectiveBandaidsConfiguration { get; set; }
@@ -250,6 +251,13 @@ namespace MoreShipUpgrades.Configuration
             #endregion
 
             #region Upgrades
+
+            topSection = BulletResistance.UPGRADE_NAME;
+            BulletResistanceConfiguration = new TierPrimitiveUpgradeConfiguration<int>(cfg, topSection, LguConstants.BULLET_RESISTANCE_ENABLED_DESCRIPTION, BulletResistance.DEFAULT_PRICES)
+            {
+                InitialEffect = cfg.BindSyncedEntry(topSection, LguConstants.BULLET_RESISTANCE_INITIAL_DAMAGE_REDUCTION_KEY, LguConstants.BULLET_RESISTANCE_INITIAL_DAMAGE_REDUCTION_DEFAULT, LguConstants.BULLET_RESISTANCE_INITIAL_DAMAGE_REDUCTION_DESCRIPTION),
+                IncrementalEffect = cfg.BindSyncedEntry(topSection, LguConstants.BULLET_RESISTANCE_INCREMENTAL_DAMAGE_REDUCTION_KEY, LguConstants.BULLET_RESISTANCE_INCREMENTAL_DAMAGE_REDUCTION_DEFAULT, LguConstants.BULLET_RESISTANCE_INCREMENTAL_DAMAGE_REDUCTION_DESCRIPTION),
+            };
 
             topSection = ExplosionResistance.UPGRADE_NAME;
             ExplosionReistanceConfiguration = new TierPrimitiveUpgradeConfiguration<int>(cfg, topSection, LguConstants.EXPLOSION_RESISTANCE_ENABLED_DESCRIPTION, ExplosionResistance.DEFAULT_PRICES)

--- a/MoreShipUpgrades/Configuration/Upgrades/Custom/NightVisionUpgradeConfiguration.cs
+++ b/MoreShipUpgrades/Configuration/Upgrades/Custom/NightVisionUpgradeConfiguration.cs
@@ -16,6 +16,7 @@ namespace MoreShipUpgrades.Configuration.Upgrades.Custom
         [field: SyncedEntryField] public SyncedEntry<float> ExhaustTime { get; set; }
         [field: SyncedEntryField] public SyncedEntry<bool> LoseOnDeath {  get; set; }
         [field: SyncedEntryField] public SyncedEntry<bool> DropOnDeath { get; set; }
+        [field: SyncedEntryField] public SyncedEntry<bool> IndividualNV { get; set; }
         public NightVisionUpgradeConfiguration(ConfigFile cfg, string topSection, string enabledDescription, string defaultPrices) : base(cfg, topSection, enabledDescription, defaultPrices)
         {
             ItemPrice = cfg.BindSyncedEntry(topSection, LguConstants.NIGHT_VISION_PRICE_KEY, LguConstants.NIGHT_VISION_PRICE_DEFAULT);
@@ -26,6 +27,7 @@ namespace MoreShipUpgrades.Configuration.Upgrades.Custom
             ExhaustTime = cfg.BindSyncedEntry(topSection, LguConstants.NIGHT_VISION_EXHAUST_KEY, LguConstants.NIGHT_VISION_EXHAUST_DEFAULT, LguConstants.NIGHT_VISION_EXHAUST_DESCRIPTION);
             LoseOnDeath = cfg.BindSyncedEntry(topSection, LguConstants.LOSE_NIGHT_VISION_ON_DEATH_KEY, LguConstants.LOSE_NIGHT_VISION_ON_DEATH_DEFAULT, LguConstants.LOSE_NIGHT_VISION_ON_DEATH_DESCRIPTION);
             DropOnDeath = cfg.BindSyncedEntry(topSection, LguConstants.NIGHT_VISION_DROP_ON_DEATH_KEY, LguConstants.NIGHT_VISION_DROP_ON_DEATH_DEFAULT, LguConstants.NIGHT_VISION_DROP_ON_DEATH_DESCRIPTION);
+            IndividualNV = cfg.BindSyncedEntry(topSection, LguConstants.INDIVIDUAL_NIGHT_VISION_KEY, LguConstants.INDIVIDUAL_NIGHT_VISION_DEFAULT, LguConstants.INDIVIDUAL_NIGHT_VISION_DESCRIPTION);
         }
     }
 }

--- a/MoreShipUpgrades/Configuration/Upgrades/Custom/TZPBufferUpgradeConfiguration.cs
+++ b/MoreShipUpgrades/Configuration/Upgrades/Custom/TZPBufferUpgradeConfiguration.cs
@@ -1,0 +1,15 @@
+﻿using BepInEx.Configuration;
+using CSync.Extensions;
+using CSync.Lib;
+using MoreShipUpgrades.Configuration.Upgrades.Abstractions.TIerUpgrades;
+using MoreShipUpgrades.Misc.Util;
+
+namespace MoreShipUpgrades.Configuration.Upgrades.Custom
+{
+    public class TZPBufferUpgradeConfiguration : TierIndividualMultiplePrimitiveUpgradeConfiguration<int>
+    {
+        public TZPBufferUpgradeConfiguration(ConfigFile cfg, string topSection, string enabledDescription, string defaultPrices) : base(cfg, topSection, enabledDescription, defaultPrices)
+        {
+        }
+    }
+}

--- a/MoreShipUpgrades/Extensions/PlayerControllerBExtensions.cs
+++ b/MoreShipUpgrades/Extensions/PlayerControllerBExtensions.cs
@@ -90,5 +90,12 @@ namespace MoreShipUpgrades.Extensions
             if (player.IsTeleporting()) return Mathf.Clamp(defaultValue + player.GetCurrentWeightFromInventory(),1f,10f);
             return defaultValue;
         }
+
+        public static GrabbableObject RemainItemSlotIfTeleporting(this PlayerControllerB player, int itemSlotIndex)
+        {
+            Plugin.mls.LogDebug(player == null);
+            if (player.IsTeleporting()) return player.ItemSlots[itemSlotIndex];
+            return null;
+        }
     }
 }

--- a/MoreShipUpgrades/Extensions/PlayerControllerBExtensions.cs
+++ b/MoreShipUpgrades/Extensions/PlayerControllerBExtensions.cs
@@ -3,6 +3,7 @@ using MoreShipUpgrades.Managers;
 using MoreShipUpgrades.Misc.Upgrades;
 using MoreShipUpgrades.UpgradeComponents.TierUpgrades.AttributeUpgrades;
 using MoreShipUpgrades.UpgradeComponents.TierUpgrades.Player;
+using MoreShipUpgrades.UpgradeComponents.TierUpgrades.Ship;
 using UnityEngine;
 
 namespace MoreShipUpgrades.Extensions
@@ -66,7 +67,7 @@ namespace MoreShipUpgrades.Extensions
         }
         public static bool RemainIsHoldingObjectIfTeleporting(this PlayerControllerB player)
         {
-            return player.IsTeleporting() && player.CheckIfCurrentlyHeldObjectIsInInventory();
+            return player.currentlyHeldObjectServer != null && FusionMatter.CanHoldItem(player.currentlyHeldObjectServer, player) && player.CheckIfCurrentlyHeldObjectIsInInventory();
         }
 
         public static bool RemainActivatingItemIfTeleporting(this PlayerControllerB player)
@@ -93,8 +94,7 @@ namespace MoreShipUpgrades.Extensions
 
         public static GrabbableObject RemainItemSlotIfTeleporting(this PlayerControllerB player, int itemSlotIndex)
         {
-            Plugin.mls.LogDebug(player == null);
-            if (player.IsTeleporting()) return player.ItemSlots[itemSlotIndex];
+            if (FusionMatter.CanHoldItem(player.ItemSlots[itemSlotIndex], player)) return player.ItemSlots[itemSlotIndex];
             return null;
         }
     }

--- a/MoreShipUpgrades/Managers/LGUStore.cs
+++ b/MoreShipUpgrades/Managers/LGUStore.cs
@@ -614,8 +614,19 @@ namespace MoreShipUpgrades.Managers
         {
             Terminal terminal = UpgradeBus.Instance.GetTerminal();
             terminal.SyncGroupCreditsClientRpc(newAmount, terminal.numberOfItemsInDropship);
-        }
-    }
+		}
+		[ClientRpc]
+		internal void CheckForceCreditsConsensusClientRpc()
+		{
+			CheckForceCreditsConsensusServerRpc(UpgradeBus.Instance.PluginConfiguration.EnableForceCredits.Value);
+		}
+		[ServerRpc(RequireOwnership = false)]
+		internal void CheckForceCreditsConsensusServerRpc(bool consensus, ServerRpcParams serverRpcParams = default)
+		{
+            Plugin.mls.LogInfo($"Received consensus response from {serverRpcParams.Receive.SenderClientId}...");
+            CommandParser.CheckForceCreditsConsensus(consensus, serverRpcParams.Receive.SenderClientId);
+		}
+	}
 
     [Serializable]
     public class SaveInfo

--- a/MoreShipUpgrades/Managers/LGUStore.cs
+++ b/MoreShipUpgrades/Managers/LGUStore.cs
@@ -249,18 +249,7 @@ namespace MoreShipUpgrades.Managers
                 upgrade.Register();
             }
             LguSave = JsonConvert.DeserializeObject<LguSave>(Encoding.ASCII.GetString(json));
-            List<ulong> saves = [.. LguSave.playerSaves.Keys];
-            if(UpgradeBus.Instance.PluginConfiguration.SHARED_UPGRADES.Value && saves.Count > 0)
-            {
-                ulong steamID = LguSave.playerSaves.Keys.ToList<ulong>()[0];
-                logger.LogInfo($"SHARED SAVE FILE: Loading index 0 save under steam ID: {steamID}");
-                SaveInfo = LguSave.playerSaves[steamID];
-                UpdateUpgradeBus(false);
-            }
-            else
-            {
-                UpdateUpgradeBus();
-            }
+            UpdateUpgradeBus();
         }
 
         /// <summary>

--- a/MoreShipUpgrades/Managers/PatchManager.cs
+++ b/MoreShipUpgrades/Managers/PatchManager.cs
@@ -96,6 +96,7 @@ namespace MoreShipUpgrades.Managers
             harmony.PatchAll(typeof(ShipTeleporterPatcher));
             harmony.PatchAll(typeof(VehicleControllerPatcher));
             harmony.PatchAll(typeof(LandminePatcher));
+            harmony.PatchAll(typeof(TurretPatcher));
             Plugin.mls.LogInfo("Interactables have been patched");
         }
 

--- a/MoreShipUpgrades/Managers/PatchManager.cs
+++ b/MoreShipUpgrades/Managers/PatchManager.cs
@@ -95,6 +95,7 @@ namespace MoreShipUpgrades.Managers
             harmony.PatchAll(typeof(EntranceTeleportPatcher));
             harmony.PatchAll(typeof(ShipTeleporterPatcher));
             harmony.PatchAll(typeof(VehicleControllerPatcher));
+            harmony.PatchAll(typeof(LandminePatcher));
             Plugin.mls.LogInfo("Interactables have been patched");
         }
 

--- a/MoreShipUpgrades/Managers/UpgradeBus.cs
+++ b/MoreShipUpgrades/Managers/UpgradeBus.cs
@@ -16,6 +16,7 @@ using MoreShipUpgrades.UpgradeComponents.TierUpgrades.AttributeUpgrades;
 using MoreShipUpgrades.UpgradeComponents.TierUpgrades.Player;
 using MoreShipUpgrades.UpgradeComponents.TierUpgrades.Ship;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -25,6 +26,7 @@ namespace MoreShipUpgrades.Managers
 {
     public class UpgradeBus : MonoBehaviour
     {
+        public bool AllowOverspending = false;
         internal static UpgradeBus Instance { get; set; }
         internal LategameConfiguration PluginConfiguration { get; set; }
         static readonly LguLogger logger = new(nameof(UpgradeBus));
@@ -58,6 +60,18 @@ namespace MoreShipUpgrades.Managers
             DontDestroyOnLoad(gameObject);
         }
 
+        public void ToggleOverspending(bool toggle)
+		{
+			this.AllowOverspending = toggle;
+			if (toggle)
+            {
+                Plugin.mls.LogInfo("Overspending on upgrades and other related purchases has been enabled from third-party mod, players can now go negative credits whenever purchasing from this mod.");
+            }
+            else
+            {
+                Plugin.mls.LogInfo("Overspending on upgrades and other related purchases has been disabled from third-party mod, players can't from this point go negative credits whenever purchasing from this mod.");
+            }
+        }
         public Terminal GetTerminal()
         {
             if (terminal == null) terminal = GameObject.Find("TerminalScript").GetComponent<Terminal>();

--- a/MoreShipUpgrades/Managers/UpgradeBus.cs
+++ b/MoreShipUpgrades/Managers/UpgradeBus.cs
@@ -470,6 +470,12 @@ namespace MoreShipUpgrades.Managers
         internal void SetConfiguration(LategameConfiguration config)
         {
             PluginConfiguration = config;
-        }
-    }
+		}
+		public IEnumerator ChangeTerminalText(TerminalNode node)
+		{
+			yield return new WaitForEndOfFrame();
+			Terminal terminal = UpgradeBus.Instance.GetTerminal();
+			terminal.LoadNewNode(node);
+		}
+	}
 }

--- a/MoreShipUpgrades/Misc/CommandParser.cs
+++ b/MoreShipUpgrades/Misc/CommandParser.cs
@@ -13,6 +13,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Unity.Netcode;
 using UnityEngine;
 
 namespace MoreShipUpgrades.Misc
@@ -20,6 +21,10 @@ namespace MoreShipUpgrades.Misc
     internal static class CommandParser
     {
         static readonly LguLogger logger = new(nameof(CommandParser));
+
+        static readonly List<ulong> responses = [];
+        static bool allConsensus = false;
+        static int forceCreditAmount = 0;
 
         const string LOAD_LGU_COMMAND = "load lgu";
         public static readonly List<string> contracts = [LguConstants.DATA_CONTRACT_NAME, LguConstants.EXTERMINATOR_CONTRACT_NAME, LguConstants.EXTRACTION_CONTRACT_NAME,LguConstants.EXORCISM_CONTRACT_NAME,LguConstants.DEFUSAL_CONTRACT_NAME];
@@ -94,16 +99,54 @@ namespace MoreShipUpgrades.Misc
                 logger.LogError("LGU SAVE NOT FOUND in ExecuteResetLGUSave()!");
                 return DisplayTerminalMessage(LguConstants.LGU_SAVE_NOT_FOUND);
             }
-        }
-        private static TerminalNode ExecuteForceCredits(string creditAmount, ref Terminal terminal)
+		}
+		internal static void CheckForceCreditsConsensus(bool consensus, ulong senderClientId)
+		{
+            if (responses.Contains(senderClientId))
+            {
+                Plugin.mls.LogInfo($"Already received response from {senderClientId}, ignoring...");
+                return;
+            }
+            if (!StartOfRound.Instance.ClientPlayerList.ContainsKey(senderClientId))
+            {
+                Plugin.mls.LogInfo($"Received response from unknown client identifier, ignoring...");
+                return;
+            }
+            if (!allConsensus)
+            {
+                Plugin.mls.LogInfo("Somebody already said no to using forcecredits command, ignoring...");
+                return;
+            }
+            responses.Add(senderClientId);
+			allConsensus &= consensus;
+            if (!allConsensus)
+            {
+                Plugin.mls.LogInfo("Somebody rejected using forcecredits command.");
+                Terminal terminal = UpgradeBus.Instance.GetTerminal();
+				UpgradeBus.Instance.StartCoroutine(UpgradeBus.Instance.ChangeTerminalText(DisplayTerminalMessage("Rejecting command due to not all players agree to use the command.\n\n")));
+			}
+            else if (responses.Count == StartOfRound.Instance.ClientPlayerList.Count)
+            {
+				Plugin.mls.LogInfo("Everyone agreed to use forcecredits command.");
+				Terminal terminal = UpgradeBus.Instance.GetTerminal();
+				terminal.SyncGroupCreditsClientRpc(forceCreditAmount, terminal.numberOfItemsInDropship);
+                forceCreditAmount = 0;
+                UpgradeBus.Instance.StartCoroutine(UpgradeBus.Instance.ChangeTerminalText(DisplayTerminalMessage("Consensus has been achieved, forcing credit amount...\n\n")));
+			}
+		}
+		private static TerminalNode ExecuteForceCredits(string creditAmount, ref Terminal terminal)
         {
             if (int.TryParse(creditAmount, out int value))
             {
                 if (terminal.IsHost || terminal.IsServer)
                 {
-                    terminal.SyncGroupCreditsClientRpc(value, terminal.numberOfItemsInDropship);
-                    return DisplayTerminalMessage(string.Format(LguConstants.FORCE_CREDITS_SUCCESS_FORMAT, value));
-                }
+                    responses.Clear();
+					allConsensus = true;
+                    forceCreditAmount = value;
+                    LguStore.Instance.CheckForceCreditsConsensusClientRpc();
+					//terminal.SyncGroupCreditsClientRpc(value, terminal.numberOfItemsInDropship);
+					return DisplayTerminalMessage("Processing consensus for usage of forcecredits command...\n\n");
+				}
                 else
                 {
                     return DisplayTerminalMessage(LguConstants.FORCE_CREDITS_HOST_ONLY);
@@ -117,7 +160,7 @@ namespace MoreShipUpgrades.Misc
         {
             if (!UpgradeBus.Instance.PluginConfiguration.INTERN_ENABLED) return outputNode;
 
-            if (terminal.groupCredits < UpgradeBus.Instance.PluginConfiguration.INTERN_PRICE.Value)
+            if (terminal.groupCredits < UpgradeBus.Instance.PluginConfiguration.INTERN_PRICE.Value && !UpgradeBus.Instance.AllowOverspending)
                 return DisplayTerminalMessage(string.Format(LguConstants.INTERNS_NOT_ENOUGH_CREDITS_FORMAT, UpgradeBus.Instance.PluginConfiguration.INTERN_PRICE.Value, terminal.groupCredits));
 
             if (Interns.instance.revivalTimer > 0f)
@@ -411,7 +454,7 @@ namespace MoreShipUpgrades.Misc
                 logger.LogInfo($"User tried starting a new contract while they still have a {ContractManager.Instance.contractType} contract on {ContractManager.Instance.contractLevel}!");
                 return DisplayTerminalMessage(txt);
             }
-            if (terminal.groupCredits < UpgradeBus.Instance.PluginConfiguration.ContractsConfiguration.RandomPrice.Value)
+            if (terminal.groupCredits < UpgradeBus.Instance.PluginConfiguration.ContractsConfiguration.RandomPrice.Value && !UpgradeBus.Instance.AllowOverspending)
             {
                 txt = $"Contracts costs ${UpgradeBus.Instance.PluginConfiguration.ContractsConfiguration.RandomPrice.Value} and you have ${terminal.groupCredits}\n\n";
                 return DisplayTerminalMessage(txt);
@@ -545,5 +588,6 @@ namespace MoreShipUpgrades.Misc
             displayText += "\n\n";
             return DisplayTerminalMessage(displayText);
         }
-    }
+
+	}
 }

--- a/MoreShipUpgrades/Misc/PluginMetadata.cs
+++ b/MoreShipUpgrades/Misc/PluginMetadata.cs
@@ -5,6 +5,6 @@
         public const string GUID = "com.malco.lethalcompany.moreshipupgrades";
         public const string DAWN_ID = "lategame_upgrades";
         public const string NAME = "More Ship Upgrades";
-        public const string VERSION = "3.12.13.2";
+        public const string VERSION = "3.13.1";
     }
 }

--- a/MoreShipUpgrades/Misc/PluginMetadata.cs
+++ b/MoreShipUpgrades/Misc/PluginMetadata.cs
@@ -5,6 +5,6 @@
         public const string GUID = "com.malco.lethalcompany.moreshipupgrades";
         public const string DAWN_ID = "lategame_upgrades";
         public const string NAME = "More Ship Upgrades";
-        public const string VERSION = "3.13.2";
+        public const string VERSION = "3.14.0";
     }
 }

--- a/MoreShipUpgrades/Misc/PluginMetadata.cs
+++ b/MoreShipUpgrades/Misc/PluginMetadata.cs
@@ -5,6 +5,6 @@
         public const string GUID = "com.malco.lethalcompany.moreshipupgrades";
         public const string DAWN_ID = "lategame_upgrades";
         public const string NAME = "More Ship Upgrades";
-        public const string VERSION = "3.13.1";
+        public const string VERSION = "3.13.2";
     }
 }

--- a/MoreShipUpgrades/Misc/Util/LGUConstants.cs
+++ b/MoreShipUpgrades/Misc/Util/LGUConstants.cs
@@ -397,6 +397,20 @@ namespace MoreShipUpgrades.Misc.Util
         internal const string ENABLED_FORMAT = "Enable {0} Upgrade";
         internal const string PRICE_FORMAT = "Price of {0} Upgrade";
 
+        #region Bullet Resistance
+
+        internal const string BULLET_RESISTANCE_ENABLED_DESCRIPTION = "Tier upgrade that increases the bullet resistance of the player, reducing the damage taken from bullets.";
+
+        internal const string BULLET_RESISTANCE_INITIAL_DAMAGE_REDUCTION_KEY = "Initial Damage Reduction";
+        internal const int BULLET_RESISTANCE_INITIAL_DAMAGE_REDUCTION_DEFAULT = 25;
+        internal const string BULLET_RESISTANCE_INITIAL_DAMAGE_REDUCTION_DESCRIPTION = "Initial percentage of damage reduction from bullets when first purchasing the upgrade.";
+
+        internal const string BULLET_RESISTANCE_INCREMENTAL_DAMAGE_REDUCTION_KEY = "Incremental Damage Reduction";
+        internal const int BULLET_RESISTANCE_INCREMENTAL_DAMAGE_REDUCTION_DEFAULT = 25;
+        internal const string BULLET_RESISTANCE_INCREMENTAL_DAMAGE_REDUCTION_DESCRIPTION = "Incremental percentage of damage reduction from bullets when purchasing further levels of the upgrade";
+
+        #endregion
+
         #region Explosion Resistance
 
         internal const string EXPLOSION_RESISTANCE_ENABLED_DESCRIPTION = "Tier upgrade that increases the explosion resistance of the player, reducing the damage taken from explosions.";

--- a/MoreShipUpgrades/Misc/Util/LGUConstants.cs
+++ b/MoreShipUpgrades/Misc/Util/LGUConstants.cs
@@ -397,6 +397,28 @@ namespace MoreShipUpgrades.Misc.Util
         internal const string ENABLED_FORMAT = "Enable {0} Upgrade";
         internal const string PRICE_FORMAT = "Price of {0} Upgrade";
 
+        #region TZP Buffer
+
+        internal const string TZP_BUFFER_ENABLED_DESCRIPTION = "Tier upgrade that increases the TZP Inhaler's buff effect while also decreasing the debuff's effect";
+
+        internal const string TZP_BUFFER_INITIAL_BUFF_DURATION_INCREASE_KEY = "Initial Buff Effect Increase";
+        internal const int TZP_BUFFER_INITIAL_BUFF_DURATION_INCREASE_DEFAULT = 20;
+        internal const string TZP_BUFFER_INITIAL_BUFF_DURATION_INCREASE_DESCRIPTION = "Initial percentage increase of the buff effect of the TZP Inhaler when first purchasing the upgrade.";
+
+        internal const string TZP_BUFFER_INCREMENTAL_BUFF_DURATION_INCREASE_KEY = "Incremental Buff Effect Increase";
+        internal const int TZP_BUFFER_INCREMENTAL_BUFF_DURATION_INCREASE_DEFAULT = 15;
+        internal const string TZP_BUFFER_INCREMENTAL_BUFF_DURATION_INCREASE_DESCRIPTION = "Incremental percentage increase of the buff effect of the TZP Inhaler when purchasing further levels of the upgrade";
+
+        internal const string TZP_BUFFER_INITIAL_DEBUFF_DURATION_REDUCTION_KEY = "Initial Debuff Effect Reduction";
+        internal const int TZP_BUFFER_INITIAL_DEBUFF_DURATION_REDUCTION_DEFAULT = 20;
+        internal const string TZP_BUFFER_INITIAL_DEBUFF_DURATION_REDUCTION_DESCRIPTION = "Initial percentage reduction of the debuff effect of the TZP Inhaler when first purchasing the upgrade.";
+        
+        internal const string TZP_BUFFER_INCREMENTAL_DEBUFF_DURATION_REDUCTION_KEY = "Incremental Debuff Effect Reduction";
+        internal const int TZP_BUFFER_INCREMENTAL_DEBUFF_DURATION_REDUCTION_DEFAULT = 15;
+        internal const string TZP_BUFFER_INCREMENTAL_DEBUFF_DURATION_REDUCTION_DESCRIPTION = "Incremental percentage reduction of the debuff effect of the TZP Inhaler when purchasing further levels of the upgrade";
+
+        #endregion
+
         #region Bullet Resistance
 
         internal const string BULLET_RESISTANCE_ENABLED_DESCRIPTION = "Tier upgrade that increases the bullet resistance of the player, reducing the damage taken from bullets.";

--- a/MoreShipUpgrades/Misc/Util/LGUConstants.cs
+++ b/MoreShipUpgrades/Misc/Util/LGUConstants.cs
@@ -1078,6 +1078,10 @@ namespace MoreShipUpgrades.Misc.Util
         internal const string NIGHT_VISION_DROP_ON_DEATH_KEY = $"Drop {NightVisionGoggles.ITEM_NAME} on Death";
         internal const bool NIGHT_VISION_DROP_ON_DEATH_DEFAULT = true;
         internal const string NIGHT_VISION_DROP_ON_DEATH_DESCRIPTION = $"If true, when you die and lose {NightVision.SIMPLE_UPGRADE_NAME} upon death, you will drop the {NightVisionGoggles.ITEM_NAME} on your body.";
+
+        internal const string INDIVIDUAL_NIGHT_VISION_KEY = $"Individual {NightVision.SIMPLE_UPGRADE_NAME} Upgrade";
+        internal const bool INDIVIDUAL_NIGHT_VISION_DEFAULT = false;
+        internal const string INDIVIDUAL_NIGHT_VISION_DESCRIPTION = $"If true, equipping the goggles will only activate the night vision mechanic on the person equipping them, not the team.";
         #endregion
 
         #region Mechanical Arms

--- a/MoreShipUpgrades/Misc/Util/LGUConstants.cs
+++ b/MoreShipUpgrades/Misc/Util/LGUConstants.cs
@@ -397,6 +397,20 @@ namespace MoreShipUpgrades.Misc.Util
         internal const string ENABLED_FORMAT = "Enable {0} Upgrade";
         internal const string PRICE_FORMAT = "Price of {0} Upgrade";
 
+        #region Explosion Resistance
+
+        internal const string EXPLOSION_RESISTANCE_ENABLED_DESCRIPTION = "Tier upgrade that increases the explosion resistance of the player, reducing the damage taken from explosions.";
+
+        internal const string EXPLOSION_RESISTANCE_INITIAL_DAMAGE_REDUCTION_KEY = "Initial Damage Reduction";
+        internal const int EXPLOSION_RESISTANCE_INITIAL_DAMAGE_REDUCTION_DEFAULT = 25;
+        internal const string EXPLOSION_RESISTANCE_INITIAL_DAMAGE_REDUCTION_DESCRIPTION = "Initial percentage of damage reduction from explosions when first purchasing the upgrade.";
+
+        internal const string EXPLOSION_RESISTANCE_INCREMENTAL_DAMAGE_REDUCTION_KEY = "Incremental Damage Reduction";
+        internal const int EXPLOSION_RESISTANCE_INCREMENTAL_DAMAGE_REDUCTION_DEFAULT = 25;
+        internal const string EXPLOSION_RESISTANCE_INCREMENTAL_DAMAGE_REDUCTION_DESCRIPTION = "Incremental percentage of damage reduction from explosions when purchasing further levels of the upgrade";
+
+        #endregion
+
         #region Smarter Lockpick
         internal const string SMARTER_LOCKPICK_ENABLED_DESCRIPTION = "Tier upgrade that increases the efficiency of the lockpicker item, making it faster at opening doors.";
 

--- a/MoreShipUpgrades/Misc/Util/Tools.cs
+++ b/MoreShipUpgrades/Misc/Util/Tools.cs
@@ -85,8 +85,23 @@ namespace MoreShipUpgrades.Misc.Util
             }
             if (!found) logger.LogError(errorMessage);
             index++;
-        }
-        public static void FindString(ref int index, ref List<CodeInstruction> codes, string findValue, MethodInfo addCode = null, bool skip = false, bool notInstruction = false, bool andInstruction = false, bool orInstruction = false, bool requireInstance = false, string errorMessage = "Not found")
+		}
+		public static void FindArgumentField(ref int index, ref List<CodeInstruction> codes, int argumentIndex, object addCode = null, bool skip = false, bool store = false, bool requireInstance = false, string errorMessage = "Not found")
+		{
+			bool found = false;
+			for (; index < codes.Count; index++)
+			{
+				if (!CheckCodeInstruction(codes[index], argumentIndex, store, argument: true)) continue;
+				found = true;
+				if (skip) break;
+				codes.Insert(index + 1, new CodeInstruction(OpCodes.Call, addCode));
+				if (requireInstance) codes.Insert(index + 1, new CodeInstruction(OpCodes.Ldarg_0));
+				break;
+			}
+			if (!found) logger.LogError(errorMessage);
+			index++;
+		}
+		public static void FindString(ref int index, ref List<CodeInstruction> codes, string findValue, MethodInfo addCode = null, bool skip = false, bool notInstruction = false, bool andInstruction = false, bool orInstruction = false, bool requireInstance = false, string errorMessage = "Not found")
         {
             FindCodeInstruction(ref index, ref codes, findValue: findValue, addCode: addCode, skip: skip, requireInstance: requireInstance, notInstruction: notInstruction, andInstruction: andInstruction, orInstruction: orInstruction, errorMessage: errorMessage);
         }
@@ -143,30 +158,54 @@ namespace MoreShipUpgrades.Misc.Util
         {
             FindCodeInstruction(ref index, ref codes, findValue: null, addCode: addCode, skip: skip, notInstruction: notInstruction, andInstruction: andInstruction, orInstruction: orInstruction, requireInstance: requireInstance, instanceBefore: instanceBefore, errorMessage: errorMessage);
         }
-        private static bool CheckCodeInstruction(CodeInstruction code, int localIndex, bool store = false)
+        private static bool CheckCodeInstruction(CodeInstruction code, int index, bool store = false, bool argument = false)
         {
-            if (!store)
+            if (!argument)
             {
-                switch (localIndex)
-                {
-                    case 0: return code.opcode == OpCodes.Ldloc_0;
-                    case 1: return code.opcode == OpCodes.Ldloc_1;
-                    case 2: return code.opcode == OpCodes.Ldloc_2;
-                    case 3: return code.opcode == OpCodes.Ldloc_3;
-                    default: return code.opcode == OpCodes.Ldloc && (int)code.operand == localIndex;
-                }
-            }
+				if (!store)
+				{
+					switch (index)
+					{
+						case 0: return code.opcode == OpCodes.Ldloc_0;
+						case 1: return code.opcode == OpCodes.Ldloc_1;
+						case 2: return code.opcode == OpCodes.Ldloc_2;
+						case 3: return code.opcode == OpCodes.Ldloc_3;
+						default: return code.opcode == OpCodes.Ldloc && (int)code.operand == index;
+					}
+				}
+				else
+				{
+					switch (index)
+					{
+						case 0: return code.opcode == OpCodes.Stloc_0;
+						case 1: return code.opcode == OpCodes.Stloc_1;
+						case 2: return code.opcode == OpCodes.Stloc_2;
+						case 3: return code.opcode == OpCodes.Stloc_3;
+						default: return code.opcode == OpCodes.Stloc && (int)code.operand == index;
+					}
+				}
+			}
             else
             {
-                switch (localIndex)
-                {
-                    case 0: return code.opcode == OpCodes.Stloc_0;
-                    case 1: return code.opcode == OpCodes.Stloc_1;
-                    case 2: return code.opcode == OpCodes.Stloc_2;
-                    case 3: return code.opcode == OpCodes.Stloc_3;
-                    default: return code.opcode == OpCodes.Stloc && (int)code.operand == localIndex;
-                }
-            }
+				if (!store)
+				{
+					switch (index)
+					{
+						case 0: return code.opcode == OpCodes.Ldarg_0;
+						case 1: return code.opcode == OpCodes.Ldarg_1;
+						case 2: return code.opcode == OpCodes.Ldarg_2;
+						case 3: return code.opcode == OpCodes.Ldarg_3;
+						default: return code.opcode == OpCodes.Ldarg && (int)code.operand == index;
+					}
+				}
+				else
+				{
+					switch (index)
+					{
+						default: return code.opcode == OpCodes.Starg && (int)code.operand == index;
+					}
+				}
+			}
         }
         private static bool CheckCodeInstruction(CodeInstruction code, object findValue)
         {

--- a/MoreShipUpgrades/Misc/Util/Tools.cs
+++ b/MoreShipUpgrades/Misc/Util/Tools.cs
@@ -100,8 +100,9 @@ namespace MoreShipUpgrades.Misc.Util
 			}
 			if (!found) logger.LogError(errorMessage);
 			index++;
-		}
-		public static void FindString(ref int index, ref List<CodeInstruction> codes, string findValue, MethodInfo addCode = null, bool skip = false, bool notInstruction = false, bool andInstruction = false, bool orInstruction = false, bool requireInstance = false, string errorMessage = "Not found")
+        }
+
+        public static void FindString(ref int index, ref List<CodeInstruction> codes, string findValue, MethodInfo addCode = null, bool skip = false, bool notInstruction = false, bool andInstruction = false, bool orInstruction = false, bool requireInstance = false, string errorMessage = "Not found")
         {
             FindCodeInstruction(ref index, ref codes, findValue: findValue, addCode: addCode, skip: skip, requireInstance: requireInstance, notInstruction: notInstruction, andInstruction: andInstruction, orInstruction: orInstruction, errorMessage: errorMessage);
         }
@@ -170,8 +171,8 @@ namespace MoreShipUpgrades.Misc.Util
 						case 1: return code.opcode == OpCodes.Ldloc_1;
 						case 2: return code.opcode == OpCodes.Ldloc_2;
 						case 3: return code.opcode == OpCodes.Ldloc_3;
-						default: return code.opcode == OpCodes.Ldloc && (int)code.operand == index;
-					}
+                        default: return (code.opcode == OpCodes.Ldloc && (int)code.operand == index) || (code.opcode == OpCodes.Ldloc_S && ((LocalBuilder)(code.operand)).LocalIndex == index);
+                    }
 				}
 				else
 				{
@@ -181,7 +182,7 @@ namespace MoreShipUpgrades.Misc.Util
 						case 1: return code.opcode == OpCodes.Stloc_1;
 						case 2: return code.opcode == OpCodes.Stloc_2;
 						case 3: return code.opcode == OpCodes.Stloc_3;
-						default: return code.opcode == OpCodes.Stloc && (int)code.operand == index;
+						default: return (code.opcode == OpCodes.Stloc || code.opcode == OpCodes.Stloc_S) && (int)code.operand == index;
 					}
 				}
 			}
@@ -195,7 +196,7 @@ namespace MoreShipUpgrades.Misc.Util
 						case 1: return code.opcode == OpCodes.Ldarg_1;
 						case 2: return code.opcode == OpCodes.Ldarg_2;
 						case 3: return code.opcode == OpCodes.Ldarg_3;
-						default: return code.opcode == OpCodes.Ldarg && (int)code.operand == index;
+						default: return (code.opcode == OpCodes.Ldarg && (int)code.operand == index) || (code.opcode == OpCodes.Ldarg_S && (byte)code.operand == index);
 					}
 				}
 				else

--- a/MoreShipUpgrades/Patches/Enemies/RedLocustBeesPatch.cs
+++ b/MoreShipUpgrades/Patches/Enemies/RedLocustBeesPatch.cs
@@ -32,20 +32,11 @@ namespace MoreShipUpgrades.Patches.Enemies
             MethodInfo beeIncreaseHiveValue = typeof(Beekeeper).GetMethod(nameof(Beekeeper.GetHiveScrapValue));
 
             List<CodeInstruction> codes = instructions.ToList();
-            bool found = false;
-            for (int i = 0; i < codes.Count; i++)
-            {
-                if (found) break;
-                if (codes[i].opcode != OpCodes.Ldarg_2) continue;
-                if (!(codes[i + 1].opcode == OpCodes.Stfld && codes[i + 1].operand.ToString() == "System.Int32 scrapValue")) continue;
-
-                codes.Insert(i + 1, new CodeInstruction(OpCodes.Ldarg_2));
-                codes.Insert(i + 1, new CodeInstruction(OpCodes.Starg, 2));
-                codes.Insert(i + 1, new CodeInstruction(OpCodes.Call, beeIncreaseHiveValue));
-                found = true;
-            }
-            if (!found) { logger.LogError("Did not find the hive scrap value..."); }
-            return codes.AsEnumerable();
+            int index = 0;
+			Tools.FindArgumentField(ref index, ref codes, argumentIndex: 2, addCode: beeIncreaseHiveValue, errorMessage: "Could not find the argument with hive's scrap value");
+			Tools.FindArgumentField(ref index, ref codes, argumentIndex: 2, addCode: beeIncreaseHiveValue, errorMessage: "Could not find the argument with hive's scrap value");
+			Tools.FindArgumentField(ref index, ref codes, argumentIndex: 2, addCode: beeIncreaseHiveValue, errorMessage: "Could not find the argument with hive's scrap value");
+			return codes.AsEnumerable();
         }
     }
 }

--- a/MoreShipUpgrades/Patches/HUD/HUDManagerPatcher.cs
+++ b/MoreShipUpgrades/Patches/HUD/HUDManagerPatcher.cs
@@ -17,26 +17,30 @@ namespace MoreShipUpgrades.Patches.HUD
     [HarmonyPatch(typeof(HUDManager))]
     internal static class HudManagerPatcher
     {
-        [HarmonyPostfix]
+        [HarmonyTranspiler]
         [HarmonyPatch(nameof(HUDManager.MeetsScanNodeRequirements))]
-        static void MeetsScanNodeRequirementsPostFix(ScanNodeProperties node, ref bool __result, PlayerControllerB playerScript)
+        static IEnumerable<CodeInstruction> MeetsScanNodeRequirementsTranspiler(IEnumerable<CodeInstruction> instructions)
         {
-            if (__result) return;
-            if (!BaseUpgrade.GetActiveUpgrade(BetterScanner.UPGRADE_NAME)) { return; }
-            if (node == null) { __result = false; return; }
-            float rangeIncrease = node.headerText == "Main entrance" || node.headerText == "Ship" ? UpgradeBus.Instance.PluginConfiguration.BetterScannerUpgradeConfiguration.OutsideNodesRangeIncrease.Value : UpgradeBus.Instance.PluginConfiguration.BetterScannerUpgradeConfiguration.NodeRangeIncrease.Value;
-			bool throughWall = Physics.Linecast(playerScript.gameplayCamera.transform.position, node.transform.position, 134217984, QueryTriggerInteraction.Ignore);
-			float num = Vector3.Distance(playerScript.transform.position, node.transform.position);
-            __result = num <= node.maxRange + rangeIncrease && (num >= node.minRange) && (!node.requiresLineOfSight || !throughWall);
-			bool hasRequiredLevel = BaseUpgrade.GetUpgradeLevel(BetterScanner.UPGRADE_NAME) == 2;
-            if (!hasRequiredLevel) return;
-			bool cannotSeeEnemiesThroughWalls = node.nodeType == 1 && !UpgradeBus.Instance.PluginConfiguration.BetterScannerUpgradeConfiguration.SeeEnemiesThroughWalls.Value;
-			if (node.requiresLineOfSight && throughWall && cannotSeeEnemiesThroughWalls)
-			{
-				__result = false;
-			}
+            MethodInfo GetAdditionalRange = typeof(BetterScanner).GetMethod(nameof(BetterScanner.GetAdditionalMaximumScanNodeRange));
+			MethodInfo CanSeeScrapThroughWalls = typeof(BetterScanner).GetMethod(nameof(BetterScanner.CanSeeScrapThroughWall));
+			MethodInfo CanSeeEnemiesThroughWalls = typeof(BetterScanner).GetMethod(nameof(BetterScanner.CanSeeEnemiesThroughWall));
+
+            FieldInfo maxRange = typeof(ScanNodeProperties).GetField(nameof(ScanNodeProperties.maxRange));
+            FieldInfo requireLineOfSight = typeof(ScanNodeProperties).GetField(nameof(ScanNodeProperties.requiresLineOfSight));
+
+            List<CodeInstruction> codes = new(instructions);
+            int index = 0;
+
+            Tools.FindField(ref index, ref codes, findField: maxRange, addCode: GetAdditionalRange, errorMessage: "Couldn't find maximum range of scan node properties");
+            codes.Insert(index, new CodeInstruction(OpCodes.Ldarg_1));
+            Tools.FindField(ref index, ref codes, findField: requireLineOfSight, addCode: CanSeeScrapThroughWalls, andInstruction: true, notInstruction: true, errorMessage: "Couldn't find line of sight requirement of scan node properties");
+			codes.Insert(index, new CodeInstruction(OpCodes.Ldarg_1));
+			Tools.FindFieldReverse(ref index, ref codes, findField: requireLineOfSight, addCode: CanSeeEnemiesThroughWalls, andInstruction: true, notInstruction: true, errorMessage: "Couldn't find line of sight requirement of scan node properties");
+			codes.Insert(index+2, new CodeInstruction(OpCodes.Ldarg_1));
+            return codes;
+
 		}
-        [HarmonyPatch(nameof(HUDManager.UseSignalTranslatorServerRpc))]
+		[HarmonyPatch(nameof(HUDManager.UseSignalTranslatorServerRpc))]
         [HarmonyTranspiler]
         static IEnumerable<CodeInstruction> UseSignalTranslatorServerRpcTranspiler(IEnumerable<CodeInstruction> instructions)
         {

--- a/MoreShipUpgrades/Patches/HUD/HUDManagerPatcher.cs
+++ b/MoreShipUpgrades/Patches/HUD/HUDManagerPatcher.cs
@@ -5,6 +5,7 @@ using MoreShipUpgrades.Misc.Upgrades;
 using MoreShipUpgrades.Misc.Util;
 using MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades.Ship;
 using MoreShipUpgrades.UpgradeComponents.TierUpgrades.Items;
+using MoreShipUpgrades.UpgradeComponents.TierUpgrades.Items.TZP;
 using MoreShipUpgrades.UpgradeComponents.TierUpgrades.Player;
 using MoreShipUpgrades.UpgradeComponents.TierUpgrades.Ship;
 using System.Collections.Generic;
@@ -22,8 +23,8 @@ namespace MoreShipUpgrades.Patches.HUD
         static IEnumerable<CodeInstruction> MeetsScanNodeRequirementsTranspiler(IEnumerable<CodeInstruction> instructions)
         {
             MethodInfo GetAdditionalRange = typeof(BetterScanner).GetMethod(nameof(BetterScanner.GetAdditionalMaximumScanNodeRange));
-			MethodInfo CanSeeScrapThroughWalls = typeof(BetterScanner).GetMethod(nameof(BetterScanner.CanSeeScrapThroughWall));
-			MethodInfo CanSeeEnemiesThroughWalls = typeof(BetterScanner).GetMethod(nameof(BetterScanner.CanSeeEnemiesThroughWall));
+            MethodInfo CanSeeScrapThroughWalls = typeof(BetterScanner).GetMethod(nameof(BetterScanner.CanSeeScrapThroughWall));
+            MethodInfo CanSeeEnemiesThroughWalls = typeof(BetterScanner).GetMethod(nameof(BetterScanner.CanSeeEnemiesThroughWall));
 
             FieldInfo maxRange = typeof(ScanNodeProperties).GetField(nameof(ScanNodeProperties.maxRange));
             FieldInfo requireLineOfSight = typeof(ScanNodeProperties).GetField(nameof(ScanNodeProperties.requiresLineOfSight));
@@ -34,13 +35,13 @@ namespace MoreShipUpgrades.Patches.HUD
             Tools.FindField(ref index, ref codes, findField: maxRange, addCode: GetAdditionalRange, errorMessage: "Couldn't find maximum range of scan node properties");
             codes.Insert(index, new CodeInstruction(OpCodes.Ldarg_1));
             Tools.FindField(ref index, ref codes, findField: requireLineOfSight, addCode: CanSeeScrapThroughWalls, andInstruction: true, notInstruction: true, errorMessage: "Couldn't find line of sight requirement of scan node properties");
-			codes.Insert(index, new CodeInstruction(OpCodes.Ldarg_1));
-			Tools.FindFieldReverse(ref index, ref codes, findField: requireLineOfSight, addCode: CanSeeEnemiesThroughWalls, andInstruction: true, notInstruction: true, errorMessage: "Couldn't find line of sight requirement of scan node properties");
-			codes.Insert(index+2, new CodeInstruction(OpCodes.Ldarg_1));
+            codes.Insert(index, new CodeInstruction(OpCodes.Ldarg_1));
+            Tools.FindFieldReverse(ref index, ref codes, findField: requireLineOfSight, addCode: CanSeeEnemiesThroughWalls, andInstruction: true, notInstruction: true, errorMessage: "Couldn't find line of sight requirement of scan node properties");
+            codes.Insert(index + 2, new CodeInstruction(OpCodes.Ldarg_1));
             return codes;
 
-		}
-		[HarmonyPatch(nameof(HUDManager.UseSignalTranslatorServerRpc))]
+        }
+        [HarmonyPatch(nameof(HUDManager.UseSignalTranslatorServerRpc))]
         [HarmonyTranspiler]
         static IEnumerable<CodeInstruction> UseSignalTranslatorServerRpcTranspiler(IEnumerable<CodeInstruction> instructions)
         {
@@ -98,6 +99,19 @@ namespace MoreShipUpgrades.Patches.HUD
             List<CodeInstruction> codes = new(instructions);
             int index = 0;
             Tools.FindField(ref index, ref codes, findField: allPlayersDead, addCode: CheckIfKeptScrap, andInstruction: true, notInstruction: true);
+            return codes;
+        }
+
+        [HarmonyTranspiler]
+        [HarmonyPatch(nameof(HUDManager.SetScreenFilters))]
+        static IEnumerable<CodeInstruction> SetScreenFiltersTranspiler(IEnumerable<CodeInstruction> instructions)
+        {
+            MethodInfo TZPBufferDebuffEffectReduction = typeof(TZPBuffer).GetMethod(nameof(TZPBuffer.GetTZPBufferDebuffDurationReduction));
+
+            FieldInfo drunkness = typeof(PlayerControllerB).GetField(nameof(PlayerControllerB.drunkness));
+            List<CodeInstruction> codes = new(instructions);
+            int index = 0;
+            Tools.FindField(ref index, ref codes, findField: drunkness, addCode: TZPBufferDebuffEffectReduction, errorMessage: "Couldn't find the drunkness value which is used as intensity for screen filters related to TZP");
             return codes;
         }
     }

--- a/MoreShipUpgrades/Patches/Interactables/DepositItemsDeskPatcher.cs
+++ b/MoreShipUpgrades/Patches/Interactables/DepositItemsDeskPatcher.cs
@@ -27,7 +27,13 @@ namespace MoreShipUpgrades.Patches.Interactables
             codes.Insert(index, new CodeInstruction(OpCodes.Ldloc_2));
             codes.Insert(index, new CodeInstruction(OpCodes.Ldfld, itemsOnCounter));
             codes.Insert(index, new CodeInstruction(OpCodes.Ldarg_0));
-            return codes;
+			Tools.FindField(ref index, ref codes, findField: scrapValue, skip: true);
+			codes.Insert(index, new CodeInstruction(OpCodes.Call, checkCollectionScrap));
+			codes.Insert(index, new CodeInstruction(OpCodes.Callvirt, codes[index - 2].operand));
+			codes.Insert(index, new CodeInstruction(OpCodes.Ldloc_2));
+			codes.Insert(index, new CodeInstruction(OpCodes.Ldfld, itemsOnCounter));
+			codes.Insert(index, new CodeInstruction(OpCodes.Ldarg_0));
+			return codes;
         }
     }
 }

--- a/MoreShipUpgrades/Patches/Interactables/LandminePatcher.cs
+++ b/MoreShipUpgrades/Patches/Interactables/LandminePatcher.cs
@@ -1,0 +1,31 @@
+﻿using GameNetcodeStuff;
+using HarmonyLib;
+using MoreShipUpgrades.Misc.Util;
+using MoreShipUpgrades.UpgradeComponents.TierUpgrades.Player;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+
+namespace MoreShipUpgrades.Patches.Interactables
+{
+    [HarmonyPatch(typeof(Landmine))]
+    internal static class LandminePatcher
+    {
+        [HarmonyPatch(nameof(Landmine.SpawnExplosion))]
+        [HarmonyTranspiler]
+        static IEnumerable<CodeInstruction> SpawnExplosionTranspiler(IEnumerable<CodeInstruction> instructions)
+        {
+            MethodInfo explosionResistance = typeof(ExplosionResistance).GetMethod(nameof(ExplosionResistance.GetExplosionDamageResistance), BindingFlags.Public | BindingFlags.Static);
+            MethodInfo killPlayer = typeof(PlayerControllerB).GetMethod(nameof(PlayerControllerB.KillPlayer), BindingFlags.Public | BindingFlags.Instance);
+            MethodInfo damagePlayer = typeof(PlayerControllerB).GetMethod(nameof(PlayerControllerB.DamagePlayer), BindingFlags.Public | BindingFlags.Instance);
+
+            List<CodeInstruction> codes = new(instructions);
+            int index = 0;
+
+            Tools.FindArgumentField(ref index, ref codes, argumentIndex: 4, addCode: explosionResistance, errorMessage: "Could not find the argument related to damage number when near explosion");
+
+            return codes;
+        }
+    }
+}

--- a/MoreShipUpgrades/Patches/Interactables/TurretPatcher.cs
+++ b/MoreShipUpgrades/Patches/Interactables/TurretPatcher.cs
@@ -1,0 +1,23 @@
+﻿using HarmonyLib;
+using MoreShipUpgrades.Misc.Util;
+using MoreShipUpgrades.UpgradeComponents.TierUpgrades.Player;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace MoreShipUpgrades.Patches.Interactables
+{
+    [HarmonyPatch(typeof(Turret))]
+    internal class TurretPatcher
+    {
+        [HarmonyPatch(nameof(Turret.Update))]
+        [HarmonyTranspiler]
+        static IEnumerable<CodeInstruction> UpdateTranspiler(IEnumerable<CodeInstruction> instructions)
+        {
+            List<CodeInstruction> codes = new(instructions);
+            int index = 0;
+            Tools.FindInteger(ref index, ref codes, findValue: 50, addCode: typeof(BulletResistance).GetMethod(nameof(BulletResistance.GetBulletDamageResistance)), errorMessage: "Couldn't find the integer used to determine player damage");
+            Tools.FindInteger(ref index, ref codes, findValue: 50, addCode: typeof(BulletResistance).GetMethod(nameof(BulletResistance.GetBulletDamageResistance)), errorMessage: "Couldn't find the integer used to determine player damage");
+            return codes;
+        }
+    }
+}

--- a/MoreShipUpgrades/Patches/Items/ShotgunPatcher.cs
+++ b/MoreShipUpgrades/Patches/Items/ShotgunPatcher.cs
@@ -2,8 +2,10 @@
 using MoreShipUpgrades.Misc.Upgrades;
 using MoreShipUpgrades.Misc.Util;
 using MoreShipUpgrades.UpgradeComponents.TierUpgrades.Items.Shotgun;
+using MoreShipUpgrades.UpgradeComponents.TierUpgrades.Player;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Reflection.Emit;
 
 namespace MoreShipUpgrades.Patches.Items
 {
@@ -47,10 +49,11 @@ namespace MoreShipUpgrades.Patches.Items
             MethodInfo GetHollowPointDamageBoost = typeof(HollowPoint).GetMethod(nameof(HollowPoint.GetHollowPointDamageBoost));
             MethodInfo GetLongBarrelRangeBoost = typeof(LongBarrel).GetMethod(nameof(LongBarrel.GetLongBarrelRangeBoost));
             FieldInfo enemyColliders = typeof(ShotgunItem).GetField(nameof(ShotgunItem.enemyColliders), BindingFlags.Instance | BindingFlags.NonPublic);
+            MethodInfo bulletResistance = typeof(BulletResistance).GetMethod(nameof(BulletResistance.GetBulletDamageResistance));
 
             List<CodeInstruction> codes = new(instructions);
             int index = 0;
-
+            Tools.FindLocalField(ref index, ref codes, localIndex: 4,  addCode: bulletResistance, errorMessage: "Couldn't find the damage number used to damage players");
             Tools.FindField(ref index, ref codes, findField: enemyColliders, skip: true);
             Tools.FindFloat(ref index, ref codes, findValue: 15f, addCode: GetLongBarrelRangeBoost);
             Tools.FindFloat(ref index, ref codes, findValue: 3.7f, addCode: GetLongBarrelRangeBoost);

--- a/MoreShipUpgrades/Patches/PlayerController/PlayerControllerBPatcher.cs
+++ b/MoreShipUpgrades/Patches/PlayerController/PlayerControllerBPatcher.cs
@@ -1,22 +1,23 @@
 ﻿using GameNetcodeStuff;
 using HarmonyLib;
+using MoreShipUpgrades.Compat;
+using MoreShipUpgrades.Configuration;
+using MoreShipUpgrades.Extensions;
 using MoreShipUpgrades.Managers;
-using System.Collections.Generic;
-using System.Reflection;
-using System.Reflection.Emit;
-using System.Linq;
-using UnityEngine;
-using MoreShipUpgrades.UpgradeComponents.TierUpgrades;
-using MoreShipUpgrades.UpgradeComponents.TierUpgrades.AttributeUpgrades;
 using MoreShipUpgrades.Misc.Upgrades;
 using MoreShipUpgrades.Misc.Util;
-using MoreShipUpgrades.UpgradeComponents.TierUpgrades.Player;
-using MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades.Items;
-using MoreShipUpgrades.Compat;
 using MoreShipUpgrades.UpgradeComponents.Commands;
+using MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades.Items;
+using MoreShipUpgrades.UpgradeComponents.TierUpgrades;
+using MoreShipUpgrades.UpgradeComponents.TierUpgrades.AttributeUpgrades;
+using MoreShipUpgrades.UpgradeComponents.TierUpgrades.Player;
 using MoreShipUpgrades.UpgradeComponents.TierUpgrades.Ship;
-using MoreShipUpgrades.Extensions;
-using MoreShipUpgrades.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using UnityEngine;
 
 namespace MoreShipUpgrades.Patches.PlayerController
 {
@@ -391,10 +392,13 @@ namespace MoreShipUpgrades.Patches.PlayerController
 
         [HarmonyPatch(nameof(PlayerControllerB.DropAllHeldItems))]
         [HarmonyTranspiler]
+        [HarmonyDebug]
         static IEnumerable<CodeInstruction> DropAllHeldItemsTranspiler(IEnumerable<CodeInstruction> instructions)
-        {
-            MethodInfo CanHoldItem = typeof(FusionMatter).GetMethod(nameof(FusionMatter.CanHoldItem));
-            MethodInfo RemainIsHoldingObjectIfTeleporting = typeof(PlayerControllerBExtensions).GetMethod(nameof(PlayerControllerBExtensions.RemainIsHoldingObjectIfTeleporting));
+		{
+			MethodInfo CanHoldItem = typeof(FusionMatter).GetMethod(nameof(FusionMatter.CanHoldItem));
+
+			MethodInfo RemainItemSlotIfTeleporting = typeof(PlayerControllerBExtensions).GetMethod(nameof(PlayerControllerBExtensions.RemainItemSlotIfTeleporting));
+			MethodInfo RemainIsHoldingObjectIfTeleporting = typeof(PlayerControllerBExtensions).GetMethod(nameof(PlayerControllerBExtensions.RemainIsHoldingObjectIfTeleporting));
             MethodInfo RemainActivatingItemIfTeleporting = typeof(PlayerControllerBExtensions).GetMethod(nameof(PlayerControllerBExtensions.RemainActivatingItemIfTeleporting));
             MethodInfo RemainTwoHandedIfTeleporting = typeof(PlayerControllerBExtensions).GetMethod(nameof(PlayerControllerBExtensions.RemainTwoHandedIfTeleporting));
             MethodInfo RemainCarryWeightIfTeleporting = typeof(PlayerControllerBExtensions).GetMethod(nameof(PlayerControllerBExtensions.RemainCarryWeightIfTeleporting));
@@ -402,17 +406,42 @@ namespace MoreShipUpgrades.Patches.PlayerController
 
             FieldInfo isHoldingObject = typeof(PlayerControllerB).GetField(nameof(PlayerControllerB.isHoldingObject));
             FieldInfo playerBodyAnimator = typeof(PlayerControllerB).GetField(nameof(PlayerControllerB.playerBodyAnimator));
+            FieldInfo ItemOnlySlot = typeof(PlayerControllerB).GetField(nameof(PlayerControllerB.ItemOnlySlot));
 
-            List<CodeInstruction> codes = new(instructions);
+
+			List <CodeInstruction> codes = new(instructions);
             int index = 0;
             Tools.FindNull(ref index, ref codes, skip: true);
+			Tools.FindNull(ref index, ref codes, skip: true);
             index++;
-            codes.Insert(index, new CodeInstruction(OpCodes.And));
-            codes.Insert(index, new CodeInstruction(OpCodes.Not));
-            codes.Insert(index, new CodeInstruction(OpCodes.Call, CanHoldItem));
-            codes.Insert(index, new CodeInstruction(OpCodes.Ldarg_0));
+			codes.Insert(index, new CodeInstruction(OpCodes.And));
+			codes.Insert(index, new CodeInstruction(OpCodes.Not));
+			codes.Insert(index, new CodeInstruction(OpCodes.Call, CanHoldItem));
+			codes.Insert(index, new CodeInstruction(OpCodes.Ldarg_0));
+			codes.Insert(index, new CodeInstruction(OpCodes.Ldloc_0));
+
+			Tools.FindArgumentField(ref index, ref codes, argumentIndex: 2, skip: true);
+			Tools.FindArgumentField(ref index, ref codes, argumentIndex: 2, skip: true);
+			codes.Insert(index, new CodeInstruction(OpCodes.Or));
+			codes.Insert(index, new CodeInstruction(OpCodes.Call, CanHoldItem));
+			codes.Insert(index, new CodeInstruction(OpCodes.Ldarg_0));
             codes.Insert(index, new CodeInstruction(OpCodes.Ldloc_0));
-            Tools.FindField(ref index, ref codes, findField: isHoldingObject, addCode: RemainIsHoldingObjectIfTeleporting, andInstruction: true, notInstruction: true, requireInstance: true);
+			Tools.FindNull(ref index, ref codes, addCode: RemainItemSlotIfTeleporting, requireInstance: true);
+            codes.RemoveAt(index - 1);
+            index--;
+			codes.Insert(index+1, new CodeInstruction(OpCodes.Ldloc_1));
+            //Tools.FindNull(ref index, ref codes, skip: true);
+
+			Tools.FindNull(ref index, ref codes, skip: true);
+			index++;
+			codes.Insert(index, new CodeInstruction(OpCodes.And));
+			codes.Insert(index, new CodeInstruction(OpCodes.Not));
+			codes.Insert(index, new CodeInstruction(OpCodes.Call, CanHoldItem));
+			codes.Insert(index, new CodeInstruction(OpCodes.Ldarg_0));
+			codes.Insert(index, new CodeInstruction(OpCodes.Ldfld, ItemOnlySlot));
+			codes.Insert(index, new CodeInstruction(OpCodes.Ldarg_0));
+
+			Tools.FindField(ref index, ref codes, findField: isHoldingObject, addCode: RemainIsHoldingObjectIfTeleporting, andInstruction: true, notInstruction: true, requireInstance: true);
             Tools.FindField(ref index, ref codes, findField: playerBodyAnimator, skip: true);
             Tools.FindInteger(ref index, ref codes, findValue: 0, addCode: RemainActivatingItemIfTeleporting, orInstruction: true, requireInstance: true);
             Tools.FindInteger(ref index, ref codes, findValue: 0, addCode: RemainTwoHandedIfTeleporting, orInstruction: true, requireInstance: true);

--- a/MoreShipUpgrades/Patches/PlayerController/PlayerControllerBPatcher.cs
+++ b/MoreShipUpgrades/Patches/PlayerController/PlayerControllerBPatcher.cs
@@ -392,7 +392,6 @@ namespace MoreShipUpgrades.Patches.PlayerController
 
         [HarmonyPatch(nameof(PlayerControllerB.DropAllHeldItems))]
         [HarmonyTranspiler]
-        [HarmonyDebug]
         static IEnumerable<CodeInstruction> DropAllHeldItemsTranspiler(IEnumerable<CodeInstruction> instructions)
 		{
 			MethodInfo CanHoldItem = typeof(FusionMatter).GetMethod(nameof(FusionMatter.CanHoldItem));

--- a/MoreShipUpgrades/Patches/PlayerController/PlayerControllerBPatcher.cs
+++ b/MoreShipUpgrades/Patches/PlayerController/PlayerControllerBPatcher.cs
@@ -10,6 +10,7 @@ using MoreShipUpgrades.UpgradeComponents.Commands;
 using MoreShipUpgrades.UpgradeComponents.OneTimeUpgrades.Items;
 using MoreShipUpgrades.UpgradeComponents.TierUpgrades;
 using MoreShipUpgrades.UpgradeComponents.TierUpgrades.AttributeUpgrades;
+using MoreShipUpgrades.UpgradeComponents.TierUpgrades.Items.TZP;
 using MoreShipUpgrades.UpgradeComponents.TierUpgrades.Player;
 using MoreShipUpgrades.UpgradeComponents.TierUpgrades.Ship;
 using System;
@@ -243,12 +244,16 @@ namespace MoreShipUpgrades.Patches.PlayerController
             MethodInfo backMusclesStaminaWeight = typeof(BackMuscles).GetMethod(nameof(BackMuscles.DecreaseStrain));
             MethodInfo medicalNanobotsHealthRegenMethod = typeof(MedicalNanobots).GetMethod(nameof(MedicalNanobots.GetIncreasedHealthRegeneration));
             MethodInfo effectiveBandaidsHealthAmountMethod = typeof(EffectiveBandaids).GetMethod(nameof(EffectiveBandaids.GetIncreasedHealthRegenerated));
+            MethodInfo TZPBufferBuffEffectIncrease = typeof(TZPBuffer).GetMethod(nameof(TZPBuffer.GetTZPBufferBuffEffectIncrease));
 
             FieldInfo sprintTime = typeof(PlayerControllerB).GetField(nameof(PlayerControllerB.sprintTime));
             FieldInfo carryWeight = typeof(PlayerControllerB).GetField(nameof(PlayerControllerB.carryWeight));
 
+            MethodInfo Abs = typeof(Mathf).GetMethod(nameof(Mathf.Abs), [typeof(float)]);
+
             List<CodeInstruction> codes = new(instructions);
             int index = 0;
+            Tools.FindMethod(ref index, ref codes, findMethod: Abs, addCode: TZPBufferBuffEffectIncrease, errorMessage: "Couldn't find the value used to decrement the effect of stamina efficiency while on TZP");
             Tools.FindField(ref index, ref codes, findField: sprintTime, addCode: additionalSprintTime, errorMessage: "Couldn't find the first occurence of sprintTime field");
             Tools.FindDiv(ref index, ref codes, addCode: sickBeatsDrainMethod, errorMessage: "Couldn't find first mul instruction to include our drain method from Sick Beats");
             Tools.FindField(ref index, ref codes, findField: carryWeight, addCode: backMusclesStaminaWeight, errorMessage: "Couldn't find the occurence of carryWeight field");
@@ -326,6 +331,7 @@ namespace MoreShipUpgrades.Patches.PlayerController
             MethodInfo uphillSlopeMultiplier = typeof(HikingBoots).GetMethod(nameof(HikingBoots.ReduceUphillSlopeDebuff));
             MethodInfo ReduceCrouchMovementSpeedDebuff = typeof(CarbonKneejoints).GetMethod(nameof(CarbonKneejoints.ReduceCrouchMovementSpeedDebuff));
             MethodInfo ReduceFallDamage = typeof(ReinforcedBoots).GetMethod(nameof(ReinforcedBoots.ReduceFallDamage));
+            MethodInfo TZPBufferBuffEffectIncrease = typeof(TZPBuffer).GetMethod(nameof(TZPBuffer.GetTZPBufferBuffDurationIncrease));
 
             FieldInfo carryWeight = typeof(PlayerControllerB).GetField(nameof(PlayerControllerB.carryWeight));
             FieldInfo movementSpeed = typeof(PlayerControllerB).GetField(nameof(PlayerControllerB.movementSpeed));
@@ -340,6 +346,7 @@ namespace MoreShipUpgrades.Patches.PlayerController
             Tools.FindField(ref index, ref codes, findField: movementSpeed, addCode: additionalMovement, errorMessage: "Couldn't find second occurence of movement speed field");
             Tools.FindField(ref index, ref codes, findField: carryWeight, addCode: reduceCarryLoss, errorMessage: "Couldn't find first carryWeight occurence");
             Tools.FindFloat(ref index, ref codes, findValue: 1.5f, addCode: ReduceCrouchMovementSpeedDebuff, errorMessage: "Couldn't find the movement speed loss value while crouching");
+            Tools.FindFloat(ref index, ref codes, findValue: 1f, addCode: TZPBufferBuffEffectIncrease, errorMessage: "Couldn't find the value used to increment the effect of movement speed while on TZP");
             Tools.FindField(ref index, ref codes, findField: slopeIntensity, skip: true, errorMessage: "Couldn't find skip slope Intensity");
             Tools.FindField(ref index, ref codes, findField: slopeModifier, addCode: uphillSlopeMultiplier, errorMessage: "Couldn't find occurence of slopeModifier");
             Tools.FindFloat(ref index, ref codes, findValue: 5f, addCode: additionalTractionForce, errorMessage: "Couldn't find the numerator used when sprinting");

--- a/MoreShipUpgrades/Patches/PlayerController/PlayerControllerBPatcher.cs
+++ b/MoreShipUpgrades/Patches/PlayerController/PlayerControllerBPatcher.cs
@@ -444,7 +444,8 @@ namespace MoreShipUpgrades.Patches.PlayerController
             Tools.FindField(ref index, ref codes, findField: playerBodyAnimator, skip: true);
             Tools.FindInteger(ref index, ref codes, findValue: 0, addCode: RemainActivatingItemIfTeleporting, orInstruction: true, requireInstance: true);
             Tools.FindInteger(ref index, ref codes, findValue: 0, addCode: RemainTwoHandedIfTeleporting, orInstruction: true, requireInstance: true);
-            Tools.FindFloat(ref index, ref codes, findValue: 1f, addCode: RemainCarryWeightIfTeleporting, requireInstance: true, instanceBefore: true);
+			Tools.FindInteger(ref index, ref codes, findValue: 0, addCode: RemainTwoHandedIfTeleporting, orInstruction: true, requireInstance: true);
+			Tools.FindFloat(ref index, ref codes, findValue: 1f, addCode: RemainCarryWeightIfTeleporting, requireInstance: true, instanceBefore: true);
             Tools.FindNull(ref index, ref codes, addCode: RemainCurrentlyHeldObjectServerIfTeleporting, requireInstance: true, instanceBefore: true);
             return codes;
         }

--- a/MoreShipUpgrades/Patches/PlayerController/PlayerControllerBPatcher.cs
+++ b/MoreShipUpgrades/Patches/PlayerController/PlayerControllerBPatcher.cs
@@ -449,5 +449,28 @@ namespace MoreShipUpgrades.Patches.PlayerController
             Tools.FindNull(ref index, ref codes, addCode: RemainCurrentlyHeldObjectServerIfTeleporting, requireInstance: true, instanceBefore: true);
             return codes;
         }
+
+
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(PlayerControllerB.KillPlayer))]
+        static bool KillPlayerPrefix(PlayerControllerB __instance, Vector3 bodyVelocity, bool spawnBody, CauseOfDeath causeOfDeath, int deathAnimation, Vector3 positionOffset)
+        {
+            return PreventInstantKill(ref __instance, bodyVelocity, spawnBody, causeOfDeath, deathAnimation, positionOffset);
+        }
+
+        static bool PreventInstantKill(ref PlayerControllerB __instance, Vector3 bodyVelocity, bool spawnBody, CauseOfDeath causeOfDeath, int deathAnimation, Vector3 positionOffset)
+        {
+            switch (causeOfDeath)
+            {
+                case CauseOfDeath.Blast:
+                    {
+                        if (!BaseUpgrade.GetActiveUpgrade(ExplosionResistance.UPGRADE_NAME)) return true;
+                        Plugin.mls.LogInfo($"Kill player fired due to explosion with {ExplosionResistance.UPGRADE_NAME} upgrade on, mitigating 100 damage instead of instant kill...");
+                        __instance.DamagePlayer(ExplosionResistance.GetExplosionDamageResistance(100), hasDamageSFX: true, callRPC: true, causeOfDeath: causeOfDeath, deathAnimation: deathAnimation, fallDamage: false, force: bodyVelocity);
+                        return false;
+                    }
+                default: return true;
+            }
+        }
     }
 }

--- a/MoreShipUpgrades/Patches/TerminalComponents/TerminalPatcher.cs
+++ b/MoreShipUpgrades/Patches/TerminalComponents/TerminalPatcher.cs
@@ -34,6 +34,7 @@ namespace MoreShipUpgrades.Patches.TerminalComponents
 
         [HarmonyTranspiler]
         [HarmonyPatch(nameof(Terminal.SetItemSales))]
+        [HarmonyDebug]
         static IEnumerable<CodeInstruction> SetItemSalesTranspiler(IEnumerable<CodeInstruction> instructions)
         {
             MethodInfo bargainConnectionsAmount = typeof(BargainConnections).GetMethod(nameof(BargainConnections.GetBargainConnectionsAdditionalItems));
@@ -54,7 +55,9 @@ namespace MoreShipUpgrades.Patches.TerminalComponents
             Tools.FindInteger(ref index, ref codes, findValue: 0, skip: true);
             Tools.FindInteger(ref index, ref codes, 0, addCode: guaranteedMinimumSale, errorMessage: "Couldn't find minimum sale percentage");
             codes.Insert(index, new CodeInstruction(OpCodes.Ldloc_S, 7));
-            return codes;
+			Tools.FindInteger(ref index, ref codes, 0, addCode: guaranteedMinimumSale, errorMessage: "Couldn't find minimum sale percentage");
+			codes.Insert(index, new CodeInstruction(OpCodes.Ldloc_S, 7));
+			return codes;
         }
         [HarmonyTranspiler]
         [HarmonyPatch(nameof(Terminal.ParsePlayerSentence))]

--- a/MoreShipUpgrades/Patches/TerminalComponents/TerminalPatcher.cs
+++ b/MoreShipUpgrades/Patches/TerminalComponents/TerminalPatcher.cs
@@ -34,7 +34,6 @@ namespace MoreShipUpgrades.Patches.TerminalComponents
 
         [HarmonyTranspiler]
         [HarmonyPatch(nameof(Terminal.SetItemSales))]
-        [HarmonyDebug]
         static IEnumerable<CodeInstruction> SetItemSalesTranspiler(IEnumerable<CodeInstruction> instructions)
         {
             MethodInfo bargainConnectionsAmount = typeof(BargainConnections).GetMethod(nameof(BargainConnections.GetBargainConnectionsAdditionalItems));

--- a/MoreShipUpgrades/UI/Application/ContractApplication.cs
+++ b/MoreShipUpgrades/UI/Application/ContractApplication.cs
@@ -149,14 +149,14 @@ namespace MoreShipUpgrades.UI.Application
                         name: RANDOM_MOON_CURSOR_ELEMENT,
                         description: string.Empty,
                         action: ConfirmRandomMoonContract,
-                        active: (_) => terminal.groupCredits >= UpgradeBus.Instance.PluginConfiguration.ContractsConfiguration.RandomPrice,
+                        active: (_) => terminal.groupCredits >= UpgradeBus.Instance.PluginConfiguration.ContractsConfiguration.RandomPrice || UpgradeBus.Instance.AllowOverspending,
                         selectInactive: true
                         ),
                 CursorElement.Create(
                         name: SPECIFIED_MOON_CURSOR_ELEMENT,
                         description: string.Empty,
                         action: PickSpecifiedMoonContract,
-                        active: (_) => terminal.groupCredits >= UpgradeBus.Instance.PluginConfiguration.ContractsConfiguration.SpecifyPrice,
+                        active: (_) => terminal.groupCredits >= UpgradeBus.Instance.PluginConfiguration.ContractsConfiguration.SpecifyPrice || UpgradeBus.Instance.AllowOverspending,
                         selectInactive: true
                         ),
                 CursorElement.Create(
@@ -181,7 +181,7 @@ namespace MoreShipUpgrades.UI.Application
         {
             IScreen previousScreen = currentScreen;
             BaseCursorMenu<CursorElement> previousCursorMenu = currentCursorMenu;
-            if (terminal.groupCredits < UpgradeBus.Instance.PluginConfiguration.ContractsConfiguration.SpecifyPrice)
+            if (terminal.groupCredits < UpgradeBus.Instance.PluginConfiguration.ContractsConfiguration.SpecifyPrice && !UpgradeBus.Instance.AllowOverspending)
             {
                 ErrorMessage(MAIN_MENU_TITLE, () => SwitchScreen(previousScreen, previousCursorMenu, true), "Not enough credits to purchase a specified moon contract.");
                 return;
@@ -254,7 +254,7 @@ namespace MoreShipUpgrades.UI.Application
         {
             IScreen previousScreen = currentScreen;
             BaseCursorMenu<CursorElement> previousCursorMenu = currentCursorMenu;
-            if (terminal.groupCredits < UpgradeBus.Instance.PluginConfiguration.ContractsConfiguration.RandomPrice)
+            if (terminal.groupCredits < UpgradeBus.Instance.PluginConfiguration.ContractsConfiguration.RandomPrice && !UpgradeBus.Instance.AllowOverspending)
             {
                 ErrorMessage(MAIN_MENU_TITLE, () => SwitchScreen(previousScreen, previousCursorMenu, true), "Not enough credits to purchase a randomized moon contract.");
                 return;

--- a/MoreShipUpgrades/UI/Application/ConvertPlayerCreditApplication.cs
+++ b/MoreShipUpgrades/UI/Application/ConvertPlayerCreditApplication.cs
@@ -103,7 +103,7 @@ namespace MoreShipUpgrades.UI.Application
 			}
 			int requiredCredits = CurrencyManager.Instance.GetRequiredCreditsFromCurrencyConversion(count);
 
-			if (terminal.groupCredits < requiredCredits)
+			if (terminal.groupCredits < requiredCredits && !UpgradeBus.Instance.AllowOverspending)
             {
                 ErrorMessage(title: TITLE, description: "", backAction, error: "Not enough Company Credits to perform conversion.");
                 return;
@@ -117,7 +117,7 @@ namespace MoreShipUpgrades.UI.Application
         private bool HasEnoughCreditsToConvert(int amount = MINIMUM_PC)
         {
             if (CurrencyManager.Instance.BlockExceedOperations(amount)) return false;
-            return terminal.groupCredits >= CurrencyManager.Instance.GetRequiredCreditsFromCurrencyConversion(amount);
+            return terminal.groupCredits >= CurrencyManager.Instance.GetRequiredCreditsFromCurrencyConversion(amount) || UpgradeBus.Instance.AllowOverspending;
         }
 
         private bool HasEnoughPCsToConvert(int amount = 0)

--- a/MoreShipUpgrades/UI/Application/UpgradeStoreApplication.cs
+++ b/MoreShipUpgrades/UI/Application/UpgradeStoreApplication.cs
@@ -223,7 +223,7 @@ namespace MoreShipUpgrades.UI.Application
 
             int groupCredits = UpgradeBus.Instance.GetTerminal().groupCredits;
             int price = node.GetCurrentPrice();
-            bool canBeBoughtWithGroupCredits = groupCredits >= price;
+            bool canBeBoughtWithGroupCredits = groupCredits >= price || UpgradeBus.Instance.AllowOverspending;
 
             if (!node.AlternateCurrency) return canBeBoughtWithGroupCredits;
 
@@ -248,7 +248,7 @@ namespace MoreShipUpgrades.UI.Application
 
             int groupCredits = UpgradeBus.Instance.GetTerminal().groupCredits;
             int price = node.GetCurrentPrice();
-            bool canBeBoughtWithGroupCredits = groupCredits >= price;
+            bool canBeBoughtWithGroupCredits = groupCredits >= price || UpgradeBus.Instance.AllowOverspending;
             return canBeBoughtWithGroupCredits;
         }
 
@@ -294,7 +294,7 @@ namespace MoreShipUpgrades.UI.Application
             {
                 case PurchaseMode.CompanyCredits:
                     {
-                        if (groupCredits < price && !node.Refundable)
+                        if (groupCredits < price && !node.Refundable && !UpgradeBus.Instance.AllowOverspending)
                         {
                             ErrorMessage(node.Name, finalText, backAction, LguConstants.NOT_ENOUGH_CREDITS);
                             return;
@@ -320,7 +320,7 @@ namespace MoreShipUpgrades.UI.Application
                     }
                 case PurchaseMode.Both:
                     {
-                        if (groupCredits >= price) break;
+                        if (groupCredits >= price || UpgradeBus.Instance.AllowOverspending) break;
 
                         if (!node.AlternateCurrency && !node.Refundable)
                         {
@@ -458,7 +458,7 @@ namespace MoreShipUpgrades.UI.Application
 		void ConfirmPurchaseUpgrade(CustomTerminalNode node, int price, Action backAction)
         {
             int groupCredits = UpgradeBus.Instance.GetTerminal().groupCredits;
-            if (groupCredits < price)
+            if (groupCredits < price && !UpgradeBus.Instance.AllowOverspending)
             {
                 ErrorMessage(node.Name, backAction, LguConstants.NOT_ENOUGH_CREDITS);
                 return;

--- a/MoreShipUpgrades/UI/Cursor/UpgradeCursorElement.cs
+++ b/MoreShipUpgrades/UI/Cursor/UpgradeCursorElement.cs
@@ -53,7 +53,7 @@ namespace MoreShipUpgrades.UI.Cursor
             if (!Node.AlternateCurrency || Node.PurchaseMode != PurchaseMode.AlternateCurrency)
             {
                 int currentCredits = UpgradeBus.Instance.GetTerminal().groupCredits;
-                if (price <= currentCredits)
+                if (price <= currentCredits || UpgradeBus.Instance.AllowOverspending)
                 {
                     sb.Append(price);
                     sb.Append("$");

--- a/MoreShipUpgrades/UpgradeComponents/Items/NightVisionGoggles.cs
+++ b/MoreShipUpgrades/UpgradeComponents/Items/NightVisionGoggles.cs
@@ -48,7 +48,7 @@ namespace MoreShipUpgrades.UpgradeComponents.Items
                 HUDManager.Instance.chatText.text += "<color=#FF0000>Night vision is already active!</color>";
                 return;
             }
-            if (UpgradeBus.GetUpgradeNodes().First((x) => x.OriginalName == NightVision.UPGRADE_NAME).SharedUpgrade)
+            if (!UpgradeBus.Instance.PluginConfiguration.NightVisionUpgradeConfiguration.IndividualNV)
             {
                 NightVision.Instance.EnableNightVisionServerRpc();
             }

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/Items/TZP/TZPBuffer.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/Items/TZP/TZPBuffer.cs
@@ -1,0 +1,112 @@
+﻿using CSync.Lib;
+using MoreShipUpgrades.Configuration.Upgrades.Custom;
+using MoreShipUpgrades.Configuration.Upgrades.Interfaces.TierUpgrades;
+using MoreShipUpgrades.Managers;
+using MoreShipUpgrades.Misc.Upgrades;
+using MoreShipUpgrades.Misc.Util;
+using MoreShipUpgrades.UI.TerminalNodes;
+using MoreShipUpgrades.UpgradeComponents.TierUpgrades.Items.Shotgun;
+using System.Text;
+using UnityEngine;
+
+namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades.Items.TZP
+{
+    internal class TZPBuffer : TierUpgrade
+    {
+        internal const string UPGRADE_NAME = "TZP Buffer";
+        internal const string DEFAULT_PRICES = "100,200,300";
+
+        internal override void Start()
+        {
+            upgradeName = UPGRADE_NAME;
+            overridenUpgradeName = GetConfiguration().TZPBufferConfiguration.OverrideName;
+            base.Start();
+        }
+        public override bool CanInitializeOnStart
+        {
+            get
+            {
+                ITierUpgradeConfiguration upgradeConfig = GetConfiguration().TZPBufferConfiguration;
+                string[] prices = upgradeConfig.Prices.Value.Split(',');
+                return prices.Length == 0 || (prices.Length == 1 && (prices[0].Length == 0 || prices[0] == "0"));
+            }
+        }
+        string GetTZPBufferInfo(int level, int price)
+        {
+            static float buffEffectInfo(int level)
+            {
+                TZPBufferUpgradeConfiguration config = GetConfiguration().TZPBufferConfiguration;
+                (SyncedEntry<int>, SyncedEntry<int>) buffDurationPair = config.GetEffectPair(0);
+                return buffDurationPair.Item1.Value + (level * buffDurationPair.Item2.Value);
+            }
+            static float debuffEffectInfo(int level)
+            {
+                TZPBufferUpgradeConfiguration config = GetConfiguration().TZPBufferConfiguration;
+                (SyncedEntry<int>, SyncedEntry<int>) debuffDurationPair = config.GetEffectPair(1);
+                return debuffDurationPair.Item1.Value + (level * debuffDurationPair.Item2.Value);
+            }
+            StringBuilder sb = new();
+            sb.Append($"LVL {level} - {GetUpgradePrice(price, GetConfiguration().TZPBufferConfiguration.PurchaseMode)}: Upgrades to TZP Inhaler:\n");
+            sb.Append($"- Increases the buff effect (movement speed and stamina usage reduction) by {buffEffectInfo(level)}%\n");
+            sb.Append($"- Decreases the debuff effect (visual impairment) by {debuffEffectInfo(level)}%\n");
+            sb.Append('\n');
+            return sb.ToString();
+        }
+        public override string GetDisplayInfo(int initialPrice = -1, int maxLevels = -1, int[] incrementalPrices = null)
+        {
+            StringBuilder sb = new();
+            sb.Append(GetTZPBufferInfo(1, initialPrice));
+            for (int i = 0; i < maxLevels; i++)
+                sb.Append(GetTZPBufferInfo(i + 2, incrementalPrices[i]));
+            return sb.ToString();
+        }
+        public static float ComputeTZPBufferBuffEffectIncrease()
+        {
+            TZPBufferUpgradeConfiguration upgradeConfig = GetConfiguration().TZPBufferConfiguration;
+            (SyncedEntry<int>, SyncedEntry<int>) buffDurationPair = upgradeConfig.GetEffectPair(0);
+            return (buffDurationPair.Item1.Value + (GetUpgradeLevel(UPGRADE_NAME) * buffDurationPair.Item2.Value)) / 100f;
+        }
+        public static float ComputeTZPBufferDeBuffEffectReduction()
+        {
+            TZPBufferUpgradeConfiguration upgradeConfig = GetConfiguration().TZPBufferConfiguration;
+            (SyncedEntry<int>, SyncedEntry<int>) debuffDurationPair = upgradeConfig.GetEffectPair(1);
+            return (debuffDurationPair.Item1.Value + (GetUpgradeLevel(UPGRADE_NAME) * debuffDurationPair.Item2.Value)) / 100f;
+        }
+        public static float GetTZPBufferBuffDurationIncrease(float defaultValue)
+        {
+            if (!GetConfiguration().TZPBufferConfiguration.Enabled) return defaultValue;
+            if (!GetActiveUpgrade(UPGRADE_NAME)) return defaultValue;
+            float additionalDamage = ComputeTZPBufferBuffEffectIncrease();
+            return defaultValue + defaultValue * additionalDamage;
+        }
+        public static float GetTZPBufferBuffEffectIncrease(float defaultValue)
+        {
+            if (!GetConfiguration().TZPBufferConfiguration.Enabled) return defaultValue;
+            if (!GetActiveUpgrade(UPGRADE_NAME)) return defaultValue;
+            float additionalDamage = ComputeTZPBufferBuffEffectIncrease();
+            return Mathf.Clamp(defaultValue - defaultValue * additionalDamage, 0f, float.MaxValue);
+        }
+        public static float GetTZPBufferDebuffDurationReduction(float defaultValue)
+        {
+            if (!GetConfiguration().TZPBufferConfiguration.Enabled) return defaultValue;
+            if (!GetActiveUpgrade(UPGRADE_NAME)) return defaultValue;
+            float additionalDamage = ComputeTZPBufferDeBuffEffectReduction();
+            return Mathf.Clamp(defaultValue - defaultValue * additionalDamage, 0f, float.MaxValue);
+        }
+        public new static (string, string[]) RegisterScrapToUpgrade()
+        {
+            return (UPGRADE_NAME, GetConfiguration().TZPBufferConfiguration.ItemProgressionItems.Value.Split(","));
+        }
+        public new static void RegisterUpgrade()
+        {
+            GameObject prefab = ItemManager.CreateNetworkPrefab(UPGRADE_NAME);
+            prefab.AddComponent<TZPBuffer>();
+            ItemManager.RegisterNetworkPrefab(prefab);
+            Plugin.networkPrefabs[UPGRADE_NAME] = prefab;
+        }
+        public new static CustomTerminalNode RegisterTerminalNode()
+        {
+            return UpgradeBus.Instance.SetupMultiplePurchaseableTerminalNode(UPGRADE_NAME, GetConfiguration().TZPBufferConfiguration, Plugin.networkPrefabs[UPGRADE_NAME]);
+        }
+    }
+}

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/Player/Beekeeper.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/Player/Beekeeper.cs
@@ -20,7 +20,7 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
         internal const string WORLD_BUILDING_TEXT = "\n\nOn-the-job training package that instructs {0} how to more safely and efficiently handle Circuit Bee Nests." +
             " Departments with a LVL {1} Certification in Circuit Bee Nest Handling earn an extra commission for every Nest they sell.\n\n";
 
-        protected bool CanIncreaseHivePrice => GetUpgradeLevel(UPGRADE_NAME) == GetConfiguration().BeekeeperConfiguration.Prices.Value.Split(',').Length;
+        protected bool CanIncreaseHivePrice => GetActiveUpgrade(UPGRADE_NAME) && (GetUpgradeLevel(UPGRADE_NAME) + 1 == GetConfiguration().BeekeeperConfiguration.Prices.Value.Split(',').Length);
 
         void Awake()
         {

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/Player/BetterScanner.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/Player/BetterScanner.cs
@@ -61,6 +61,43 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades.Player
         {
             LguScanNodeProperties.RemoveScanNode(steamValveHazard.gameObject);
         }
+
+        public static int GetAdditionalMaximumScanNodeRange(int defaultValue, ScanNodeProperties scanNode)
+        {
+            if (!GetActiveUpgrade(UPGRADE_NAME)) return defaultValue;
+            float rangeIncrease;
+            switch(scanNode.headerText.ToLower().Trim())
+            {
+                case "main entrance":
+                case "ship":
+                {
+                    rangeIncrease = GetConfiguration().BetterScannerUpgradeConfiguration.OutsideNodesRangeIncrease;
+                    break;
+                }
+                default:
+                {
+                    rangeIncrease = GetConfiguration().BetterScannerUpgradeConfiguration.NodeRangeIncrease;
+                    break;
+                }
+
+			}
+			return Mathf.CeilToInt(defaultValue + rangeIncrease);
+		}
+
+        public static bool CanSeeScrapThroughWall(ScanNodeProperties scanNode)
+        {
+            return GetActiveUpgrade(UPGRADE_NAME) &&
+            GetUpgradeLevel(UPGRADE_NAME) == 2 &&
+            scanNode.nodeType == (int)LguScanNodeProperties.NodeType.SCRAP;
+        }
+
+        public static bool CanSeeEnemiesThroughWall(ScanNodeProperties scanNode)
+        {
+            return GetActiveUpgrade(UPGRADE_NAME) &&
+            GetUpgradeLevel(UPGRADE_NAME) == 2 &&
+            scanNode.nodeType == (int)LguScanNodeProperties.NodeType.DANGER &&
+            GetConfiguration().BetterScannerUpgradeConfiguration.SeeEnemiesThroughWalls;
+        }
         public static string GetBetterScannerInfo(int level, int price)
         {
             BetterScannerUpgradeConfiguration config = GetConfiguration().BetterScannerUpgradeConfiguration;

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/Player/BiggerLungs.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/Player/BiggerLungs.cs
@@ -62,23 +62,23 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades
                 (SyncedEntry<float>, SyncedEntry<float>) additionalStaminaPair = config.GetEffectPair(0);
                 return additionalStaminaPair.Item1.Value + (level * additionalStaminaPair.Item2.Value);
             }
-            static float costReductionInfo(int level)
-            {
-                BiggerLungsUpgradeConfiguration config = GetConfiguration().BiggerLungsConfiguration;
-                (SyncedEntry<float>, SyncedEntry<float>) jumpReductionPair = config.GetEffectPair(2);
-                return 1f - (jumpReductionPair.Item1.Value - (level * jumpReductionPair.Item2.Value));
-            }
             static float staminaRegenerationInfo(int level)
             {
                 BiggerLungsUpgradeConfiguration config = GetConfiguration().BiggerLungsConfiguration;
                 (SyncedEntry<float>, SyncedEntry<float>) staminaRegenPair = config.GetEffectPair(1);
                 return staminaRegenPair.Item1.Value + (level * staminaRegenPair.Item2.Value) - 1f;
             }
+            static float costReductionInfo(int level)
+            {
+                BiggerLungsUpgradeConfiguration config = GetConfiguration().BiggerLungsConfiguration;
+                (SyncedEntry<float>, SyncedEntry<float>) jumpReductionPair = config.GetEffectPair(2);
+                return 1f - (jumpReductionPair.Item1.Value - (level * jumpReductionPair.Item2.Value));
+            }
             StringBuilder sb = new();
             sb.AppendFormat(AssetBundleHandler.GetInfoFromJSON(UPGRADE_NAME), level, GetUpgradePrice(price, GetConfiguration().BiggerLungsConfiguration.PurchaseMode), infoFunction(level - 1));
             BiggerLungsUpgradeConfiguration config = GetConfiguration().BiggerLungsConfiguration;
-            if (level >= config.StaminaRegenerationLevel) sb.Append($"Stamina regeneration is increased by {Mathf.FloorToInt(staminaRegenerationInfo(level) * 100f)}%\n");
-            if (level >= config.JumpReductionLevel.Value) sb.Append($"Stamina used when jumping is reduced by {Mathf.FloorToInt(costReductionInfo(level) * 100f)}%\n");
+            if (level >= config.StaminaRegenerationLevel) sb.Append($"Stamina regeneration is increased by {Mathf.RoundToInt(staminaRegenerationInfo(level-config.StaminaRegenerationLevel) * 100f)}%\n");
+            if (level >= config.JumpReductionLevel.Value) sb.Append($"Stamina used when jumping is reduced by {Mathf.RoundToInt(costReductionInfo(level-config.JumpReductionLevel) * 100f)}%\n");
             return sb.ToString();
         }
 

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/Player/BulletResistance.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/Player/BulletResistance.cs
@@ -1,0 +1,65 @@
+﻿using MoreShipUpgrades.Configuration.Upgrades.Interfaces.TierUpgrades;
+using MoreShipUpgrades.Managers;
+using MoreShipUpgrades.Misc.Upgrades;
+using MoreShipUpgrades.Misc.Util;
+using MoreShipUpgrades.UI.TerminalNodes;
+using UnityEngine;
+
+namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades.Player
+{
+    internal class BulletResistance : TierUpgrade
+    {
+        internal const string UPGRADE_NAME = "Bullet Resistance";
+        internal const string DEFAULT_PRICES = "200, 250, 350";
+
+        internal override void Start()
+        {
+            upgradeName = UPGRADE_NAME;
+            overridenUpgradeName = GetConfiguration().BulletResistanceConfiguration.OverrideName;
+            base.Start();
+        }
+        public override string GetDisplayInfo(int initialPrice = -1, int maxLevels = -1, int[] incrementalPrices = null)
+        {
+            float infoFunction(int level)
+            {
+                ITierEffectUpgradeConfiguration<int> upgradeConfig = GetConfiguration().BulletResistanceConfiguration;
+                return upgradeConfig.InitialEffect.Value + (level * upgradeConfig.IncrementalEffect.Value);
+            }
+            const string infoFormat = "LVL {0} - {1} - Increases the damage resistance to bullets by {2}\n";
+            return Tools.GenerateInfoForUpgrade(infoFormat, initialPrice, incrementalPrices, infoFunction, purchaseMode: GetConfiguration().BulletResistanceConfiguration.PurchaseMode);
+        }
+        public static int GetBulletDamageResistance(int defaultValue)
+        {
+            ITierEffectUpgradeConfiguration<int> upgradeConfig = GetConfiguration().BulletResistanceConfiguration;
+            if (!upgradeConfig.Enabled) return defaultValue;
+            if (!GetActiveUpgrade(UPGRADE_NAME)) return defaultValue;
+            int bulletDamageResistance = upgradeConfig.InitialEffect + (GetUpgradeLevel(UPGRADE_NAME) * upgradeConfig.IncrementalEffect);
+            return defaultValue - (Mathf.RoundToInt(defaultValue * (bulletDamageResistance / 100f)));
+        }
+
+        public override bool CanInitializeOnStart
+        {
+            get
+            {
+                ITierUpgradeConfiguration upgradeConfig = GetConfiguration().BulletResistanceConfiguration;
+                string[] prices = upgradeConfig.Prices.Value.Split(',');
+                return prices.Length == 0 || (prices.Length == 1 && (prices[0].Length == 0 || prices[0] == "0"));
+            }
+        }
+        public new static (string, string[]) RegisterScrapToUpgrade()
+        {
+            return (UPGRADE_NAME, GetConfiguration().BulletResistanceConfiguration.ItemProgressionItems.Value.Split(","));
+        }
+        public new static void RegisterUpgrade()
+        {
+            GameObject prefab = ItemManager.CreateNetworkPrefab(UPGRADE_NAME);
+            prefab.AddComponent<BulletResistance>();
+            ItemManager.RegisterNetworkPrefab(prefab);
+            Plugin.networkPrefabs[UPGRADE_NAME] = prefab;
+        }
+        public new static CustomTerminalNode RegisterTerminalNode()
+        {
+            return UpgradeBus.Instance.SetupMultiplePurchaseableTerminalNode(UPGRADE_NAME, GetConfiguration().BulletResistanceConfiguration, Plugin.networkPrefabs[UPGRADE_NAME]);
+        }
+    }
+}

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/Player/ExplosionResistance.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/Player/ExplosionResistance.cs
@@ -1,0 +1,65 @@
+﻿using MoreShipUpgrades.Configuration.Upgrades.Interfaces.TierUpgrades;
+using MoreShipUpgrades.Managers;
+using MoreShipUpgrades.Misc.Upgrades;
+using MoreShipUpgrades.Misc.Util;
+using MoreShipUpgrades.UI.TerminalNodes;
+using UnityEngine;
+
+namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades.Player
+{
+    internal class ExplosionResistance : TierUpgrade
+    {
+        internal const string UPGRADE_NAME = "Explosion Resistance";
+        internal const string DEFAULT_PRICES = "150, 200, 250";
+
+        internal override void Start()
+        {
+            upgradeName = UPGRADE_NAME;
+            overridenUpgradeName = GetConfiguration().ExplosionReistanceConfiguration.OverrideName;
+            base.Start();
+        }
+        public override string GetDisplayInfo(int initialPrice = -1, int maxLevels = -1, int[] incrementalPrices = null)
+        {
+            float infoFunction(int level)
+            {
+                ITierEffectUpgradeConfiguration<int> upgradeConfig = GetConfiguration().ExplosionReistanceConfiguration;
+                return upgradeConfig.InitialEffect.Value + (level * upgradeConfig.IncrementalEffect.Value);
+            }
+            const string infoFormat = "LVL {0} - {1} - Increases the damage resistance to explosions by {2}%\n";
+            return Tools.GenerateInfoForUpgrade(infoFormat, initialPrice, incrementalPrices, infoFunction, purchaseMode: GetConfiguration().ExplosionReistanceConfiguration.PurchaseMode);
+        }
+        public static int GetExplosionDamageResistance(int defaultValue)
+        {
+            ITierEffectUpgradeConfiguration<int> upgradeConfig = GetConfiguration().ExplosionReistanceConfiguration;
+            if (!upgradeConfig.Enabled) return defaultValue;
+            if (!GetActiveUpgrade(UPGRADE_NAME)) return defaultValue;
+            int explosionDamageResistance = upgradeConfig.InitialEffect + (GetUpgradeLevel(UPGRADE_NAME) * upgradeConfig.IncrementalEffect);
+            return defaultValue - (Mathf.RoundToInt(defaultValue * (explosionDamageResistance / 100f)));
+        }
+
+        public override bool CanInitializeOnStart
+        {
+            get
+            {
+                ITierUpgradeConfiguration upgradeConfig = GetConfiguration().ExplosionReistanceConfiguration;
+                string[] prices = upgradeConfig.Prices.Value.Split(',');
+                return prices.Length == 0 || (prices.Length == 1 && (prices[0].Length == 0 || prices[0] == "0"));
+            }
+        }
+        public new static (string, string[]) RegisterScrapToUpgrade()
+        {
+            return (UPGRADE_NAME, GetConfiguration().ExplosionReistanceConfiguration.ItemProgressionItems.Value.Split(","));
+        }
+        public new static void RegisterUpgrade()
+        {
+            GameObject prefab = ItemManager.CreateNetworkPrefab(UPGRADE_NAME);
+            prefab.AddComponent<ExplosionResistance>();
+            ItemManager.RegisterNetworkPrefab(prefab);
+            Plugin.networkPrefabs[UPGRADE_NAME] = prefab;
+        }
+        public new static CustomTerminalNode RegisterTerminalNode()
+        {
+            return UpgradeBus.Instance.SetupMultiplePurchaseableTerminalNode(UPGRADE_NAME, GetConfiguration().ExplosionReistanceConfiguration, Plugin.networkPrefabs[UPGRADE_NAME]);
+        }
+    }
+}

--- a/MoreShipUpgrades/UpgradeComponents/TierUpgrades/Player/NightVision.cs
+++ b/MoreShipUpgrades/UpgradeComponents/TierUpgrades/Player/NightVision.cs
@@ -64,11 +64,11 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades.Player
             if (client == null) { return; }
 
             NightVisionUpgradeConfiguration config = GetConfiguration().NightVisionUpgradeConfiguration;
-            float maxBattery = config.InitialEffects[0].Value + ((GetUpgradeLevel(UPGRADE_NAME) + 1) * config.IncrementalEffects[0].Value);
+            float maxBattery = config.InitialEffects[0].Value + (GetActiveUpgrade(UPGRADE_NAME) ? ((GetUpgradeLevel(UPGRADE_NAME)+1) * config.IncrementalEffects[0].Value) : 0);
 
             if (nightVisionActive)
             {
-                nightBattery -= Time.deltaTime * (config.InitialEffects[2].Value - ((GetUpgradeLevel(UPGRADE_NAME) + 1) * config.IncrementalEffects[2].Value));
+                nightBattery -= Time.deltaTime * (config.InitialEffects[2].Value - (GetActiveUpgrade(UPGRADE_NAME) ? ((GetUpgradeLevel(UPGRADE_NAME)+1) * config.IncrementalEffects[2].Value) : 0));
                 nightBattery = Mathf.Clamp(nightBattery, 0f, maxBattery);
                 transform.GetChild(0).gameObject.SetActive(true);
 
@@ -79,7 +79,7 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades.Player
             }
             else if (!batteryExhaustion)
             {
-                nightBattery += Time.deltaTime * (config.InitialEffects[1].Value + ((GetUpgradeLevel(UPGRADE_NAME) + 1) * config.IncrementalEffects[1].Value));
+                nightBattery += Time.deltaTime * (config.InitialEffects[1].Value + (GetActiveUpgrade(UPGRADE_NAME) ? ((GetUpgradeLevel(UPGRADE_NAME)+1) * config.IncrementalEffects[1].Value) : 0));
                 nightBattery = Mathf.Clamp(nightBattery, 0f, maxBattery);
 
                 if (nightBattery >= maxBattery)
@@ -156,8 +156,8 @@ namespace MoreShipUpgrades.UpgradeComponents.TierUpgrades.Player
         public override void Unwind()
         {
             base.Unwind();
-            if (!GetActiveUpgrade(SIMPLE_UPGRADE_NAME)) return;
-            DisableOnClient();
+            //if (!GetActiveUpgrade(SIMPLE_UPGRADE_NAME)) return;
+            //DisableOnClient();
         }
 
         [ServerRpc(RequireOwnership = false)]


### PR DESCRIPTION
- Added ``OverSpending`` attribute in the UpgradeAPI related code where it allows credit purchases to go negative
- Added configuration for enabling force credits command to be used during the run.
    - This is a consensus configuration, if at least one of the clients does not wish to use the command, the command is unavailable to the host.
    - Once all clients (including host) agree to use the force credits command, the host is allowed to use the command.
- Added Bullet Resistance upgrade which reduces incoming damage from bullets by a percentage.
    - The affected damage sources are the turrets and the shotgun (both when used by the nutcracker and the player).
- Added Explosion Resistance upgrade which reduces incoming damage from explosions by a percentage.
- Added TZP Buffer upgrade which increases the effectiveness of its positive buffs (movement speed and stamina effieciency) and reduces the effectiveness of its negative debuffs (visual impairment).
    - Separate configurable values for both positive and negative effects.
    - At 100% effectiveness of positive buff, you won't lose any stamina while in the effect of TZP.
    - At 100% effectiveness loss of negative debuff, the gas visual impairment will be completely removed.
- Implemented configuration for Night Vision where equipping the goggles activates the night vision mechanic for the whole team or only for the player equipping it.
    - Previously, this was done with just the "Individual Upgrade" setting, however this would also make the NV Headset Battery upgrade to be individual aswell, which is undesireable for some situations.
    - Now, "Individual Upgrade" only affects NV Headset Battery upgrade while this new setting ("Individual Night Vision Upgrade") only affects the goggles item.
- Fixed Beekeeper's last level not applying correctly when increasing the hive's scrap value.
- Fixed issue with Fusion Matter causing items to be discarded incorrectly.
- Fixed issue with NV Headset Batteries upgrade applying too early when activating night vision from the goggles item.
- Fixed issue with NV Headset Batteries refund causing night vision being disabled, having to rebuy the goggles to turn it back on.
- Fixed Bigger Lungs upgrade displaying incorrect values related with stamina regeneration and stamina cost decrease when jumping.
- Removed code related to save sharing when globally sharing upgrades.
    - This code was never updated and/or looked at and caused more issues than it solved and the current save system already shares the contents of the save file between clients and it still functions when upgrades become individual later.